### PR TITLE
Fix double parentheses in WHERE IN

### DIFF
--- a/src/mako/database/query/Compiler.php
+++ b/src/mako/database/query/Compiler.php
@@ -263,7 +263,9 @@ class Compiler
 
 	protected function in(array $where)
 	{
-		return $this->wrap($where['column']) . ($where['not'] ? ' NOT IN ' : ' IN ') . '(' . $this->params($where['values']) . ')';
+		$values = $this->params($where['values']);
+		return $this->wrap($where['column']) . ($where['not'] ? ' NOT IN ' : ' IN ')
+			. ($this->isParenthesesEnclosed($values) ? $values : '(' . $values . ')');
 	}
 
 	/**
@@ -536,5 +538,21 @@ class Compiler
 		$sql .= $this->wheres($this->query->getWheres());
 
 		return ['sql' => $sql, 'params' => $this->params];
+	}
+
+	/**
+	 * Checks whether a string is between bracse.
+	 *
+	 * @param string $string The string to check
+	 *
+	 * @access protected
+	 * @return boolean
+	 */
+
+	protected function isParenthesesEnclosed($string)
+	{
+		return mb_strlen($string) >= 2
+			&& mb_substr($string, 0, 1) == "("
+			&& mb_substr($string, -1) == ")";
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,4 +8,5 @@ mb_language('uni');
 mb_regex_encoding('UTF-8');
 mb_internal_encoding('UTF-8');
 
+require_once dirname(__DIR__) . '/vendor/autoload.php';
 require_once __DIR__ . '/integration/resources/ORMTestCase.php';

--- a/tests/unit/database/query/compilers/BaseCompilerTest.php
+++ b/tests/unit/database/query/compilers/BaseCompilerTest.php
@@ -419,7 +419,7 @@ class BaseCompilerTest extends \PHPUnit_Framework_TestCase
 
 		$query = $query->getCompiler()->select();
 
-		$this->assertEquals('SELECT * FROM "foobar" WHERE "foo" IN ((SELECT "id" FROM "barfoo"))', $query['sql']);
+		$this->assertEquals('SELECT * FROM "foobar" WHERE "foo" IN (SELECT "id" FROM "barfoo")', $query['sql']);
 		$this->assertEquals(array(), $query['params']);
 	}
 


### PR DESCRIPTION
Check for double parentheses when building a WHERE IN query. Fix #157.

Also improves the phpunit bootstrap, as my unit test would not run locally without it.