### PR TITLE
HasOnePolymorphic and HasManyPolymorphic with tests

### DIFF
--- a/src/mako/database/midgard/Hydrator.php
+++ b/src/mako/database/midgard/Hydrator.php
@@ -254,6 +254,21 @@ class Hydrator extends \mako\database\query\Query
 	}
 
 	/**
+	 * Returns a hydrated model.
+	 * 
+	 * @access  protected
+	 * @param   object                      $result  Database result
+	 * @return  \mako\database\midgard\ORM
+	 */
+
+	protected function hydrateModel($result)
+	{
+		$model = $this->model->getClass();
+
+		return new $model((array) $result, true, false, true, $this->makeReadOnly);
+	}
+
+	/**
 	 * Returns hydrated models.
 	 * 
 	 * @access  protected
@@ -272,9 +287,7 @@ class Hydrator extends \mako\database\query\Query
 
 		foreach($results as $result)
 		{
-			$model = $this->model->getClass();
-
-			$hydrated[] = new $model((array) $result, true, false, true, $this->makeReadOnly);
+			$hydrated[] = $this->hydrateModel($result);
 		}
 
 		if(!empty($hydrated))

--- a/src/mako/database/midgard/ORM.php
+++ b/src/mako/database/midgard/ORM.php
@@ -15,7 +15,9 @@ use \mako\database\ConnectionManager;
 use \mako\database\midgard\Hydrator;
 use \mako\database\midgard\relations\BelongsTo;
 use \mako\database\midgard\relations\HasMany;
+use \mako\database\midgard\relations\HasManyPolymorphic;
 use \mako\database\midgard\relations\HasOne;
+use \mako\database\midgard\relations\HasOnePolymorphic;
 use \mako\database\midgard\relations\ManyToMany;
 use \mako\database\midgard\StaleRecordException;
 use \mako\utility\DateTime;
@@ -778,6 +780,22 @@ abstract class ORM
 	}
 
 	/**
+	 * Returns a HasOnePolymorphic relation.
+	 * 
+	 * @access  protected
+	 * @param   string                                              $model            Related model
+	 * @param   string                                              $polymorphicType  Polymorphic type
+	 * @return  \mako\database\midgard\relation\HasManyPolymorphic
+	 */
+
+	protected function hasOnePolymorphic($model, $polymorphicType)
+	{
+		$related = new $model;
+
+		return new HasOnePolymorphic($related->getConnection(), $this, $related, $polymorphicType);
+	}
+
+	/**
 	 * Returns a HasMany relation.
 	 * 
 	 * @access  protected
@@ -791,6 +809,22 @@ abstract class ORM
 		$related = new $model;
 
 		return new HasMany($related->getConnection(), $this, $related, $foreignKey);
+	}
+
+	/**
+	 * Returns a HasManyPolymorphic relation.
+	 * 
+	 * @access  protected
+	 * @param   string                                              $model            Related model
+	 * @param   string                                              $polymorphicType  Polymorphic type
+	 * @return  \mako\database\midgard\relation\HasManyPolymorphic
+	 */
+
+	protected function hasManyPolymorphic($model, $polymorphicType)
+	{
+		$related = new $model;
+
+		return new HasManyPolymorphic($related->getConnection(), $this, $related, $polymorphicType);
 	}
 
 	/**

--- a/src/mako/database/midgard/relations/HasManyPolymorphic.php
+++ b/src/mako/database/midgard/relations/HasManyPolymorphic.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright  Frederic G. Østby
+ * @license    http://www.makoframework.com/license
+ */
+
+namespace mako\database\midgard\relations;
+
+use \mako\database\Connection;
+use \mako\database\midgard\ORM;
+
+/**
+ * Has many polymorphic relation.
+ *
+ * @author  Frederic G. Østby
+ */
+
+class HasManyPolymorphic extends \mako\database\midgard\relations\HasMany
+{
+	use \mako\database\midgard\relations\HasOneOrManyPolymorphicTrait {
+		\mako\database\midgard\relations\HasOneOrManyPolymorphicTrait::__construct as constructor;
+	}
+
+	/**
+	 * Constructor.
+	 * 
+	 * @access  public
+	 * @param   \mako\database\Connection   $connection       Database connection
+	 * @param   \mako\database\midgard\ORM  $parent           Parent model
+	 * @param   \mako\database\midgard\ORM  $related          Related model
+	 * @param   string                      $polymorphicType  Polymorphic type
+	 */
+
+	public function __construct(Connection $connection, ORM $parent, ORM $related, $polymorphicType)
+	{
+		$this->constructor($connection, $parent, $related, $polymorphicType);
+	}
+}

