### PR TITLE
Allow CSS on URI's that do not have .css extension

### DIFF
--- a/src/mako/utility/assets/Container.php
+++ b/src/mako/utility/assets/Container.php
@@ -72,7 +72,7 @@ class Container
 			$source = Assets::location() . $source;
 		}
 
-		if(pathinfo(strtok($source, '?'), PATHINFO_EXTENSION) === 'css')
+		if((pathinfo(strtok($source, '?'), PATHINFO_EXTENSION) === 'css') or (in_array('text/css', $attributes)))
 		{
 			defined('MAKO_XHTML') && $attributes['type'] = 'text/css';
 


### PR DESCRIPTION
Many CSS resources do not end in .css (ie. PHP generated, @font-face providers etc).
Using $attributes ('type' => 'text/css') will now render those correctly.

Possibly a fix for issue 69.
