### PR TITLE
Added unified JSON field syntax

### DIFF
--- a/src/mako/database/ConnectionManager.php
+++ b/src/mako/database/ConnectionManager.php
@@ -20,6 +20,7 @@ use mako\database\query\compilers\MySQL as MySQLCompiler;
 use mako\database\query\compilers\NuoDB as NuoDBCompiler;
 use mako\database\query\compilers\Oracle as OracleCompiler;
 use mako\database\query\compilers\Postgres as PostgresCompiler;
+use mako\database\query\compilers\SQLite as SQLiteCompiler;
 use mako\database\query\compilers\SQLServer as SQLServerCompiler;
 use mako\database\query\helpers\Helper;
 use mako\database\query\helpers\Postgres as PostgresHelper;
@@ -69,6 +70,7 @@ class ConnectionManager extends BaseConnectionManager
 		'nuodb'    => NuoDBCompiler::class,
 		'oracle'   => OracleCompiler::class,
 		'pgsql'    => PostgresCompiler::class,
+		'sqlite'   => SQLiteCompiler::class,
 		'sqlsrv'   => SQLServerCompiler::class,
 	];
 

--- a/src/mako/database/query/Query.php
+++ b/src/mako/database/query/Query.php
@@ -1224,7 +1224,7 @@ class Query
 	 */
 	protected function aggregate($column, $function)
 	{
-		$aggregate = new Raw($function . '(' . $this->compiler->escapeTableAndOrColumn($column) . ')');
+		$aggregate = new Raw($function . '(' . $this->compiler->wrapTableAndOrColumn($column) . ')');
 
 		$query = $this->select([$aggregate])->compiler->select();
 

--- a/src/mako/database/query/compilers/Compiler.php
+++ b/src/mako/database/query/compilers/Compiler.php
@@ -141,6 +141,11 @@ class Compiler
 	{
 		$wrapped = [];
 
+		if(strpos($value, '->') !== false)
+		{
+			list($value, $jsonPath) = explode('->', $value, 2);
+		}
+
 		foreach(explode('.', $value) as $segment)
 		{
 			if($segment === '*')
@@ -149,20 +154,18 @@ class Compiler
 			}
 			else
 			{
-				if(strpos($segment, '->') === false)
-				{
-					$wrapped[] = $this->escapeIdentifier($segment);
-				}
-				else
-				{
-					$segments = explode('->', $segment);
-
-					$wrapped[] = $this->buildJsonPath(array_shift($segments), $segments);
-				}
+				$wrapped[] = $this->escapeIdentifier($segment);
 			}
 		}
 
-		return implode('.', $wrapped);
+		$wrapped = implode('.', $wrapped);
+
+		if(isset($jsonPath))
+		{
+			$wrapped = $this->buildJsonPath($wrapped, explode('->', $jsonPath));
+		}
+
+		return $wrapped;
 	}
 
 	/**

--- a/src/mako/database/query/compilers/MySQL.php
+++ b/src/mako/database/query/compilers/MySQL.php
@@ -27,6 +27,28 @@ class MySQL extends Compiler
 	/**
 	 * {@inheritdoc}
 	 */
+	protected function buildJsonPath($field, array $segments)
+	{
+		$path = '';
+
+		foreach($segments as $segment)
+		{
+			if(is_numeric($segment))
+			{
+				$path .= '[' . $segment . ']';
+			}
+			else
+			{
+				$path .= '.' . $segment;
+			}
+		}
+
+		return $this->escapeIdentifier($field) . '->"$' . str_replace('"', '""', $path) . '"';
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function lock($lock)
 	{
 		if($lock === null)

--- a/src/mako/database/query/compilers/Oracle.php
+++ b/src/mako/database/query/compilers/Oracle.php
@@ -19,7 +19,7 @@ class Oracle extends Compiler
 	/**
 	 * {@inheritdoc}
 	 */
-	protected function buildJsonPath($field, array $segments)
+	protected function buildJsonPath($column, array $segments)
 	{
 		$path = '';
 
@@ -35,7 +35,7 @@ class Oracle extends Compiler
 			}
 		}
 
-		return $this->escapeIdentifier($field) . $path;
+		return $column . $path;
 	}
 
 	/**

--- a/src/mako/database/query/compilers/Oracle.php
+++ b/src/mako/database/query/compilers/Oracle.php
@@ -19,6 +19,28 @@ class Oracle extends Compiler
 	/**
 	 * {@inheritdoc}
 	 */
