### PR TITLE
Add support for Postgres booleans in scalar casting.

### DIFF
--- a/src/mako/database/midgard/ORM.php
+++ b/src/mako/database/midgard/ORM.php
@@ -531,7 +531,7 @@ abstract class ORM
 				case 'float':
 					return (float) $value;
 				case 'boolean':
-					return (bool) $value;
+					return $value === 'f' ? false : (bool) $value;
 				case 'date':
 					return ($value instanceof DateTime) ? $value : Time::createFromFormat('Y-m-d H:i:s', $value);
 				case 'string':

--- a/tests/unit/database/midgard/ORMTest.php
+++ b/tests/unit/database/midgard/ORMTest.php
@@ -489,6 +489,16 @@ class ORMTest extends \PHPUnit_Framework_TestCase
 		$this->assertInternalType('float', $cast->float);
 
 		$this->assertSame(1.0, $cast->float);
+
+		//
+
+		$cast = new TestCastingScalars(['boolean' => 't'], true, false, true);
+		$this->assertInternalType('boolean', $cast->boolean);
+		$this->assertSame(true, $cast->boolean);
+
+		$cast = new TestCastingScalars(['boolean' => 'f'], true, false, true);
+		$this->assertInternalType('boolean', $cast->boolean);
+		$this->assertSame(false, $cast->boolean);
 	}
 
 	/**


### PR DESCRIPTION
PostgreSQL returns booleans as the strings "t" and "f". This modification allows those values to be properly casted by the automatic scalar casting.