### PR TITLE
Route filters are now executed using Container::call

### DIFF
--- a/src/mako/http/routing/Dispatcher.php
+++ b/src/mako/http/routing/Dispatcher.php
@@ -9,6 +9,7 @@ namespace mako\http\routing;
 
 use \Closure;
 
+use \mako\common\FunctionParserTrait;
 use \mako\http\Request;
 use \mako\http\Response;
 use \mako\http\routing\Route;
@@ -22,6 +23,8 @@ use \mako\syringe\Container;
 
 class Dispatcher
 {
+	use FunctionParserTrait;
+
 	/**
 	 * Request.
 	 * 
@@ -136,24 +139,17 @@ class Dispatcher
 
 	protected function executeFilter($filter)
 	{
-		$parameters = [];
+		// Parse the filter function call
 
-		// Check if we have filter paramters
+		list($filter, $parameters) = $this->parseFunction($filter);
 
-		if(($position = strpos($filter, '[')) !== false)
-		{
-			$parameters = explode(',', substr($filter, $position + 1, -1));
-
-			$filter = substr($filter, 0, $position);
-		}
-
-		// Get the filter from the route collection
+		// Get the filter from the filter collection
 
 		$filter = $this->resolveFilter($filter);
 
 		// Execute the filter and return its return value
 
-		return call_user_func_array($filter, array_merge([$this->request, $this->response], $parameters));
+		return $this->container->call($filter, $parameters);
 	}
 
 	/**

--- a/tests/unit/http/routing/DispatcherTest.php
+++ b/tests/unit/http/routing/DispatcherTest.php
@@ -371,7 +371,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 	{
 		$filters = m::mock('\mako\http\routing\Filters');
 
-		$filters->shouldReceive('get')->once()->with('before')->andReturn(function($request, $response)
+		$filters->shouldReceive('get')->once()->with('before')->andReturn(function(Response $response)
 		{
 			$response->header('X-Foo-Bar', 'Foo Bar');
 		});
@@ -391,7 +391,11 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 
 		$response = m::mock('\mako\http\Response')->makePartial();
 
-		$dispatcher = new Dispatcher($request, $response, $filters, $route);
+		$container = m::mock('\mako\syringe\Container')->makePartial();
+
+		$container->shouldReceive('get')->with('mako\http\Response')->andReturn($response);
+
+		$dispatcher = new Dispatcher($request, $response, $filters, $route, [], $container);
 
 		$response = $dispatcher->dispatch();
 
@@ -436,7 +440,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 	{
 		$filters = m::mock('\mako\http\routing\Filters');
 
-		$filters->shouldReceive('get')->once()->with('after')->andReturn(function($request, $response)
+		$filters->shouldReceive('get')->once()->with('after')->andReturn(function(Response $response)
 		{
 			$response->body(strtoupper($response->getBody()));
 		});
@@ -456,7 +460,11 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 
 		$response = m::mock('\mako\http\Response')->makePartial();
 
-		$dispatcher = new Dispatcher($request, $response, $filters, $route);
+		$container = m::mock('\mako\syringe\Container')->makePartial();
+
+		$container->shouldReceive('get')->with('mako\http\Response')->andReturn($response);
+
+		$dispatcher = new Dispatcher($request, $response, $filters, $route, [], $container);
 
 		$response = $dispatcher->dispatch();
 
@@ -471,14 +479,14 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 	{
 		$filters = m::mock('\mako\http\routing\Filters');
 
-		$filters->shouldReceive('get')->once()->with('before')->andReturn(function($request, $response, $param)
+		$filters->shouldReceive('get')->once()->with('before')->andReturn(function($param)
 		{
 			return $param;
 		});
 
 		$route = m::mock('\mako\http\routing\Route');
 
-		$route->shouldReceive('getBeforeFilters')->once()->andReturn(['before[foobar]']);
+		$route->shouldReceive('getBeforeFilters')->once()->andReturn(['before:"foobar"']);
 
 		$request = m::mock('\mako\http\Request');
 
@@ -499,14 +507,14 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 	{
 		$filters = m::mock('\mako\http\routing\Filters');
 
-		$filters->shouldReceive('get')->once()->with('before')->andReturn(function($request, $response, $param1, $param2)
+		$filters->shouldReceive('get')->once()->with('before')->andReturn(function($param1, $param2)
 		{
 			return $param1 . $param2;
 		});
 
 		$route = m::mock('\mako\http\routing\Route');
 
-		$route->shouldReceive('getBeforeFilters')->once()->andReturn(['before[foobar,bazbax]']);
+		$route->shouldReceive('getBeforeFilters')->once()->andReturn(['before:["foobar","bazbax"]']);
 
 		$request = m::mock('\mako\http\Request');
 


### PR DESCRIPTION
Last commit for #117 :)

Filters are now executed by `Container::call()` and I also updated the unit tests.
