### PR TITLE
Simplified query builder pagination

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "4.6.*",
-		"mockery/mockery": "0.9.*"
+		"mockery/mockery": "dev-master"
 	},
 	"config": {
 		"preferred-install": "dist"

--- a/src/mako/application/services/DatabaseService.php
+++ b/src/mako/application/services/DatabaseService.php
@@ -9,6 +9,7 @@ namespace mako\application\services;
 
 use mako\application\services\Service;
 use mako\database\ConnectionManager;
+use mako\database\query\Query;
 
 /**
  * Database service.
@@ -26,6 +27,14 @@ class DatabaseService extends Service
 	{
 		$this->container->registerSingleton([ConnectionManager::class, 'database'], function($container)
 		{
+			if($container->has('pagination'))
+			{
+				Query::setPaginationFactory(function() use ($container)
+				{
+					return $container->get('pagination');
+				});
+			}
+
 			$config = $container->get('config')->get('database');
 
 			return new ConnectionManager($config['default'], $config['configurations']);

--- a/src/mako/application/services/PaginationFactoryService.php
+++ b/src/mako/application/services/PaginationFactoryService.php
@@ -9,6 +9,7 @@ namespace mako\application\services;
 
 use mako\application\services\Service;
 use mako\pagination\PaginationFactory;
+use mako\pagination\PaginationFactoryInterface;
 
 /**
  * Pagination factory service.
@@ -24,7 +25,7 @@ class PaginationFactoryService extends Service
 
 	public function register()
 	{
-		$this->container->registerSingleton([PaginationFactory::class, 'pagination'], function($container)
+		$this->container->registerSingleton([PaginationFactoryInterface::class, 'pagination'], function($container)
 		{
 			$paginationFactory = new PaginationFactory($container->get('request'), $container->get('config')->get('pagination'));
 

--- a/src/mako/database/midgard/Query.php
+++ b/src/mako/database/midgard/Query.php
@@ -391,6 +391,20 @@ class Query extends QueryBuilder
 	}
 
 	/**
+	 * Paginates the results using a pagination instance.
+	 *
+	 * @access  public
+	 * @param   null|int                          $itemsPerPage  Number of items per page
+	 * @param   array                             $options       Pagination options
+	 * @return  \mako\database\midgard\ResultSet
+	 */
+
+	public function paginate($itemsPerPage = null, array $options = [])
+	{
+		return parent::paginate($itemsPerPage, $options);
+	}
+
+	/**
 	 * {@inheritdoc}
 	 */
 

--- a/src/mako/database/query/QueryConvenienceTrait.php
+++ b/src/mako/database/query/QueryConvenienceTrait.php
@@ -458,19 +458,6 @@ trait QueryConvenienceTrait
 	}
 
 	/**
-	 * Paginates the results using a pagination instance.
-	 *
-	 * @access  public
-	 * @param   \mako\pagination\Pagination  $pagination  Pagination instance
-	 * @return  \mako\database\query\Query
-	 */
-
-	public function paginate(Pagination $pagination)
-	{
-		return $this->limit($pagination->limit())->offset($pagination->offset());
-	}
-
-	/**
 	 * Increments column value.
 	 *
 	 * @access  public

--- a/src/mako/database/query/ResultSet.php
+++ b/src/mako/database/query/ResultSet.php
@@ -7,6 +7,7 @@
 
 namespace mako\database\query;
 
+use mako\pagination\PaginationInterface;
 use mako\utility\Arr;
 use mako\utility\Collection;
 
@@ -18,6 +19,38 @@ use mako\utility\Collection;
 
 class ResultSet extends Collection
 {
+	/**
+	 * Pagination.
+	 *
+	 * @var \mako\pagination\PaginationInterface
+	 */
+
+	protected $pagination;
+
+	/**
+	 * Sets the pagination.
+	 *
+	 * @access  public
+	 * @param   \mako\pagination\PaginationInterface  $pagination  Pagination
+	 */
+
+	public function setPagination(PaginationInterface $pagination)
+	{
+		$this->pagination = $pagination;
+	}
+
+	/**
+	 * Returns the pagination.
+	 *
+	 * @access  public
+	 * @return  \mako\pagination\PaginationInterface
+	 */
+
+	public function getPagination(): PaginationInterface
+	{
+		return $this->pagination;
+	}
+
 	/**
 	 * Returns an array containing only the values of chosen column.
 	 *

--- a/src/mako/pagination/Pagination.php
+++ b/src/mako/pagination/Pagination.php
@@ -9,9 +9,9 @@ namespace mako\pagination;
 
 use RuntimeException;
 
-use mako\pagination\PaginationInterface;
 use mako\http\Request;
 use mako\http\routing\URLBuilder;
+use mako\pagination\PaginationInterface;
 use mako\view\ViewFactory;
 
 /**

--- a/src/mako/pagination/Pagination.php
+++ b/src/mako/pagination/Pagination.php
@@ -9,6 +9,7 @@ namespace mako\pagination;
 
 use RuntimeException;
 
+use mako\pagination\PaginationInterface;
 use mako\http\Request;
 use mako\http\routing\URLBuilder;
 use mako\view\ViewFactory;
@@ -17,54 +18,26 @@ use mako\view\ViewFactory;
  * Pagination class.
  *
  * @author  Frederic G. Østby
+ * @author  Yamada Taro
  */
 