--- a/src/mako/database/midgard/relations/HasOneOrManyPolymorphicTrait.php
+++ b/src/mako/database/midgard/relations/HasOneOrManyPolymorphicTrait.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @copyright  Frederic G. Østby
+ * @license    http://www.makoframework.com/license
+ */
+
+namespace mako\database\midgard\relations;
+
+use \mako\database\Connection;
+use \mako\database\midgard\ORM;
+
+/**
+ * Has one or has many polymorphic relation.
+ *
+ * @author  Frederic G. Østby
+ */
+
+trait HasOneOrManyPolymorphicTrait
+{
+	/**
+	 * Polymorphic type.
+	 * 
+	 * @var string
+	 */
+
+	protected $polymorphicType;
+
+	/**
+	 * Constructor.
+	 * 
+	 * @access  public
+	 * @param   \mako\database\Connection   $connection       Database connection
+	 * @param   \mako\database\midgard\ORM  $parent           Parent model
+	 * @param   \mako\database\midgard\ORM  $related          Related model
+	 * @param   string                      $polymorphicType  Polymorphic type
+	 */
+
+	public function __construct(Connection $connection, ORM $parent, ORM $related, $polymorphicType)
+	{
+		$this->polymorphicType = $polymorphicType . '_type';
+
+		parent::__construct($connection, $parent, $related, $polymorphicType . '_id');
+
+		$this->where($this->polymorphicType, '=', $parent->getClass());
+	}
+
+	/**
+	 * Creates a related record.
+	 * 
+	 * @access  public
+	 * @param   mixed                    $related  Related record
+	 * @return  \mako\database\midgard
+	 */
+
+	public function create($related)
+	{
+		if($related instanceof $this->model)
+		{
+			$related->{$this->polymorphicType} = $this->parent->getClass();
+		}
+		else
+		{
+			$related[$this->polymorphicType] = $this->parent->getClass();
+		}
+
+		return parent::create($related);
+	}
+}

--- a/src/mako/database/midgard/relations/HasOnePolymorphic.php
+++ b/src/mako/database/midgard/relations/HasOnePolymorphic.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright  Frederic G. Østby
+ * @license    http://www.makoframework.com/license
+ */
+
+namespace mako\database\midgard\relations;
+
+use \mako\database\Connection;
+use \mako\database\midgard\ORM;
+
+/**
+ * Has one polymorphic relation.
+ *
+ * @author  Frederic G. Østby
+ */
+
+class HasOnePolymorphic extends \mako\database\midgard\relations\HasOne
+{
+	use \mako\database\midgard\relations\HasOneOrManyPolymorphicTrait {
+		\mako\database\midgard\relations\HasOneOrManyPolymorphicTrait::__construct as constructor;
+	}
+
+	/**
+	 * Constructor.
+	 * 
+	 * @access  public
+	 * @param   \mako\database\Connection   $connection       Database connection
+	 * @param   \mako\database\midgard\ORM  $parent           Parent model
+	 * @param   \mako\database\midgard\ORM  $related          Related model
+	 * @param   string                      $polymorphicType  Polymorphic type
+	 */
+
+	public function __construct(Connection $connection, ORM $parent, ORM $related, $polymorphicType)
+	{
+		$this->constructor($connection, $parent, $related, $polymorphicType);
+	}
+}

