### PR TITLE
Added 'where' clauses to 'exists' validator

### DIFF
--- a/src/mako/validator/plugins/DatabaseExistsValidator.php
+++ b/src/mako/validator/plugins/DatabaseExistsValidator.php
@@ -68,6 +68,29 @@ class DatabaseExistsValidator extends \mako\validator\plugins\ValidatorPlugin im
 
 	public function validate($input, $parameters)
 	{
-		return ($this->connectionManager->builder()->table($parameters[0])->where($parameters[1], '=', $input)->count() != 0);
+        // Start query
+
+        $query = $this->connectionManager->builder()->table($parameters[0])->where($parameters[1], '=', $input);
+
+        // Unset 'table' and 'column' parameters
+
+        unset($parameters[0]);
+        unset($parameters[1]);
+
+        // Reset array keys from parameters
+
+        $parameters = array_values($parameters);
+
+        // Check extra parameters
+
+        if($parameters && (count($parameters) % 3 == 0))
+        {
+            for($i = 0; $i < count($parameters); $i += 3)
+            {
+                $query->where($parameters[$i], $parameters[$i+1], $parameters[$i+2]);
+            }
+        }
+
+        return ($query->count() != 0);
 	}
 }


### PR DESCRIPTION
Added possibility to parse 'where' clauses to 'exists' validator.

Eg:

$validator = $this->validator->create($this->request->post(),
[
    "user_id"         => "exists:users,id,activated,=,1,banned,=,0",
    "customer_id" => "exists:customers,id,type,!=,reseller,activated,=,1",
    "admin_id"      => "exists:administrators,id,date_added,>=,1999-12-31,date_added,<=,2000-12-31"
]);


Parse unlimited parameters following the the sequence: 'column','operator','value'