### PR TITLE
Added cli countdown helper

### DIFF
--- a/src/mako/cli/output/helpers/Countdown.php
+++ b/src/mako/cli/output/helpers/Countdown.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright  Frederic G. Østby
+ * @license    http://www.makoframework.com/license
+ */
+
+namespace mako\cli\output\helpers;
+
+use mako\cli\output\Output;
+
+/**
+ * Countdown helper.
+ *
+ * @author  Yamada Taro
+ */
+
+class Countdown
+{
+	/**
+	 * Output instance.
+	 * 
+	 * @var \mako\cli\output\Output
+	 */
+
+	protected $output;
+
+	/**
+	 * Constructor.
+	 * 
+	 * @access  public
+	 * @param   \mako\cli\output\Output  $output  Output instance
+	 */
+
+	public function __construct(Output $output)
+	{
+		$this->output = $output;
+	}
+
+	/**
+	 * Counts down from n.
+	 * 
+	 * @access  public
+	 * @param   int     $from  Number of seconds to count down
+	 */
+
+	public function draw($from = 5)
+	{
+		$dots = 0;
+
+		$fromLength = strlen($from);
+
+		$totalLength = $fromLength + 5;
+
+		do
+		{
+			do
+			{
+				$numbers = str_pad($from, $fromLength, '0', STR_PAD_LEFT);
+
+				$this->output->write("\r" . str_pad($numbers . ' ' . str_repeat('.', $dots) . ' ', $totalLength, ' '));
+
+				usleep(250000);
+			}
+			while($dots++ < 3);
+			
+			$dots = 0;
+		}
+		while($from-- > 1);
+
+		$this->output->write("\r" . str_repeat(' ', $totalLength) . "\r");
+	}
+}

--- a/src/mako/reactor/Command.php
+++ b/src/mako/reactor/Command.php
@@ -12,6 +12,7 @@ use mako\cli\input\helpers\Confirmation;
 use mako\cli\input\helpers\Question;
 use mako\cli\output\Output;
 use mako\cli\output\helpers\Bell;
+use mako\cli\output\helpers\Countdown;
 use mako\cli\output\helpers\Table;
 use mako\cli\output\helpers\ProgressBar;
 
@@ -205,17 +206,15 @@ abstract class Command
 	}
 
 	/**
-	 * Draws a table.
-	 * 
+	 * Counts down from n.
+	 *
 	 * @access  protected
-	 * @param   array      $columnNames  Array of column names
-	 * @param   array      $rows         Array of rows
-	 * @param   int        $writer       Output writer
+	 * @param   int        $from  Number of seconds to count down
 	 */
 
-	protected function table(array $columnNames, array $rows, $writer = Output::STANDARD)
+	protected function countdown($from = 5)
 	{
-		(new Table($this->output))->draw($columnNames, $rows, $writer);
+		(new Countdown($this->output))->draw($from);
 	}
 
 	/**
@@ -238,6 +237,20 @@ abstract class Command
 		$progressBar->draw();
 
 		return $progressBar;
+	}
+
+	/**
+	 * Draws a table.
+	 * 
+	 * @access  protected
+	 * @param   array      $columnNames  Array of column names
+	 * @param   array      $rows         Array of rows
+	 * @param   int        $writer       Output writer
+	 */
+
+	protected function table(array $columnNames, array $rows, $writer = Output::STANDARD)
+	{
+		(new Table($this->output))->draw($columnNames, $rows, $writer);
 	}
 
 	/**

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,3 +14,4 @@ Here you'll find all the Mako framework tests. They are divided in to groups so 
 | integration          | All integration tests                                                 |
 | integration:database | All integration tests that touch the database (SQLite in memory)      |
 | integration:redis    | All integration tests that connect to a redis database                |
+| slow                 | All slow tests (both unit and integration)                            |

--- a/tests/unit/cli/output/helpers/CountdownTest.php
+++ b/tests/unit/cli/output/helpers/CountdownTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace mako\tests\unit\cli\output\helpers;
+
+use mako\cli\output\helpers\Countdown;
+
+use Mockery as m;
+
+/**
+ * @group unit
+ * @group slow
+ */
+
+class CountdownTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * 
+	 */
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+	/**
+	 * 
+	 */
+
+	public function testCountdownFromDefault()
+	{
+		$output = m::mock('mako\cli\output\Output');
+
+		$output->shouldReceive('write')->once()->with("\r5     ");
+		$output->shouldReceive('write')->once()->with("\r5 .   ");
+		$output->shouldReceive('write')->once()->with("\r5 ..  ");
+		$output->shouldReceive('write')->once()->with("\r5 ... ");
+		$output->shouldReceive('write')->once()->with("\r4     ");
+		$output->shouldReceive('write')->once()->with("\r4 .   ");
+		$output->shouldReceive('write')->once()->with("\r4 ..  ");
+		$output->shouldReceive('write')->once()->with("\r4 ... ");
+		$output->shouldReceive('write')->once()->with("\r3     ");
+		$output->shouldReceive('write')->once()->with("\r3 .   ");
+		$output->shouldReceive('write')->once()->with("\r3 ..  ");
+		$output->shouldReceive('write')->once()->with("\r3 ... ");
+		$output->shouldReceive('write')->once()->with("\r2     ");
+		$output->shouldReceive('write')->once()->with("\r2 .   ");
+		$output->shouldReceive('write')->once()->with("\r2 ..  ");
+		$output->shouldReceive('write')->once()->with("\r2 ... ");
+		$output->shouldReceive('write')->once()->with("\r1     ");
+		$output->shouldReceive('write')->once()->with("\r1 .   ");
+		$output->shouldReceive('write')->once()->with("\r1 ..  ");
+		$output->shouldReceive('write')->once()->with("\r1 ... ");
+		$output->shouldReceive('write')->once()->with("\r      \r");
+
+		$bell = new Countdown($output);
+
+		$bell->draw();
+	}
+
+	/**
+	 * 
+	 */
+
+	public function testCountdownFrom2()
+	{
+		$output = m::mock('mako\cli\output\Output');
+
+		$output->shouldReceive('write')->once()->with("\r2     ");
+		$output->shouldReceive('write')->once()->with("\r2 .   ");
+		$output->shouldReceive('write')->once()->with("\r2 ..  ");
+		$output->shouldReceive('write')->once()->with("\r2 ... ");
+		$output->shouldReceive('write')->once()->with("\r1     ");
+		$output->shouldReceive('write')->once()->with("\r1 .   ");
+		$output->shouldReceive('write')->once()->with("\r1 ..  ");
+		$output->shouldReceive('write')->once()->with("\r1 ... ");
+		$output->shouldReceive('write')->once()->with("\r      \r");
+
+		$bell = new Countdown($output);
+
+		$bell->draw(2);
+	}
+}


### PR DESCRIPTION
I have added a CLI countdown output helper along with tests.

The tests take 7 seconds in total (since its a countdown :p) so I added the ```@slow``` group to it so that they can be skipped when running tests locally using ```--exclude-group slow```.