### PR TITLE
Now possible to provide an associative array of parameters to the container

### DIFF
--- a/src/mako/syringe/Container.php
+++ b/src/mako/syringe/Container.php
@@ -156,6 +156,47 @@ class Container
 	}
 
 	/**
+	 * Merges the provided parameters with the reflection parameters.
+	 *
+	 * @access  public
+	 * @param   array   $reflectionParameters  Reflection parameters
+	 * @param   array   $providedParameters    Provided parameters
+	 * @return  array
+	 */
+
+	protected function mergeParameters(array $reflectionParameters, array $providedParameters)
+	{
+		// Make the provided parameter array associative
+
+		$associativeProvidedParameters = [];
+
+		foreach($providedParameters as $key => $value)
+		{
+			if(is_numeric($key))
+			{
+				$associativeProvidedParameters[$reflectionParameters[$key]->getName()] = $value;
+			}
+			else
+			{
+				$associativeProvidedParameters[$key] = $value;
+			}
+		}
+
+		// Make reflection parameter array associative
+
+		$associativeReflectionParameters = [];
+
+		foreach($reflectionParameters as $key => $value)
+		{
+			$associativeReflectionParameters[$value->getName()] = $value;
+		}
+
+		// Return merged paramters
+
+		return array_replace($associativeReflectionParameters, $associativeProvidedParameters);
+	}
+
+	/**
 	 * Resolve a parameter.
 	 * 
 	 * @access  protected
@@ -251,11 +292,8 @@ class Container
 				if(!empty($constructorParamters))
 				{
 					// Merge provided parameters with the ones we got using reflection
-					// and sort to make sure that they come in the right order
 
-					$parameters = $parameters + $constructorParamters;
-
-					ksort($parameters);
+					$parameters = $this->mergeParameters($constructorParamters, $parameters);
 
 					// Loop through the parameters and resolve the ones that need resolving
 

--- a/tests/unit/syringe/ContainerTest.php
+++ b/tests/unit/syringe/ContainerTest.php
@@ -91,7 +91,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 	 * 
 	 */
 
-	public function testParameters()
+	public function testNumericParameters()
 	{
 		$container = new Container;
 
@@ -105,6 +105,34 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 		$container = new Container;
 
 		$bar = $container->get('mako\tests\unit\syringe\Bar', [1 => 'def', 0 => 'abc']);
+
+		$this->assertEquals('abc', $bar->foo);
+		$this->assertEquals('def', $bar->bar);
+	}
+
+	/**
+	 *
+	 */
+
+	public function testAssociativeParameters()
+	{
+		$container = new Container;
+
+		$bar = $container->get('mako\tests\unit\syringe\Bar', ['bar' => 789]);
+
+		$this->assertEquals(123, $bar->foo);
+		$this->assertEquals(789, $bar->bar);
+	}
+
+	/**
+	 *
+	 */
+
+	public function testMixedParameters()
+	{
+		$container = new Container;
+		
+		$bar = $container->get('mako\tests\unit\syringe\Bar', ['bar' => 'def', 0 => 'abc']);
 
 		$this->assertEquals('abc', $bar->foo);
 		$this->assertEquals('def', $bar->bar);


### PR DESCRIPTION
I have made some changes to the container so that you can now provide an associative array of parameters to the container.

This is useful if you only want to override/provide some of the parameters when resolving an object. This is possible using the current implementation too but you would have to set the numeric key to the parameter number + 1 in order to achieve the same result.

This pull request is 100% backwards compatible and I have also added unit tests.

I'm also working on another addition to the container but it kinda depends on this so I'll wait before making a second pull request.
