### PR TITLE
Fixed issue in getting new primaryKey when inserting in PostgreSQL

### DIFF
--- a/src/mako/database/ORM.php
+++ b/src/mako/database/ORM.php
@@ -790,7 +790,15 @@ abstract class ORM
 
 				if($this->incrementing)
 				{
-					$this->columns[$this->primaryKey] = Database::connection($this->connection)->pdo->lastInsertId($this->primaryKey);
+					switch (Database::connection($this->connection)->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME))
+					{
+						case 'pgsql':
+							$lastInsertName = $this->tableName . "_" . $this->primaryKey . "_seq";
+							break;
+						default:
+							$lastInsertName = $this->primaryKey;
+					}
+					$this->columns[$this->primaryKey] = Database::connection($this->connection)->pdo->lastInsertId($lastInsertName);
 				}
 			}
 


### PR DESCRIPTION
When inserting an auto-increment entry in PostgreSQL, lastInsertId requires the sequence name as parameter. (See http://www.php.net/manual/en/pdo.lastinsertid.php)
