### PR TITLE
Ignore a given value at "unique" validator rule

### DIFF
--- a/src/mako/utility/Validate.php
+++ b/src/mako/utility/Validate.php
@@ -581,7 +581,16 @@ class Validate
 
 	protected function validateUnique($input, $parameters)
 	{
-		return (Database::connection()->table($parameters[0])->where($parameters[1], '=', $input)->count() == 0);
+		$query = Database::connection()->table($parameters[0])->where($parameters[1], '=', $input);
+
+		// Ignore a given value
+		
+		if (isset($parameters[2]))
+		{
+			$query->where($parameters[1], '!=', $parameters[2]);
+		}
+
+		return ($query->count() == 0);
 	}
 
 	/**


### PR DESCRIPTION
This is usefull if we have a profile area that allows the users to update their own email or login.

So is possible to check if input email/login already exists without conflict with it self.

Eg 1: ['email' => "unique:table,email,ignoreme@domain.tld"]
Eg 2: ['nick' => "unique:table,nick,ignoremylogin"]
