### PR TITLE
Added call method to the container.

### DIFF
--- a/tests/unit/syringe/ContainerTest.php
+++ b/tests/unit/syringe/ContainerTest.php
@@ -50,6 +50,16 @@ class Baz
 	}
 }
 
+class Baq
+{
+	public $baq;
+
+	public function setBaq($baq = 123)
+	{
+		$this->baq = $baq;
+	}
+}
+
 // --------------------------------------------------------------------------
 // END CLASSES
 // --------------------------------------------------------------------------
@@ -224,5 +234,78 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals($container->get('bar'), $container->get('bar'));
 
 		$this->assertNotEquals($container->get('bar'), $container->getFresh('bar'));
+	}
+
+	/**
+	 *
+	 */
+
+	public function testCallClosure()
+	{
+		$closure = function(Bar $bar)
+		{
+			return $bar;
+		};
+
+		$container = new Container;
+
+		$returnValue = $container->call($closure);
+
+		$this->assertInstanceOf('mako\tests\unit\syringe\Bar', $returnValue);
+
+		//
+
+		$closure = function(Bar $bar, $foo = 123)
+		{
+			return [$bar, $foo];
+		};
+
+		$container = new Container;
+
+		$returnValue = $container->call($closure);
+
+		$this->assertInstanceOf('mako\tests\unit\syringe\Bar', $returnValue[0]);
+
+		$this->assertSame(123, $returnValue[1]);
+
+		//
+
+		$closure = function(Bar $bar, $foo = 123)
+		{
+			return [$bar, $foo];
+		};
+
+		$container = new Container;
+
+		$returnValue = $container->call($closure, ['foo' => 456]);
+
+		$this->assertInstanceOf('mako\tests\unit\syringe\Bar', $returnValue[0]);
+
+		$this->assertSame(456, $returnValue[1]);
+	}
+
+	/**
+	 *
+	 */
+
+	public function testCallMethod()
+	{
+		$baq = new Baq;
+
+		$container = new Container;
+
+		$container->call([$baq, 'setBaq']);
+
+		$this->assertSame(123, $baq->baq);
+
+		// 
+
+		$baq = new Baq;
+
+		$container = new Container;
+
+		$container->call([$baq, 'setBaq'], [456]);
+
+		$this->assertSame(456, $baq->baq);
 	}
 }


### PR DESCRIPTION
Ok as promised here's the second pull request for the container class. 100% backwards compatible and tested.

The new call method allows you to execute a callable and inject its dependencies using the container.

I have a third pull request that I'm working on but its a bit bigger so I'll probably wait until tomorrow since its getting pretty late here. I have a working prototype but I want to go through the code and write some more tests for it.

What I'm working on is making the route dispatcher execute the action using the `Container::call` method. This will enable us to inject dependencies directly into the rote controller methods and/or closures. We're converting some Silex applications to Mako and its a pretty useful feature that they have.

It would also be nice to do the same for task actions and possibly migrations as well.
