### PR TITLE
It is now possible to extend Collections with custom methods.

### DIFF
--- a/src/mako/common/ExtendableTrait.php
+++ b/src/mako/common/ExtendableTrait.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace mako\common;
+
+/**
+ * @copyright  Frederic G. Østby
+ * @license    http://www.makoframework.com/license
+ */
+
+use Closure;
+use BadMethodCallException;
+
+/**
+ * Extendable trait.
+ *
+ * @author  Yamada Taro
+ */
+
+trait ExtendableTrait
+{
+	/**
+	 * Class extensions.
+	 *
+	 * @var array
+	 */
+
+	protected static $_extensions;
+
+	/**
+	 * Extends the class.
+	 *
+	 * @access  public
+	 * @param   string    $methodName  Method name
+	 * @param   \Closure  $closure     Closure
+	 */
+
+	public static function extend(string $methodName, Closure $closure)
+	{
+		static::$_extensions[$methodName] = $closure;
+	}
+
+	/**
+	 * Executes class extensions.
+	 *
+	 * @access  public
+	 * @param   string  $name       Method name
+	 * @param   array   $arguments  Method arguments
+	 * @return  mixed
+	 */
+
+	public function __call(string $name, array $arguments)
+	{
+		if(!isset(static::$_extensions[$name]))
+		{
+			throw new BadMethodCallException(vsprintf("Call to undefined method %s::%s().", [static::class, $name]));
+		}
+
+		return static::$_extensions[$name]->bindTo($this, static::class)(...$arguments);
+	}
+
+	/**
+	 * Executes class extensions.
+	 *
+	 * @access  public
+	 * @param   string  $name       Method name
+	 * @param   array   $arguments  Method arguments
+	 * @return  mixed
+	 */
+
+	public static function __callStatic(string $name, array $arguments)
+	{
+		if(!isset(static::$_extensions[$name]))
+		{
+			throw new BadMethodCallException(vsprintf("Call to undefined method %s::%s().", [static::class, $name]));
+		}
+
+		return Closure::bind(static::$_extensions[$name], null, static::class)(...$arguments);
+	}
+}

--- a/src/mako/utility/Collection.php
+++ b/src/mako/utility/Collection.php
@@ -13,6 +13,8 @@ use Closure;
 use Countable;
 use IteratorAggregate;
 
+use mako\common\ExtendableTrait;
+
 /**
  * Collection.
  *
@@ -21,6 +23,8 @@ use IteratorAggregate;
 
 class Collection implements ArrayAccess, Countable, IteratorAggregate
 {
+	use ExtendableTrait;
+
 	/**
 	 * Collection items.
 	 *

--- a/src/mako/utility/HTML.php
+++ b/src/mako/utility/HTML.php
@@ -7,8 +7,7 @@
 
 namespace mako\utility;
 
-use Closure;
-use BadMethodCallException;
+use mako\common\ExtendableTrait;
 
 /**
  * HTML helper.
@@ -18,6 +17,8 @@ use BadMethodCallException;
 
 class HTML
 {
+	use ExtendableTrait;
+
 	/**
 	 * Should we return XHTML?
 	 *
@@ -25,14 +26,6 @@ class HTML
 	 */
 
 	protected $xhtml;
-
-	/**
-	 * Custom tags.
-	 *
-	 * @var array
-	 */
-
-	protected static $tags = [];
 
 	/**
 	 * Constructor.
@@ -44,19 +37,6 @@ class HTML
 	public function __construct($xhtml = false)
 	{
 		$this->xhtml = $xhtml;
-	}
-
-	/**
-	 * Registers a new HTML tag.
-	 *
-	 * @access  public
-	 * @param   string    $name  Tag name
-	 * @param   \Closure  $tag   Tag closure
-	 */
-
-	public static function registerTag($name, Closure $tag)
-	{
-		static::$tags[$name] = $tag;
 	}
 
 	/**
@@ -204,24 +184,5 @@ class HTML
 	public function ol(array $items, array $attributes = [])
 	{
 		return $this->buildList('ol', $items, $attributes);
-	}
-
-	/**
-	 * Magic shortcut to the custom HTML macros.
-	 *
-	 * @access  public
-	 * @param   string  $name       Method name
-	 * @param   array   $arguments  Method arguments
-	 * @return  string
-	 */
-
-	public function __call($name, array $arguments)
-	{
-		if(!isset(static::$tags[$name]))
-		{
-			throw new BadMethodCallException(vsprintf("Call to undefined method %s::%s().", [__CLASS__, $name]));
-		}
-
-		return (static::$tags[$name])(...array_merge([$this], $arguments));
 	}
 }