-class Pagination
+class Pagination implements PaginationInterface
 {
-	/**
-	 * Request instance.
-	 *
-	 * @var \mako\http\Request
-	 */
-
-	protected $request;
-
 	/**
 	 * Number of items.
 	 *
 	 * @var int
 	 */
 
-	protected $count;
+	protected $items;
 
 	/**
-	 * Configuration.
+	 * Number of items per page.
 	 *
-	 * @var array
+	 * @var int
 	 */
 
-	protected $config =
-	[
-		'page_key'       => 'page',
-		'max_page_links' => 5,
-		'items_per_page' => 20,
-	];
-
-	/**
-	 * URL builder instance.
-	 *
-	 * @var \mako\http\request\URLBuilder
-	 */
-
-	protected $urlBuilder;
-
-	/**
-	 * View factory instance.
-	 *
-	 * @var \mako\view\ViewFactory
-	 */
-
-	protected $viewFactory;
+	protected $itemsPerPage;
 
 	/**
 	 * Current page.
@@ -73,6 +46,18 @@ class Pagination
 	 */
 
 	protected $currentPage;
+
+	/**
+	 * Options.
+	 *
+	 * @var array
+	 */
+
+	protected $options =
+	[
+		'page_key'       => 'page',
+		'max_page_links' => 5,
+	];
 
 	/**
 	 * Number of pages.
@@ -91,6 +76,30 @@ class Pagination
 	protected $offset;
 
 	/**
+	 * Request instance.
+	 *
+	 * @var \mako\http\Request
+	 */
+
+	protected $request;
+
+	/**
+	 * URL builder instance.
+	 *
+	 * @var \mako\http\routing\URLBuilder
+	 */
+
+	protected $urlBuilder;
+
+	/**
+	 * View factory instance.
+	 *
+	 * @var \mako\view\ViewFactory
+	 */
+
+	protected $viewFactory;
+
+	/**
 	 * Pagination.
 	 *
 	 * @var array
@@ -99,58 +108,48 @@ class Pagination
 	protected $pagination = [];
 
 	/**
-	 * Constructor.
-	 *
-	 * @access  public
-	 * @param   \mako\http\Request             $request      Request
-	 * @param   int                            $count        Item count
-	 * @param   array                          $config       Configuration
-	 * @param   \mako\http\routing\URLBuilder  $urlBuilder   URL builder instance
-	 * @param   \mako\view\ViewFactory         $viewFactory  View factory instance
+	 * {@inheritdoc}
 	 */
 
-	public function __construct(Request $request, $count, array $config = [], URLBuilder $urlBuilder = null, ViewFactory $viewFactory = null)
+	public function __construct($items, $itemsPerPage, $currentPage, array $options = [])
 	{
-		$this->request = $request;
+		$this->items = $items;
 
-		$this->count = $count;
+		$this->itemsPerPage = $itemsPerPage;
 
-		$this->config = $config + $this->config;
+		$this->currentPage = $currentPage;
 
-		$this->urlBuilder = $urlBuilder;
-
-		$this->viewFactory = $viewFactory;
-
-		// Get the current page
-
-		$this->currentPage = max((int) $this->request->get($this->config['page_key'], 1), 1);
+		$this->options = $options + $this->options;
 
 		// Calculate the number of pages
 
-		$this->pages = ceil(($count / $this->config['items_per_page']));
+		$this->pages = (int) ceil(($this->items / $this->itemsPerPage));
 
 		// Calculate the offset
 
-		$this->offset = ($this->currentPage - 1) * $this->config['items_per_page'];
+		$this->offset = ($this->currentPage - 1) * $this->itemsPerPage;
 	}
 
 	/**
-	 * Returns the total amount of pages.
-	 *
-	 * @access  public
-	 * @return  int
+	 * {@inheritdoc}
 	 */
 
-	public function pages()
+	public function items()
 	{
-		return $this->pages;
+		return $this->items;
 	}
 
 	/**
-	 * Returns the current page.
-	 *
-	 * @access  public
-	 * @return  int
+	 * {@inheritdoc}
+	 */
+
+	public function itemsPerPage()
+	{
+		return $this->itemsPerPage;
+	}
+
+	/**
+	 * {@inheritdoc}
 	 */
 
 	public function currentPage()
@@ -159,27 +158,66 @@ class Pagination
 	}
 
 	/**
-	 * Returns the limit.
-	 *
-	 * @access  public
-	 * @return  int
+	 * {@inheritdoc}
+	 */
+
+	public function numberOfPages()
+	{
+		return $this->pages;
+	}
+
+	/**
+	 * {@inheritdoc}
 	 */
 
 	public function limit()
 	{
-		return $this->config['items_per_page'];
+		return $this->itemsPerPage;
 	}
 
 	/**
-	 * Returns the offset.
-	 *
-	 * @access  public
-	 * @return  int
+	 * {@inheritdoc}
 	 */
 
 	public function offset()
 	{
 		return $this->offset;
+	}
+
+	/**
+	 * Sets the request instance.
+	 *
+	 * @access  public
+	 * @param   \mako\http\Request  $request  Request
+	 */
+
+	public function setRequest(Request $request)
+	{
+		$this->request = $request;
+	}
+
+	/**
+	 * Sets the URL builder instance.
+	 *
+	 * @access  public
+	 * @param   \mako\http\routing\URLBuilder  $urlBuilder  URL builder instance
+	 */
+
+	public function setURLBuilder(URLBuilder $urlBuilder)
+	{
+		$this->urlBuilder = $urlBuilder;
+	}
+
+	/**
+	 * Sets the view factory builder instance.
+	 *
+	 * @access  public
+	 * @param   \mako\view\ViewFactory  $viewFactory  View factory instance
+	 */
+
+	public function setViewFactory(ViewFactory $viewFactory)
+	{
+		$this->viewFactory = $viewFactory;
 	}
 
 	/**
@@ -189,49 +227,52 @@ class Pagination
 	 * @return  array
 	 */
 
