### PR TITLE
Added Formatter::escape() method and fixed a bug with the exception handler

### DIFF
--- a/src/mako/cli/output/Output.php
+++ b/src/mako/cli/output/Output.php
@@ -143,7 +143,7 @@ class Output
 			}
 			else
 			{
-				$string = $this->formatter->stripFormatting($string);
+				$string = $this->formatter->strip($string);
 			}
 		}
 

--- a/src/mako/cli/output/formatter/Formatter.php
+++ b/src/mako/cli/output/formatter/Formatter.php
@@ -50,6 +50,10 @@ class Formatter implements FormatterInterface
 
 	protected $styles = 
 	[
+		// Clear styles
+
+		'clear'      => 0,
+		
 		// Text options
 
 		'bold'       => 1,

--- a/src/mako/cli/output/formatter/Formatter.php
+++ b/src/mako/cli/output/formatter/Formatter.php
@@ -339,7 +339,16 @@ class Formatter implements FormatterInterface
 	 * {@inheritdoc}
 	 */
 
-	public function stripFormatting($string)
+	public function escape($string)
+	{
+		return preg_replace(static::TAG_REGEX, '\\\$0', $string);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+
+	public function strip($string)
 	{
 		return preg_replace(static::ANSI_SGR_SEQUENCE_REGEX, '', $this->format($string));
 	}

--- a/src/mako/cli/output/formatter/FormatterInterface.php
+++ b/src/mako/cli/output/formatter/FormatterInterface.php
@@ -26,12 +26,22 @@ interface FormatterInterface
 	public function format($string);
 
 	/**
-	 * Strips formatting tags.
+	 * Returns a string where all formatting tags have been escaped.
+	 *
+	 * @access  public
+	 * @param   string  $string  String to format
+	 * @return  string
+	 */
+
+	public function escape($string);
+
+	/**
+	 * Returns a string where all formatting tags have been stripped.
 	 * 
 	 * @access  public
 	 * @param   string  $string  String to strip
 	 * @return  string
 	 */
 
-	public function stripFormatting($string);
+	public function strip($string);
 }

--- a/src/mako/cli/output/helpers/Table.php
+++ b/src/mako/cli/output/helpers/Table.php
@@ -86,7 +86,7 @@ class Table
 
 	protected function stringWidthWithoutFormatting($string)
 	{
-		return mb_strwidth($this->formatter !== null ? $this->formatter->stripFormatting($string) : $string);
+		return mb_strwidth($this->formatter !== null ? $this->formatter->strip($string) : $string);
 	}
 
 	/**

--- a/src/mako/error/handlers/CLIHandler.php
+++ b/src/mako/error/handlers/CLIHandler.php
@@ -42,6 +42,25 @@ class CLIHandler extends Handler
 
 		$this->output = $output;
 	}
+
+	/**
+	 * Escape formatting tags.
+	 *
+	 * @access  protected
+	 * @param   string     $string  String to escape
+	 * @return  string
+	 */
+
+	protected function escape($string)
+	{
+		if(($formatter = $this->output->getFormatter()) === null)
+		{
+			return $string;
+		}
+
+		return $formatter->escape($string);
+	}
+
 	/**
 	 * Returns a detailed error.
 	 * 
@@ -51,7 +70,11 @@ class CLIHandler extends Handler
 
 	protected function getDetailedError()
 	{
-		$this->output->errorLn('<bg_red><white>' . $this->exception->getMessage() . PHP_EOL . PHP_EOL . $this->exception->getTraceAsString() . PHP_EOL . '</white></bg_red>');
+		$message = $this->escape($this->exception->getMessage());
+
+		$trace = $this->escape($this->exception->getTraceAsString());
+
+		$this->output->errorLn('<bg_red><white>' . $message . PHP_EOL . PHP_EOL . $trace . PHP_EOL . '</white></bg_red>');
 	}
 
 	/**

--- a/tests/unit/cli/output/OutputTest.php
+++ b/tests/unit/cli/output/OutputTest.php
@@ -237,7 +237,7 @@ class OutputTest extends PHPUnit_Framework_TestCase
 		$err       = $this->getWriter();
 		$formatter = $this->getFormatter();
 
-		$formatter->shouldReceive('stripFormatting')->once()->with('hello, world!')->andReturn('stripped');
+		$formatter->shouldReceive('strip')->once()->with('hello, world!')->andReturn('stripped');
 
 		$std->shouldReceive('write')->once()->with('stripped');
 

--- a/tests/unit/cli/output/formatter/FormatterTest.php
+++ b/tests/unit/cli/output/formatter/FormatterTest.php
@@ -61,14 +61,25 @@ class OutputTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * 
+	 *
 	 */
 
-	public function testStripFormatting()
+	public function testEscape()
 	{
 		$formatter = new Formatter(true);
 
-		$this->assertSame('foo', $formatter->stripFormatting('<blue>foo</blue>'));
+		$this->assertSame('\<blue>foo\</blue>', $formatter->escape('<blue>foo</blue>'));
+	}
+
+	/**
+	 * 
+	 */
+
+	public function testStrip()
+	{
+		$formatter = new Formatter(true);
+
+		$this->assertSame('foo', $formatter->strip('<blue>foo</blue>'));
 	}
 
 	/**

--- a/tests/unit/cli/output/helpers/TableTest.php
+++ b/tests/unit/cli/output/helpers/TableTest.php
@@ -121,9 +121,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
 		$formatter = m::mock('mako\cli\output\formatter\FormatterInterface');
 
-		$formatter->shouldReceive('stripFormatting')->times(2)->with('<blue>Col1</blue>')->andReturn('Col1');
+		$formatter->shouldReceive('strip')->times(2)->with('<blue>Col1</blue>')->andReturn('Col1');
 
-		$formatter->shouldReceive('stripFormatting')->times(2)->with('Cell1')->andReturn('Cell1');
+		$formatter->shouldReceive('strip')->times(2)->with('Cell1')->andReturn('Cell1');
 
 		$output->shouldReceive('getFormatter')->once()->andReturn($formatter);
 


### PR DESCRIPTION
Changes:

* Added a ```Formatter::escape()``` method. 
* Fixed a bug that caused the command line exception handler to fail when trying to handle a unclosed formatting tag exception. 
* Renamed the ```stripFormatting``` method to ```strip```.
* Added a "clear" style to the formatter.

And I added tests :)