### PR TITLE
Bump minimum PHP version to 7.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		}
 	},
 	"require": {
-		"php": ">=5.5.0",
+		"php": ">=7.0.0",
 		"monolog/monolog": "1.13.*"
 	},
 	"require-dev": {


### PR DESCRIPTION
The code as it is right now makes heavy use of the null coalescing operator and is therefore incompatible with php5 anyway.