### PR TITLE
Fix 'Before' and 'After' rules

### DIFF
--- a/src/mako/validator/Validator.php
+++ b/src/mako/validator/Validator.php
@@ -521,12 +521,12 @@ class Validator
 
 	protected function validateBefore($input, $format, $date)
 	{
-		if(($date = DateTime::createFromFormat($format, $input)) === false)
+		if(($input = DateTime::createFromFormat($format, $input)) === false)
 		{
 			return false;
 		}
 
-		return ($date->getTimestamp() < DateTime::createFromFormat($format, $date)->getTimestamp());
+		return ($input->getTimestamp() < DateTime::createFromFormat($format, $date)->getTimestamp());
 	}
 
 	/**
@@ -541,12 +541,12 @@ class Validator
 
 	protected function validateAfter($input, $format, $date)
 	{
-		if(($date = DateTime::createFromFormat($format, $input)) === false)
+		if(($input = DateTime::createFromFormat($format, $input)) === false)
 		{
 			return false;
 		}
 
-		return ($date->getTimestamp() > DateTime::createFromFormat($format, $date)->getTimestamp());
+		return ($input->getTimestamp() > DateTime::createFromFormat($format, $date)->getTimestamp());
 	}
 
 	/**


### PR DESCRIPTION
There are 2 small errors in those functions. I think this was caused during the version upgrade that changed the way attributes are parsed.

The original '$date' variable becomes a object so is not possible to parse it as the original string to compare the dates.