+	protected function buildJsonPath($field, array $segments)
+	{
+		$path = '';
+
+		foreach($segments as $segment)
+		{
+			if(is_numeric($segment))
+			{
+				$path .= '[' . $segment . ']';
+			}
+			else
+			{
+				$path .= '.' . $this->escapeIdentifier($segment);
+			}
+		}
+
+		return $this->escapeIdentifier($field) . $path;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function lock($lock)
 	{
 		if($lock === null)

--- a/src/mako/database/query/compilers/Postgres.php
+++ b/src/mako/database/query/compilers/Postgres.php
@@ -20,6 +20,35 @@ class Postgres extends Compiler
 	/**
 	 * {@inheritdoc}
 	 */
+	protected function buildJsonPath($field, array $segments)
+	{
+		$segments = array_map(function($segment)
+		{
+			if(is_numeric($segment))
+			{
+				return	$segment;
+			}
+
+			return "'" . str_replace("'", "''", $segment) . "'";
+		}, $segments);
+
+		$last = array_pop($segments);
+
+		if(empty($segments))
+		{
+			$path = '->>' . $last;
+		}
+		else
+		{
+			$path = '->' . implode('->', $segments) . '->>' . $last;
+		}
+
+		return $this->escapeIdentifier($field) . $path;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function lock($lock)
 	{
 		if($lock === null)

--- a/src/mako/database/query/compilers/Postgres.php
+++ b/src/mako/database/query/compilers/Postgres.php
@@ -20,7 +20,7 @@ class Postgres extends Compiler
 	/**
 	 * {@inheritdoc}
 	 */
-	protected function buildJsonPath($field, array $segments)
+	protected function buildJsonPath($column, array $segments)
 	{
 		$segments = array_map(function($segment)
 		{
@@ -43,7 +43,7 @@ class Postgres extends Compiler
 			$path = '->' . implode('->', $segments) . '->>' . $last;
 		}
 
-		return $this->escapeIdentifier($field) . $path;
+		return $column . $path;
 	}
 
 	/**

--- a/src/mako/database/query/compilers/SQLServer.php
+++ b/src/mako/database/query/compilers/SQLServer.php
@@ -34,6 +34,28 @@ class SQLServer extends Compiler
 	/**
 	 * {@inheritdoc}
 	 */
+	protected function buildJsonPath($column, array $segments)
+	{
+		$path = '';
+
+		foreach($segments as $segment)
+		{
+			if(is_numeric($segment))
+			{
+				$path .= '[' . $segment . ']';
+			}
+			else
+			{
+				$path .= '.' . $segment;
+			}
+		}
+
+		return 'json_value(' . $column . ', ' . "'lax $" . str_replace("'", "''", $path) . "'" . ')';
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function from($from)
 	{
 		$from = parent::from($from);

--- a/src/mako/database/query/compilers/SQLite.php
+++ b/src/mako/database/query/compilers/SQLite.php
@@ -10,20 +10,13 @@ namespace mako\database\query\compilers;
 use mako\database\query\compilers\Compiler;
 
 /**
- * Compiles MySQL queries.
+ * Compiles SQLite queries.
  *
  * @author  Frederic G. Østby
+ * @author  Yamada Taro
  */
-class MySQL extends Compiler
+class SQLite extends Compiler
 {
-	/**
-	 * {@inheritdoc}
-	 */
-	public function escapeIdentifier($identifier)
-	{
-		return '`' . str_replace('`', '``', $identifier) . '`';
-	}
-
 	/**
 	 * {@inheritdoc}
 	 */
@@ -43,19 +36,6 @@ class MySQL extends Compiler
 			}
 		}
 
-		return $column . '->"$' . str_replace('"', '""', $path) . '"';
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function lock($lock)
-	{
-		if($lock === null)
-		{
-			return '';
-		}
-
-		return $lock === true ? ' FOR UPDATE' : ($lock === false ? ' LOCK IN SHARE MODE' : ' ' . $lock);
+		return 'json_extract(' . $column . ', ' . "'$" . str_replace("'", "''", $path) . "'" . ')';
 	}
 }

--- a/tests/unit/database/query/compilers/BaseCompilerTest.php
+++ b/tests/unit/database/query/compilers/BaseCompilerTest.php
@@ -177,6 +177,19 @@ class BaseCompilerTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * @expectedException \Exception
+	 * @expectedExceptionMessage mako\database\query\compilers\Compiler::buildJsonPath(): The [ mako\database\query\compilers\Compiler ] query compiler does not support the unified JSON field syntax.
+	 */
+	public function testSelectWithJSONColumn()
+	{
+		$query = $this->getBuilder();
+
+		$query->select(['json->0->bar']);
+
+		$query = $query->getCompiler()->select();
+	}
+
+	/**
 	 *
 	 */
 	public function testSelectWithLimit()

--- a/tests/unit/database/query/compilers/MySQLCompilerTest.php
+++ b/tests/unit/database/query/compilers/MySQLCompilerTest.php
@@ -66,6 +66,54 @@ class MySQLCompilerTest extends PHPUnit_Framework_TestCase
 	/**
 	 *
 	 */
+	public function testSelectWithJSONColumn()
+	{
+		$query = $this->getBuilder();
+
+		$query->select(['json->foo->0->bar']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT `json`->"$.foo[0].bar" FROM `foobar`', $query['sql']);
+		$this->assertEquals([], $query['params']);
+
+		//
+
+		$query = $this->getBuilder();
+
+		$query->select(['json->foo->0->"bar']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT `json`->"$.foo[0].""bar" FROM `foobar`', $query['sql']);
+		$this->assertEquals([], $query['params']);
+
+		//
+
+		$query = $this->getBuilder();
+
+		$query->select(['json->foo->0->bar as jsonvalue']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT `json`->"$.foo[0].bar" AS `jsonvalue` FROM `foobar`', $query['sql']);
+		$this->assertEquals([], $query['params']);
+
+		//
+
+		$query = $this->getBuilder();
+
+		$query->select(['foobar.json->foo->0->bar as jsonvalue']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT `foobar`.`json`->"$.foo[0].bar" AS `jsonvalue` FROM `foobar`', $query['sql']);
+		$this->assertEquals([], $query['params']);
+	}
+
+	/**
+	 *
+	 */
 	public function testSelectWithExclusiveLock()
 	{
 		$query = $this->getBuilder();

--- a/tests/unit/database/query/compilers/OracleCompilerTest.php
+++ b/tests/unit/database/query/compilers/OracleCompilerTest.php
@@ -98,6 +98,54 @@ class OracleCompilerTest extends PHPUnit_Framework_TestCase
 	/**
 	 *
 	 */
+	public function testSelectWithJSONColumn()
+	{
+		$query = $this->getBuilder();
+
+		$query->select(['json->foo->0->bar']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT "json"."foo"[0]."bar" FROM "foobar"', $query['sql']);
+		$this->assertEquals([], $query['params']);
+
+		//
+
+		$query = $this->getBuilder();
+
+		$query->select(['json->foo->0->"bar']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT "json"."foo"[0]."""bar" FROM "foobar"', $query['sql']);
+		$this->assertEquals([], $query['params']);
+
+		//
+
+		$query = $this->getBuilder();
+
+		$query->select(['json->foo->0->bar as jsonvalue']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT "json"."foo"[0]."bar" AS "jsonvalue" FROM "foobar"', $query['sql']);
+		$this->assertEquals([], $query['params']);
+
+		//
+
+		$query = $this->getBuilder();
+
+		$query->select(['foobar.json->foo->0->bar as jsonvalue']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT "foobar"."json"."foo"[0]."bar" AS "jsonvalue" FROM "foobar"', $query['sql']);
+		$this->assertEquals([], $query['params']);
+	}
+
+	/**
+	 *
+	 */
 	public function testSelectWithExclusiveLock()
 	{
 		$query = $this->getBuilder();

--- a/tests/unit/database/query/compilers/PostgresCompilerTest.php
+++ b/tests/unit/database/query/compilers/PostgresCompilerTest.php
@@ -53,6 +53,54 @@ class PostgresCompilerTest extends PHPUnit_Framework_TestCase
 	/**
 	 *
 	 */
+	public function testSelectWithJSONColumn()
+	{
+		$query = $this->getBuilder();
+
+		$query->select(['json->foo->0->bar']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT "json"->\'foo\'->0->>\'bar\' FROM "foobar"', $query['sql']);
+		$this->assertEquals([], $query['params']);
+
+		//
+
+		$query = $this->getBuilder();
+
+		$query->select(['json->foo->0->\'bar']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT "json"->\'foo\'->0->>\'\'\'bar\' FROM "foobar"', $query['sql']);
+		$this->assertEquals([], $query['params']);
+
+		//
+
+		$query = $this->getBuilder();
+
+		$query->select(['json->foo->0->bar as jsonvalue']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT "json"->\'foo\'->0->>\'bar\' AS "jsonvalue" FROM "foobar"', $query['sql']);
+		$this->assertEquals([], $query['params']);
+
+		//
+
+		$query = $this->getBuilder();
+
+		$query->select(['foobar.json->foo->0->bar as jsonvalue']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT "foobar"."json"->\'foo\'->0->>\'bar\' AS "jsonvalue" FROM "foobar"', $query['sql']);
+		$this->assertEquals([], $query['params']);
+	}
+
+	/**
+	 *
+	 */
 	public function testSelectWithExclusiveLock()
 	{
 		$query = $this->getBuilder();

--- a/tests/unit/database/query/compilers/SQLServerCompilerTest.php
+++ b/tests/unit/database/query/compilers/SQLServerCompilerTest.php
@@ -97,6 +97,54 @@ class SQLServerCompilerTest extends PHPUnit_Framework_TestCase
 	/**
 	 *
 	 */
+	public function testSelectWithJSONColumn()
+	{
+		$query = $this->getBuilder();
+
+		$query->select(['json->foo->0->bar']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT json_value([json], \'lax $.foo[0].bar\') FROM [foobar]', $query['sql']);
+		$this->assertEquals([], $query['params']);
+
+		//
+
+		$query = $this->getBuilder();
+
+		$query->select(['json->foo->0->\'bar']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT json_value([json], \'lax $.foo[0].\'\'bar\') FROM [foobar]', $query['sql']);
+		$this->assertEquals([], $query['params']);
+
+		//
+
+		$query = $this->getBuilder();
+
+		$query->select(['json->foo->0->bar as jsonvalue']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT json_value([json], \'lax $.foo[0].bar\') AS [jsonvalue] FROM [foobar]', $query['sql']);
+		$this->assertEquals([], $query['params']);
+
+		//
+
+		$query = $this->getBuilder();
+
+		$query->select(['foobar.json->foo->0->bar as jsonvalue']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT json_value([foobar].[json], \'lax $.foo[0].bar\') AS [jsonvalue] FROM [foobar]', $query['sql']);
+		$this->assertEquals([], $query['params']);
+	}
+
+	/**
+	 *
+	 */
 	public function testSelectWithExclusiveLock()
 	{
 		$query = $this->getBuilder();

--- a/tests/unit/database/query/compilers/SQLiteCompilerTest.php
+++ b/tests/unit/database/query/compilers/SQLiteCompilerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * @copyright  Frederic G. Østby
+ * @license    http://www.makoframework.com/license
+ */
+
+namespace mako\tests\unit\database\query\compilers;
+
+use Mockery;
+use PHPUnit_Framework_TestCase;
+
+use mako\database\query\Query;
+
+/**
+ * @group unit
+ */
+class SQLiteCompilerTest extends PHPUnit_Framework_TestCase
+{
+	/**
+	 *
+	 */
+	public function tearDown()
+	{
+		Mockery::close();
+	}
+
+	/**
+	 *
+	 */
+	protected function getConnection()
+	{
+		$connection = Mockery::mock('\mako\database\connections\Connection');
+
+		$connection->shouldReceive('getQueryBuilderHelper')->andReturn(Mockery::mock('\mako\database\query\helpers\HelperInterface'));
+
+		$connection->shouldReceive('getQueryCompiler')->andReturnUsing(function($query)
+		{
+			return new \mako\database\query\compilers\SQLite($query);
+		});
+
+		return $connection;
+	}
+
+	/**
+	 *
+	 */
+	protected function getBuilder($table = 'foobar')
+	{
+		return (new Query($this->getConnection()))->table($table);
+	}
+
+	/**
+	 *
+	 */
+	public function testSelectWithJSONColumn()
+	{
+		$query = $this->getBuilder();
+
+		$query->select(['json->foo->0->bar']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT json_extract("json", \'$.foo[0].bar\') FROM "foobar"', $query['sql']);
+		$this->assertEquals([], $query['params']);
+
+		//
+
+		$query = $this->getBuilder();
+
+		$query->select(['json->foo->0->\'bar']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT json_extract("json", \'$.foo[0].\'\'bar\') FROM "foobar"', $query['sql']);
+		$this->assertEquals([], $query['params']);
+
+		//
+
+		$query = $this->getBuilder();
+
+		$query->select(['json->foo->0->bar as jsonvalue']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT json_extract("json", \'$.foo[0].bar\') AS "jsonvalue" FROM "foobar"', $query['sql']);
+		$this->assertEquals([], $query['params']);
+
+		//
+
+		$query = $this->getBuilder();
+
+		$query->select(['foobar.json->foo->0->bar as jsonvalue']);
+
+		$query = $query->getCompiler()->select();
+
+		$this->assertEquals('SELECT json_extract("foobar"."json", \'$.foo[0].bar\') AS "jsonvalue" FROM "foobar"', $query['sql']);
+		$this->assertEquals([], $query['params']);
+	}
+}


### PR DESCRIPTION
I have added a unified JSON field syntax to the query builder. It supports both JSON arrays and objects (and a mix of both). 

The syntax currently works with Postgres, MySQL and Oracle and it'll throw an exception when used with any other RDBMS. I know SQLite and SQL Server have some limited JSON capabilities but I didn't find enough info.

`$query->table('foobar')->select(['json_column->foo->bar->0->baz'])->all();`