### PR TITLE
Fix small bug when loading package config files

### DIFF
--- a/src/mako/helpers.php
+++ b/src/mako/helpers.php
@@ -62,7 +62,7 @@ function mako_cascading_paths($parentPath, $relativePath, $file, $ext = '.php')
 
 		$paths[] = $parentPath . '/' . $relativePath . '/packages/' . $package . '/' . $file . $ext;
 
-		$paths[] = $parentPath . '/' . $package . '/' . $relativePath . '/' . $file . $ext;
+		$paths[] = $parentPath . '/packages/' . $package . '/' . $relativePath . '/' . $file . $ext;
 	}
 	else
 	{


### PR DESCRIPTION
I think there is a small bug um "mako_cascading_paths" when loading config files in a package.

The generated paths are:

-> app/config/packages/foobar/config_file.php
-> app/foobar/config/config_file.php

Looks like the function is generating the right path to load file in app/config tree but is generating wrong path to app/package tree.