--- a/tests/integration/database/midgard/relations/HasManyPolymorphicTest.php
+++ b/tests/integration/database/midgard/relations/HasManyPolymorphicTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace mako\tests\integration\database\midgard\relations;
+
+// --------------------------------------------------------------------------
+// START CLASSES
+// --------------------------------------------------------------------------
+
+class HasManyPolymorphicArticle extends \TestORM
+{
+	protected $tableName = 'articles';
+
+	public function comments()
+	{
+		return $this->hasManyPolymorphic('mako\tests\integration\database\midgard\relations\HasManyPolymorphicComment', 'commentable');
+	}
+}
+
+class HasManyPolymorphicComment extends \TestORM
+{
+	protected $tableName = 'polymorphic_comments';
+}
+
+// --------------------------------------------------------------------------
+// END CLASSES
+// --------------------------------------------------------------------------
+
+/**
+ * @group integration
+ * @group integration:database
+ * @requires extension PDO
+ * @requires extension pdo_sqlite
+ */
+
+class HasManyPolymorphicTest extends \ORMTestCase
+{
+	/**
+	 * 
+	 */
+
+	public function testBasicHasManyRelation()
+	{
+		$article = HasManyPolymorphicArticle::get(1);
+
+		$comments = $article->comments;
+
+		$this->assertInstanceOf('mako\database\midgard\ResultSet', $comments);
+
+		$this->assertEquals(2, count($comments));
+
+		foreach($comments as $comment)
+		{
+			$this->assertInstanceOf('mako\tests\integration\database\midgard\relations\HasManyPolymorphicComment', $comment);
+
+			$this->assertEquals($comment->commentable_type, $article->getClass());
+
+			$this->assertEquals($comment->commentable_id, $article->id);
+		}
+	}
+
+	/**
+	 * 
+	 */
+
+	public function testLazyHasManyRelation()
+	{
+		$queryCountBefore = count($this->connectionManager->connection('sqlite')->getLog());
+
+		$articles = HasManyPolymorphicArticle::ascending('id')->all();
+
+		foreach($articles as $article)
+		{
+			$this->assertInstanceOf('mako\database\midgard\ResultSet', $article->comments);
+
+			foreach($article->comments as $comment)
+			{
+				$this->assertInstanceOf('mako\tests\integration\database\midgard\relations\HasManyPolymorphicComment', $comment);
+
+				$this->assertEquals($comment->commentable_type, $article->getClass());
+
+				$this->assertEquals($comment->commentable_id, $article->id);
+			}
+		}
+
+		$queryCountAfter = count($this->connectionManager->connection('sqlite')->getLog());
+
+		$this->assertEquals(4, $queryCountAfter - $queryCountBefore);
+	}
+
+	/**
+	 * 
+	 */
+
+	public function testEagerHasManyRelation()
+	{
+		$queryCountBefore = count($this->connectionManager->connection('sqlite')->getLog());
+
+		$articles = HasManyPolymorphicArticle::including('comments')->ascending('id')->all();
+
+		foreach($articles as $article)
+		{
+			$this->assertInstanceOf('mako\database\midgard\ResultSet', $article->comments);
+
+			foreach($article->comments as $comment)
+			{
+				$this->assertInstanceOf('mako\tests\integration\database\midgard\relations\HasManyPolymorphicComment', $comment);
+
+				$this->assertEquals($comment->commentable_type, $article->getClass());
+
+				$this->assertEquals($comment->commentable_id, $article->id);
+			}
+		}
+
+		$queryCountAfter = count($this->connectionManager->connection('sqlite')->getLog());
+
+		$this->assertEquals(2, $queryCountAfter - $queryCountBefore);
+	}
+
+	/**
+	 * 
+	 */
+
+	public function testEagerHasManyRelationWithConstraint()
+	{
+		$queryCountBefore = count($this->connectionManager->connection('sqlite')->getLog());
+
+		$articles = HasManyPolymorphicArticle::including(['comments' => function($query)
+		{
+			$query->where('comment', '=', 'does not exist');
+		}])->ascending('id')->all();
+
+		foreach($articles as $article)
+		{
+			$this->assertInstanceOf('mako\database\midgard\ResultSet', $article->comments);
+
+			$this->assertEquals(0, count($article->comments));
+		}
+
+		$queryCountAfter = count($this->connectionManager->connection('sqlite')->getLog());
+
+		$this->assertEquals(2, $queryCountAfter - $queryCountBefore);
+	}
+
+	/**
+	 * 
+	 */
+
+	public function testCreateRelated()
+	{
+		$article = HasManyPolymorphicArticle::get(1);
+
+		$comment = new HasManyPolymorphicComment();
+
+		$comment->created_at = '2014-04-30 15:02:10';
+
+		$comment->comment = 'this is a comment';
+
+		$comment->user_id = 1;
+
+		$article->comments()->create($comment);
+
+		$this->assertEquals($comment->commentable_type, $article->getClass());
+
+		$this->assertEquals($comment->commentable_id, $article->id);
+
+		$comment->delete();
+	}
+}

