### PR TITLE
Added new pagination methods

### DIFF
--- a/src/mako/pagination/Pagination.php
+++ b/src/mako/pagination/Pagination.php
@@ -138,7 +138,7 @@ class Pagination
 
 		$this->pages = ceil(($this->count / $this->itemsPerPage));
 		
-		$this->currentPage = min($this->currentPage, $this->pages);
+		$this->currentPage = ($this->currentPage > $this->pages) && ($this->pages > 0) ? $this->pages : $this->currentPage;
 
 		$this->offset = ($this->currentPage - 1) * $this->itemsPerPage;
 	}

--- a/src/mako/pagination/Pagination.php
+++ b/src/mako/pagination/Pagination.php
@@ -137,6 +137,8 @@ class Pagination
 		$this->currentPage = max((int) $this->request->get($this->key, 1), 1);
 
 		$this->pages = ceil(($this->count / $this->itemsPerPage));
+		
+		$this->currentPage = min($this->currentPage, $this->pages);
 
 		$this->offset = ($this->currentPage - 1) * $this->itemsPerPage;
 	}
@@ -155,6 +157,18 @@ class Pagination
 	public function getView()
 	{
 		return $this->view;
+	}
+	
+	/**
+	 * Returns the total amount of items.
+	 *
+	 * @access  public
+	 * @return  int
+	 */
+
+	public function total()
+	{
+		return $this->count;
 	}
 
 	/**
@@ -204,6 +218,30 @@ class Pagination
 	{
 		return $this->offset;
 	}
+	
+	/**
+	 * Returns the number of the first item on the paginator
+	 *
+	 * @access  public
+	 * @return  int
+	 */
+
+	public function from()
+	{
+		return $this->count ? ($this->currentPage - 1) * $this->itemsPerPage + 1 : 0;
+	}
+
+	/**
+	 * Returns the number of the last item on the paginator
+	 *
+	 * @access  public
+	 * @return  int
+	 */
+
+	public function to()
+	{
+		return min($this->count, $this->currentPage * $this->itemsPerPage);
+	}
 
 	/**
 	 * Builds and returns the pagination array.
@@ -217,6 +255,12 @@ class Pagination
 		$pagination = [];
 
 		$pagination['count'] = $this->pages;
+		
+		$pagination['total'] = $this->total();
+
+		$pagination['from'] = $this->from();
+
+		$pagination['to'] = $this->to();
 
 		$params = $this->request->get();
 


### PR DESCRIPTION
Added some extra functions to pagination:

// Returns the total amount of items.
$totalItems = $pagination->total();

// Returns the number of the first item on the paginator
$from = $pagination->from();

// Returns the number of the last item on the paginator
$to = $pagination->to();

// So it's possible to show show pagination information at pagination template using "preserve"
echo "Showing {{preserve:$from}} to {{preserve:$to}} of {{preserve:$total}} records";

PS.: I've named the "total" method instead "count" because in pagination render the preserve variable "count" was already taken by the number of pages.

PS².: I've also put a little "fix" in constructor method to avoid current page be higher than total of pages