-	public function paginate()
+	public function pagination()
 	{
 		if(empty($this->pagination))
 		{
-			if(empty($this->urlBuilder))
+			if(empty($this->request))
 			{
-				throw new RuntimeException(vsprintf("%s(): A [ URLBuilder ] instance is required to render pagination views.", [__METHOD__]));
+				throw new RuntimeException(vsprintf("%s(): A [ Request ] instance is required to generate the pagination array.", [__METHOD__]));
 			}
 
-			$pagination = [];
+			if(empty($this->urlBuilder))
+			{
+				throw new RuntimeException(vsprintf("%s(): A [ URLBuilder ] instance is required to generate the pagination array.", [__METHOD__]));
+			}
 
-			$pagination['count'] = $this->pages;
+			$pagination = ['items' => $this->items, 'items_per_page' => $this->itemsPerPage, 'number_of_pages' => $this->pages];
 
 			$params = $this->request->get();
 
 			if($this->currentPage > 1)
 			{
-				$pagination['first']    = $this->urlBuilder->current(array_merge($params, [$this->config['page_key'] => 1]));
-				$pagination['previous'] = $this->urlBuilder->current(array_merge($params, [$this->config['page_key'] => ($this->currentPage - 1)]));
+				$pagination['first']    = $this->urlBuilder->current(array_merge($params, [$this->options['page_key'] => 1]));
+				$pagination['previous'] = $this->urlBuilder->current(array_merge($params, [$this->options['page_key'] => ($this->currentPage - 1)]));
 			}
 
 			if($this->currentPage < $this->pages)
 			{
-				$pagination['last'] = $this->urlBuilder->current(array_merge($params, [$this->config['page_key'] => $this->pages]));
-				$pagination['next'] = $this->urlBuilder->current(array_merge($params, [$this->config['page_key'] => ($this->currentPage + 1)]));
+				$pagination['last'] = $this->urlBuilder->current(array_merge($params, [$this->options['page_key'] => $this->pages]));
+				$pagination['next'] = $this->urlBuilder->current(array_merge($params, [$this->options['page_key'] => ($this->currentPage + 1)]));
 			}
 
-			if($this->config['max_page_links'] !== 0)
+			if($this->options['max_page_links'] !== 0)
 			{
-				if($this->pages > $this->config['max_page_links'])
+				if($this->pages > $this->options['max_page_links'])
 				{
-					$start = max(($this->currentPage) - ceil($this->config['max_page_links'] / 2), 0);
+					$start = max(($this->currentPage) - ceil($this->options['max_page_links'] / 2), 0);
 
-					$end = $start + $this->config['max_page_links'];
+					$end = $start + $this->options['max_page_links'];
 
 					if($end > $this->pages)
 					{
 						$end = $this->pages;
 					}
 
-					if($start > ($end - $this->config['max_page_links']))
+					if($start > ($end - $this->options['max_page_links']))
 					{
-						$start = $end - $this->config['max_page_links'];
+						$start = $end - $this->options['max_page_links'];
 					}
 				}
 				else
@@ -247,7 +288,7 @@ class Pagination
 				{
 					$pagination['pages'][] =
 					[
-						'url'        => $this->urlBuilder->current(array_merge($params, [$this->config['page_key'] => $i])),
+						'url'        => $this->urlBuilder->current(array_merge($params, [$this->options['page_key'] => $i])),
 						'number'     => $i,
 						'is_current' => ($i == $this->currentPage),
 					];
@@ -275,6 +316,6 @@ class Pagination
 			throw new RuntimeException(vsprintf("%s(): A [ ViewFactory ] instance is required to render pagination views.", [__METHOD__]));
 		}
 
-		return $this->viewFactory->create($view, $this->paginate())->render();
+		return $this->viewFactory->create($view, $this->pagination())->render();
 	}
 }

--- a/src/mako/pagination/PaginationFactory.php
+++ b/src/mako/pagination/PaginationFactory.php
@@ -10,15 +10,18 @@ namespace mako\pagination;
 use mako\http\Request;
 use mako\http\routing\URLBuilder;
 use mako\pagination\Pagination;
+use mako\pagination\PaginationFactoryInterface;
+use mako\pagination\PaginationInterface;
 use mako\view\ViewFactory;
 
 /**
  * Pagination factory.
  *
  * @author  Frederic G. Østby
+ * @author  Yamada Taro
  */
 
-class PaginationFactory
+class PaginationFactory implements PaginationFactoryInterface
 {
 	/**
 	 * Request instance.
@@ -29,12 +32,12 @@ class PaginationFactory
 	protected $request;
 
 	/**
-	 * Configuration.
+	 * Options.
 	 *
 	 * @var array
 	 */
 
-	protected $config;
+	protected $options;
 
 	/**
 	 * URL builder instance.
@@ -56,21 +59,15 @@ class PaginationFactory
 	 * Constructor.
 	 *
 	 * @access  public
-	 * @param   \mako\http\Request             $request      Request
-	 * @param   array                          $config       Configuration
-	 * @param   \mako\http\routing\URLBuilder  $urlBuilder   URL builder instance
-	 * @param   \mako\view\ViewFactory         $viewFactory  View factory instance
+	 * @param   \mako\http\Request  $request  Request
+	 * @param   array               $config   Configuration
 	 */
 
-	public function __construct(Request $request, array $config = [], URLBuilder $urlBuilder = null, ViewFactory $viewFactory = null)
+	public function __construct(Request $request, array $config = [])
 	{
 		$this->request = $request;
 
-		$this->config = $config;
-
-		$this->urlBuilder = $urlBuilder;
-
-		$this->viewFactory = $viewFactory;
+		$this->options = $config;
 	}
 
 	/**
@@ -98,18 +95,25 @@ class PaginationFactory
 	}
 
 	/**
-	 * Creates and returns a pagination instance.
-	 *
-	 * @access  public
-	 * @param   int                          $count   Number of items
-	 * @param   array                        $config  Override configuration
-	 * @return  \mako\pagination\Pagination
+	 * {@inheritdoc}
 	 */
 
-	public function create($count, array $config = [])
+	public function create($items, $itemsPerPage = null, array $options = []): PaginationInterface
 	{
-		$config = $config + $this->config;
+		$itemsPerPage = $itemsPerPage ?? $this->options['items_per_page'];
 
-		return new Pagination($this->request, $count, $config, $this->urlBuilder, $this->viewFactory);
+		$options = $options + $this->options;
+
+		$currentPage = max((int) $this->request->get($options['page_key'], 1), 1);
+
+		$pagination = new Pagination($items, $itemsPerPage, $currentPage, $options);
+
+		$pagination->setRequest($this->request);
+
+		$pagination->setURLBuilder($this->urlBuilder);
+
+		$pagination->setViewFactory($this->viewFactory);
+
+		return $pagination;
 	}
 }

--- a/src/mako/pagination/PaginationFactoryInterface.php
+++ b/src/mako/pagination/PaginationFactoryInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @copyright  Frederic G. Østby
+ * @license    http://www.makoframework.com/license
+ */
+
+namespace mako\pagination;
+
+use mako\pagination\PaginationInterface;
+
+/**
+ * Pagination factory interface.
+ *
+ * @author  Frederic G. Østby
+ * @author  Yamada Taro
+ */
+
+interface PaginationFactoryInterface
+{
+	/**
+	 * Creates and returns a pagination instance.
+	 *
+	 * @access  public
+	 * @param   int                                   $items         Number of items
+	 * @param   null|int                              $itemsPerPage  Number of items per page
+	 * @param   array                                 $options       Pagination options
+	 * @return  \mako\pagination\PaginationInterface
+	 */
+
+	public function create($items, $itemsPerPage = null, array $options = []): PaginationInterface;
+}

--- a/src/mako/pagination/PaginationInterface.php
+++ b/src/mako/pagination/PaginationInterface.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @copyright  Frederic G. Østby
+ * @license    http://www.makoframework.com/license
+ */
+
+namespace mako\pagination;
+
+/**
+ * Pagination interface.
+ *
+ * @author  Frederic G. Østby
+ * @author  Yamada Taro
+ */
+
+interface PaginationInterface
+{
+	/**
+	 * Constructor.
+	 *
+	 * @access  public
+	 * @param   int     $items         Number of items
+	 * @param   int     $itemsPerPage  Number of items per page
+	 * @param   int     $currentPage   The current page
+	 * @param   array   $options       Pagination options
+	 */
+
+	public function __construct($items, $itemsPerPage, $currentPage, array $options = []);
+
+	/**
+	 * Returns the number of items.
+	 *
+	 * @access  public
+	 * @return  int
+	 */
+
+	public function items();
+
+	/**
+	 * Returns the number of items per page.
+	 *
+	 * @access  public
+	 * @return  int
+	 */
+
+	public function itemsPerPage();
+
+	/**
+	 * Returns the current page.
+	 *
+	 * @access  public
+	 * @return  int
+	 */
+
+	public function currentPage();
+
+	/**
+	 * Returns the number pages.
+	 *
+	 * @access  public
+	 * @return  int
+	 */
+
+	public function numberOfPages();
+
+	/**
+	 * Returns the limit.
+	 *
+	 * @access  public
+	 * @return  int
+	 */
+
+	public function limit();
+
+	/**
+	 * Returns the offset.
+	 *
+	 * @access  public
+	 * @return  int
+	 */
+
+	public function offset();
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,4 +9,5 @@ mb_regex_encoding('UTF-8');
 mb_internal_encoding('UTF-8');
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
+require_once __DIR__ . '/integration/resources/BuilderTestCase.php';
 require_once __DIR__ . '/integration/resources/ORMTestCase.php';

--- a/tests/integration/database/query/compilers/BaseCompilerTest.php
+++ b/tests/integration/database/query/compilers/BaseCompilerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace mako\tests\integration\database\query\compilers;
+
+use mako\database\query\Query;
+use mako\pagination\PaginationFactoryInterface;
+use mako\pagination\PaginationInterface;
+
+use BuilderTestCase;
+use Mockery;
+
+/**
+ * @group integration
+ * @group integration:database
+ * @requires extension PDO
+ * @requires extension pdo_sqlite
+ */
+
+class BaseCompilerTest extends BuilderTestCase
+{
+	/**
+	 *
+	 */
+
+	public function testSelectWithPagination()
+	{
+		$pagination = Mockery::mock(PaginationInterface::class);
+
+		$pagination->shouldReceive('limit')->once()->andReturn(10);
+
+		$pagination->shouldReceive('offset')->once()->andReturn(0);
+
+		$paginationFactory = Mockery::mock(PaginationFactoryInterface::class);
+
+		$paginationFactory->shouldReceive('create')->once()->andReturn($pagination);
+
+		$query = Mockery::mock(Query::class . '[getPaginationFactory]', [$this->connectionManager->connection()]);
+
+		$query->shouldReceive('getPaginationFactory')->once()->andReturn($paginationFactory);
+
+		$query->table('users')->paginate();
+
+		$this->assertEquals('SELECT COUNT(*) FROM "users"', $this->connectionManager->connection()->getLog()[0]['query']);
+
+		$this->assertEquals('SELECT * FROM "users" LIMIT 10 OFFSET 0', $this->connectionManager->connection()->getLog()[1]['query']);
+	}
+
+	/**
+	 *
+	 */
+
+	public function testSelectWithPaginationAndOrdering()
+	{
+		$pagination = Mockery::mock(PaginationInterface::class);
+
+		$pagination->shouldReceive('limit')->once()->andReturn(10);
+
+		$pagination->shouldReceive('offset')->once()->andReturn(0);
+
+		$paginationFactory = Mockery::mock(PaginationFactoryInterface::class);
+
+		$paginationFactory->shouldReceive('create')->once()->andReturn($pagination);
+
+		$query = Mockery::mock(Query::class . '[getPaginationFactory]', [$this->connectionManager->connection()]);
+
+		$query->shouldReceive('getPaginationFactory')->once()->andReturn($paginationFactory);
+
+		$query->table('users')->ascending('id')->paginate();
+
+		$this->assertEquals('SELECT COUNT(*) FROM "users"', $this->connectionManager->connection()->getLog()[0]['query']);
+
+		$this->assertEquals('SELECT * FROM "users" ORDER BY "id" ASC LIMIT 10 OFFSET 0', $this->connectionManager->connection()->getLog()[1]['query']);
+	}
+}

--- a/tests/integration/resources/BuilderTestCase.php
+++ b/tests/integration/resources/BuilderTestCase.php
@@ -1,0 +1,42 @@
+<?php
+
+use mako\database\ConnectionManager;
+
+abstract class BuilderTestCase extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 *
+	 */
+
+	protected $connectionManager;
+
+	/**
+	 *
+	 */
+
+	public function setup()
+	{
+		// Set up connection manager
+
+		$configs =
+		[
+			'sqlite' =>
+			[
+				'dsn'         => 'sqlite::memory:',
+				'log_queries' => true,
+				'queries'     =>
+				[
+					"PRAGMA encoding = 'UTF-8'",
+				],
+			],
+		];
+
+		$this->connectionManager = new ConnectionManager('sqlite', $configs);
+
+		// Load test database into memory
+
+		$sql = file_get_contents(__DIR__ . '/sqlite.sql');
+
+		$this->connectionManager->connection()->getPDO()->exec($sql);
+	}
+}

--- a/tests/integration/resources/ORMTestCase.php
+++ b/tests/integration/resources/ORMTestCase.php
@@ -7,7 +7,7 @@ class TestORM extends \mako\database\midgard\ORM
 
 }
 