--- a/tests/integration/database/midgard/relations/HasOnePolymorphicTest.php
+++ b/tests/integration/database/midgard/relations/HasOnePolymorphicTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace mako\tests\integration\database\midgard\relations;
+
+// --------------------------------------------------------------------------
+// START CLASSES
+// --------------------------------------------------------------------------
+
+class HasOnePolymorphicProfile extends \TestORM
+{
+	protected $tableName = 'profiles';
+
+	public function image()
+	{
+		return $this->hasOnePolymorphic('mako\tests\integration\database\midgard\relations\HasOnePolymorphicImage', 'imageable');
+	}
+}
+
+class HasOnePolymorphicImage extends \TestORM
+{
+	protected $tableName = 'images';
+}
+
+// --------------------------------------------------------------------------
+// END CLASSES
+// --------------------------------------------------------------------------
+
+/**
+ * @group integration
+ * @group integration:database
+ * @requires extension PDO
+ * @requires extension pdo_sqlite
+ */
+
+class HasOnePolymorphicTest extends \ORMTestCase
+{
+	/**
+	 * 
+	 */
+
+	public function testBasicHasOneRelation()
+	{
+		$profile = HasOnePolymorphicProfile::get(1);
+
+		$image = $profile->image;
+
+		$this->assertInstanceOf('mako\tests\integration\database\midgard\relations\HasOnePolymorphicImage', $image);
+
+		$this->assertEquals($profile->getClass(), $image->imageable_type);
+
+		$this->assertEquals($profile->id, $image->imageable_id);
+	}
+
+	/**
+	 * 
+	 */
+
+	public function testLazyHasOneRelation()
+	{
+		$queryCountBefore = count($this->connectionManager->connection('sqlite')->getLog());
+
+		$profiles = HasOnePolymorphicProfile::ascending('id')->all();
+
+		foreach($profiles as $profile)
+		{
+			$this->assertInstanceOf('mako\tests\integration\database\midgard\relations\HasOnePolymorphicImage', $profile->image);
+
+			$this->assertEquals($profile->getClass(), $profile->image->imageable_type);
+
+			$this->assertEquals($profile->id, $profile->image->imageable_id);
+		}
+
+		$queryCountAfter = count($this->connectionManager->connection('sqlite')->getLog());
+
+		$this->assertEquals(4, $queryCountAfter - $queryCountBefore);
+	}
+
+	/**
+	 * 
+	 */
+
+	public function testEagerHasOneRelation()
+	{
+		$queryCountBefore = count($this->connectionManager->connection('sqlite')->getLog());
+
+		$profiles = HasOnePolymorphicProfile::including('image')->ascending('id')->all();
+
+		foreach($profiles as $profile)
+		{
+			$this->assertInstanceOf('mako\tests\integration\database\midgard\relations\HasOnePolymorphicImage', $profile->image);
+
+			$this->assertEquals($profile->getClass(), $profile->image->imageable_type);
+
+			$this->assertEquals($profile->id, $profile->image->imageable_id);
+		}
+
+		$queryCountAfter = count($this->connectionManager->connection('sqlite')->getLog());
+
+		$this->assertEquals(2, $queryCountAfter - $queryCountBefore);
+	}
+
+	/**
+	 * 
+	 */
+
+	public function testEagerHasOneRelationWithConstraint()
+	{
+		$queryCountBefore = count($this->connectionManager->connection('sqlite')->getLog());
+
+		$profiles = HasOnePolymorphicProfile::including(['image' => function($query)
+		{
+			$query->where('image', '=', 'does not exist');
+		}])->ascending('id')->all();
+
+		foreach($profiles as $profile)
+		{
+			$this->assertFalse($profile->image);
+		}
+
+		$queryCountAfter = count($this->connectionManager->connection('sqlite')->getLog());
+
+		$this->assertEquals(2, $queryCountAfter - $queryCountBefore);
+	}
+
+	/**
+	 * 
+	 */
+
+	public function testCreateRelated()
+	{
+		$profile = new HasOnePolymorphicProfile;
+
+		$profile->user_id = 4;
+
+		$profile->interests = 'games';
+
+		$profile->save();
+
+		$image = new HasOnePolymorphicImage;
+
+		$image->image = 'bax.png';
+
+		$profile->image()->create($image);
+
+		$this->assertEquals($profile->getClass(), $image->imageable_type);
+
+		$this->assertEquals($profile->id, $image->imageable_id);
+
+		$image->delete();
+
+		$profile->delete();
+	}
+}

