### PR TITLE
Allow newer, but backwards-compatible versions of monolog.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	},
 	"require": {
 		"php": ">=5.5.0",
-		"monolog/monolog": "1.13.*"
+		"monolog/monolog": "^1.13.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "4.6.*",


### PR DESCRIPTION
The version mask currently specified in composer.json does not allow any newer versions, which may cause conflicts with other projects that do require a newer version (such as, for example, GrumPHP).