### PR TITLE
Added 'config_exists' and 'config_key_exists' to validation plugins

### DIFF
--- a/src/mako/core/services/ValidatorFactoryService.php
+++ b/src/mako/core/services/ValidatorFactoryService.php
@@ -8,6 +8,8 @@
 namespace mako\core\services;
 
 use \mako\validator\ValidatorFactory;
+use \mako\validator\plugins\ConfigExistsValidator;
+use \mako\validator\plugins\ConfigKeyExistsValidator;
 use \mako\validator\plugins\DatabaseExistsValidator;
 use \mako\validator\plugins\DatabaseUniqueValidator;
 use \mako\validator\plugins\TokenValidator;
@@ -38,7 +40,7 @@ class ValidatorFactoryService extends \mako\core\services\Service
 
 	/**
 	 * Registers plugins.
-	 * 
+	 *
 	 * @access  protected
 	 * @param   \mako\validator\ValidatorFactory  $validatorFactory  Validator factory instance
 	 */
@@ -56,11 +58,18 @@ class ValidatorFactoryService extends \mako\core\services\Service
 
 			$validatorFactory->registerPlugin(new DatabaseUniqueValidator($this->container->get('database')));
 		}
+
+		if($this->container->has('config'))
+		{
+			$validatorFactory->registerPlugin(new ConfigExistsValidator($this->container->get('config')));
+
+			$validatorFactory->registerPlugin(new ConfigKeyExistsValidator($this->container->get('config')));
+		}
 	}
-	
+
 	/**
 	 * Registers the service.
-	 * 
+	 *
 	 * @access  public
 	 */
 

--- a/src/mako/validator/plugins/ConfigExistsValidator.php
+++ b/src/mako/validator/plugins/ConfigExistsValidator.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright  Frederic G. Østby
+ * @license    http://www.makoframework.com/license
+ */
+
+namespace mako\validator\plugins;
+
+use \mako\core\Config;
+
+/**
+ * Database exists plugin.
+ *
+ * @author  Frederic G. Østby
+ */
+
+class ConfigExistsValidator extends \mako\validator\plugins\ValidatorPlugin implements \mako\validator\plugins\ValidatorPluginInterface
+{
+	//---------------------------------------------
+	// Class properties
+	//---------------------------------------------
+
+	/**
+	 * Rule name.
+	 *
+	 * @var string
+	 */
+
+	protected $ruleName = 'config_exists';
+
+	/**
+	 * Config instance.
+	 *
+	 * @var \mako\core\Config
+	 */
+
+	protected $config;
+
+	//---------------------------------------------
+	// Class constructor, destructor etc ...
+	//---------------------------------------------
+
+	/**
+	 * Constructor.
+	 *
+	 * @access  public
+	 * @param   \mako\core\Config  $config  Config instance
+	 */
+
+	public function __construct(Config $config)
+	{
+		$this->config = $config;
+	}
+
+	//---------------------------------------------
+	// Class methods
+	//---------------------------------------------
+
+	/**
+	 * Validator.
+	 *
+	 * @access  public
+	 * @param   string   $input       Input
+	 * @param   array    $parameters  Parameters
+	 * @return  boolean
+	 */
+
+	public function validate($input, $parameters)
+	{
+		return (in_array($input, $this->config->get($parameters[0])));
+	}
+}

--- a/src/mako/validator/plugins/ConfigKeyExistsValidator.php
+++ b/src/mako/validator/plugins/ConfigKeyExistsValidator.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright  Frederic G. Østby
+ * @license    http://www.makoframework.com/license
+ */
+
+namespace mako\validator\plugins;
+
+use \mako\core\Config;
+
+/**
+ * Database exists plugin.
+ *
+ * @author  Frederic G. Østby
+ */
+
+class ConfigKeyExistsValidator extends \mako\validator\plugins\ValidatorPlugin implements \mako\validator\plugins\ValidatorPluginInterface
+{
+	//---------------------------------------------
+	// Class properties
+	//---------------------------------------------
+
+	/**
+	 * Rule name.
+	 *
+	 * @var string
+	 */
+
+	protected $ruleName = 'config_key_exists';
+
+	/**
+	 * Config instance.
+	 *
+	 * @var \mako\core\Config
+	 */
+
+	protected $config;
+
+	//---------------------------------------------
+	// Class constructor, destructor etc ...
+	//---------------------------------------------
+
+	/**
+	 * Constructor.
+	 *
+	 * @access  public
+	 * @param   \mako\core\Config  $config  Config instance
+	 */
+
+	public function __construct(Config $config)
+	{
+		$this->config = $config;
+	}
+
+	//---------------------------------------------
+	// Class methods
+	//---------------------------------------------
+
+	/**
+	 * Validator.
+	 *
+	 * @access  public
+	 * @param   string   $input       Input
+	 * @param   array    $parameters  Parameters
+	 * @return  boolean
+	 */
+
+	public function validate($input, $parameters)
+	{
+		return (array_key_exists($input, $this->config->get($parameters[0])));
+	}
+}


### PR DESCRIPTION
Usefull if you have a 'huge' config file and want to check if a value exists or if is a valid array key in a config file. It's an alternative to 'in:foo,bar,baz'.
## Eg 1.: config file "brazil_states_ acronym.php"

return 
[
   'ac',
   'ba',
   'ce',
   'es',
    ... more 23 itens
] ;
$validator = $this->validator->create($this->request->post(),
[
        "state" => "required|config_exists:brazil_states_ acronym",
]);
## Eg 2: config file "oficial_bank_codes.php"

return 
[
    '067' => 'Bank Foo',
    '485' => 'Bank Bar ',
    '723' => 'Bank Hello World',
    '126' => 'Bank Example 1',
    '459' => 'Bank Example 2',
    ... more 127 itens
] ;
$validator = $this->validator->create($this->request->post(),
[
        "bank_code" => "required|config_key_exists:oficial_bank_codes",
]);