--- a/tests/integration/resources/sqlite.sql
+++ b/tests/integration/resources/sqlite.sql
@@ -30,6 +30,22 @@ INSERT INTO "profiles" ("id", "user_id", "interests") VALUES (2, 2, 'movies');
 INSERT INTO "profiles" ("id", "user_id", "interests") VALUES (3, 3, 'hockey');
 
 ------------------------------------------------------------
+-- IMAGES
+------------------------------------------------------------
+
+DROP TABLE IF EXISTS "images";
+CREATE TABLE "images" (
+  "id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+  "image" text NOT NULL,
+  "imageable_type" text NOT NULL,
+  "imageable_id" text NOT NULL
+);
+
+INSERT INTO "images" ("id", "image", "imageable_type", "imageable_id") VALUES (1, 'foo.png', "\mako\tests\integration\database\midgard\relations\HasOnePolymorphicProfile", 1);
+INSERT INTO "images" ("id", "image", "imageable_type", "imageable_id") VALUES (2, 'bar.png', "\mako\tests\integration\database\midgard\relations\HasOnePolymorphicProfile", 2);
+INSERT INTO "images" ("id", "image", "imageable_type", "imageable_id") VALUES (3, 'baz.png', "\mako\tests\integration\database\midgard\relations\HasOnePolymorphicProfile", 3);
+
+------------------------------------------------------------
 -- GROUPS
 ------------------------------------------------------------
 
@@ -91,6 +107,25 @@ INSERT INTO "article_comments" ("id", "article_id", "user_id", "created_at", "co
 INSERT INTO "article_comments" ("id", "article_id", "user_id", "created_at", "comment") VALUES (2, 1, 2, '2014-04-30 15:02:10', "article 1 comment 2");
 INSERT INTO "article_comments" ("id", "article_id", "user_id", "created_at", "comment") VALUES (3, 2, 1, '2014-04-30 15:02:10', "article 2 comment 1");
 INSERT INTO "article_comments" ("id", "article_id", "user_id", "created_at", "comment") VALUES (4, 3, 3, '2014-04-30 15:02:10', "article 3 comment 1");
+
+------------------------------------------------------------
+-- ARTICLE_COMMENTS
+------------------------------------------------------------
+
+DROP TABLE IF EXISTS "polymorphic_comments";
+CREATE TABLE "polymorphic_comments" (
+  "id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+  "user_id" integer NOT NULL,
+  "created_at" text NOT NULL,
+  "comment" text NOT NULL,
+  "commentable_type" text NOT NULL,
+  "commentable_id" integer NOT NULL
+);
+
+INSERT INTO "polymorphic_comments" ("id", "user_id", "created_at", "comment", "commentable_type", "commentable_id") VALUES (1, 1, '2014-04-30 15:02:10', "article 1 comment 1", "\mako\tests\integration\database\midgard\relations\HasManyPolymorphicArticle", 1);
+INSERT INTO "polymorphic_comments" ("id", "user_id", "created_at", "comment", "commentable_type", "commentable_id") VALUES (2, 2, '2014-04-30 15:02:10', "article 1 comment 2", "\mako\tests\integration\database\midgard\relations\HasManyPolymorphicArticle", 1);
+INSERT INTO "polymorphic_comments" ("id", "user_id", "created_at", "comment", "commentable_type", "commentable_id") VALUES (3, 1, '2014-04-30 15:02:10', "article 2 comment 1", "\mako\tests\integration\database\midgard\relations\HasManyPolymorphicArticle", 2);
+INSERT INTO "polymorphic_comments" ("id", "user_id", "created_at", "comment", "commentable_type", "commentable_id") VALUES (4, 3, '2014-04-30 15:02:10', "article 2 comment 1", "\mako\tests\integration\database\midgard\relations\HasManyPolymorphicArticle", 3);
 
 ------------------------------------------------------------
 -- OPTIMISTIC_LOCKS


### PR DESCRIPTION
I'm working on converting an old RoR application to PHP and it has a few polymorphic relations so I added the functionality to the ORM.

I was pleasantly surprised of how little code was needed in to implement this. There would have been even less code if it wasn't for this bug https://bugs.php.net/bug.php?id=65576 in PHP.

Everything is tested and 100% compatible with existing code.

(I have only added HasOnePolymorphic and HasManyPolymorphic relations but I'll be happy to add BelongsToPolymorphic and ManyToManyPolymorphic relations later on.)