-abstract class ORMTestCase extends \PHPUnit_Framework_TestCase
+abstract class ORMTestCase extends BuilderTestCase
 {
 	/**
 	 *
@@ -21,28 +21,7 @@ abstract class ORMTestCase extends \PHPUnit_Framework_TestCase
 
 	public function setup()
 	{
-		// Set up connection manager
-
-		$configs =
-		[
-			'sqlite' =>
-			[
-				'dsn'         => 'sqlite::memory:',
-				'log_queries' => true,
-				'queries'     =>
-				[
-					"PRAGMA encoding = 'UTF-8'",
-				],
-			],
-		];
-
-		$this->connectionManager = new ConnectionManager('sqlite', $configs);
-
-		// Load test database into memory
-
-		$sql = file_get_contents(__DIR__ . '/sqlite.sql');
-
-		$this->connectionManager->connection()->getPDO()->exec($sql);
+		parent::setup();
 
 		// Set the connection manager
 

--- a/tests/unit/database/query/compilers/BaseCompilerTest.php
+++ b/tests/unit/database/query/compilers/BaseCompilerTest.php
@@ -186,28 +186,6 @@ class BaseCompilerTest extends \PHPUnit_Framework_TestCase
 	 *
 	 */
 
-	public function testSelectWithPagination()
-	{
-		$pagination = m::mock('\mako\pagination\Pagination');
-
-		$pagination->shouldReceive('limit')->andReturn(10);
-
-		$pagination->shouldReceive('offset')->andReturn(10);
-
-		$query = $this->getBuilder();
-
-		$query->paginate($pagination);
-
-		$query = $query->getCompiler()->select();
-
-		$this->assertEquals('SELECT * FROM "foobar" LIMIT 10 OFFSET 10', $query['sql']);
-		$this->assertEquals(array(), $query['params']);
-	}
-
-	/**
-	 *
-	 */
-
 	public function testSelectWithWhere()
 	{
 		$query = $this->getBuilder();
@@ -1069,6 +1047,23 @@ class BaseCompilerTest extends \PHPUnit_Framework_TestCase
 		$query = $query->getCompiler()->select();
 
 		$this->assertEquals('SELECT * FROM "foobar" ORDER BY "foo" ASC, "bar" DESC', $query['sql']);
+		$this->assertEquals(array(), $query['params']);
+	}
+
+	/**
+	 *
+	 */
+
+	public function testSelectResetOrdering()
+	{
+		$query = $this->getBuilder();
+
+		$query->orderBy('foo');
+		$query->orderBy('bar', 'DESC');
+
+		$query = $query->resetOrdering()->getCompiler()->select();
+
+		$this->assertEquals('SELECT * FROM "foobar"', $query['sql']);
 		$this->assertEquals(array(), $query['params']);
 	}
 


### PR DESCRIPTION
Hi,

I have made some rather large changes to how pagination works (but the change for a end user should be minimal).

Now we can do like this:

```$users = User::asceding('id')->paginate()```

Thats it! To access the pagination object in your views just do this:

```{{raw:$users->getPagination()->render('pagination')}}```

This works with both the query builder and the ORM.

You can still create pagination objects the old way using ```$this->pagination->create($count);``` as well.

I'll make another pull request to the docs if this gets merged :)