### PR TITLE
Fix PrettyPageHandler not being called on bootstrap FatalError

### DIFF
--- a/src/mako/boot.php
+++ b/src/mako/boot.php
@@ -1,5 +1,7 @@
 <?php
 
+use mako\ErrorHandler;
+
 //------------------------------------------------------------------------------------------
 // Define some constants
 //------------------------------------------------------------------------------------------
@@ -29,7 +31,9 @@ set_error_handler(function($code, $message, $file, $line)
 {
 	if((error_reporting() & $code) !== 0)
 	{
-		throw new ErrorException($message, $code, 0, $file, $line);
+		$exception = new \Whoops\Exception\ErrorException($message, $code, 0, $file, $line);
+        	ErrorHandler::handler($exception);
+		return false;
 	}
 
 	return true;


### PR DESCRIPTION
Steps to reproduce:
- create new mako project using composer
- edit bootstrap.php and add new line require_once 'missing-file.php'; // of course file must be missing ;)

What should happen:
- PrettyPageHandler should output info about missing file

What happens:
- Raw php error text is displayed to the user.
