### PR TITLE
Fix URL parameters being wrongly routed

### DIFF
--- a/src/mako/reactor/tasks/server/router.php
+++ b/src/mako/reactor/tasks/server/router.php
@@ -3,6 +3,12 @@
 $requestURI   = $_SERVER['REQUEST_URI'];
 $documentRoot = $_SERVER['DOCUMENT_ROOT'];
 
+// Strip the query strng
+// Need to strip one extra spot for the '?'
+if (isset($_SERVER['QUERY_STRING']))
+	$requestURI = substr($requestURI, 0, strrpos($requestURI, $_SERVER['QUERY_STRING']) - 1);
+
+
 if($requestURI !== '/' && file_exists($documentRoot . '/' . $requestURI))
 {
 	return false; // serve the requested resource as-is.


### PR DESCRIPTION
File are incorrectly routed when they have URL parameters.

This patch fixes #79 by stripping the query string from the request URI.