--- a/tests/unit/common/ExtendableTraitTest.php
+++ b/tests/unit/common/ExtendableTraitTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace mako\tests\unit\common;
+
+use mako\common\ExtendableTrait;
+
+// --------------------------------------------------------------------------
+// START CLASSES
+// --------------------------------------------------------------------------
+
+class Extended
+{
+	use ExtendableTrait;
+
+	protected static $foo = 'foo';
+
+	protected $bar = 'bar';
+}
+
+// --------------------------------------------------------------------------
+// END CLASSES
+// --------------------------------------------------------------------------
+
+/**
+ * @group unit
+ */
+
+class ExtendableTraitTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 *
+	 */
+
+	public function testExtending()
+	{
+		Extended::extend('foo', function()
+		{
+			return static::$foo;
+		});
+
+		Extended::extend('bar', function()
+		{
+			return $this->bar;
+		});
+
+		$this->assertSame('foo', Extended::foo());
+
+		$this->assertSame('bar', (new Extended)->bar());
+	}
+
+	/**
+	 * @expectedException \BadMethodCallException
+	 */
+
+	public function testException()
+	{
+		$collection = new Extended();
+
+		$collection->nope();
+	}
+}

--- a/tests/unit/utility/CollectionTest.php
+++ b/tests/unit/utility/CollectionTest.php
@@ -282,4 +282,36 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
 		$this->assertTrue(($collection[0] === 1 || $collection[0] === 2));
 	}
+
+	/**
+	 *
+	 */
+
+	public function testExtending()
+	{
+		Collection::extend('increaseByOne', function()
+		{
+			foreach($this->items as $key => $value)
+			{
+				$this->items[$key] += 1;
+			}
+		});
+
+		$collection = new Collection([1, 2, 3, 4, 5, 6]);
+
+		$collection->increaseByOne();
+
+		$this->assertSame([2, 3, 4, 5, 6, 7], $collection->getItems());
+	}
+
+	/**
+	 * @expectedException \BadMethodCallException
+	 */
+
+	public function testException()
+	{
+		$collection = new Collection();
+
+		$collection->nope();
+	}
 }

--- a/tests/unit/utility/HTMLTest.php
+++ b/tests/unit/utility/HTMLTest.php
@@ -159,11 +159,11 @@ class HTMLTest extends \PHPUnit_Framework_TestCase
 	 *
 	 */
 
-	public function testCustom()
+	public function testExtending()
 	{
-		HTML::registerTag('foo', function($html, $content = null, $attributes = [])
+		HTML::extend('foo', function($content = null, $attributes = [])
 		{
-			return $html->tag('foo', $attributes, $content);
+			return $this->tag('foo', $attributes, $content);
 		});
 
 		$html = new HTML;
@@ -193,6 +193,6 @@ class HTMLTest extends \PHPUnit_Framework_TestCase
 	{
 		$html = new HTML;
 
-		$html->bar();
+		$html->nope();
 	}
 }


### PR DESCRIPTION
This makes it easy to extend Collections with custom methods. We needed a `toJsonWithPagination` method and this seemed like a clean and easy way to do it.

I also made some changes to the HTML helper so that it uses the same `ExtendableTrait`. It causes a minor bc-break (as you can see in the HTML helper unit test) but I think it's worth it when we're jumping to a new major release.