### PR TITLE
Add support for xdebug in error handler

### DIFF
--- a/src/mako/error/handlers/WebHandler.php
+++ b/src/mako/error/handlers/WebHandler.php
@@ -217,6 +217,8 @@ class WebHandler extends Handler
 
 			$data['trace'] = $this->modifyTrace($trace);
 
+			$data['escapeVariables'] = !extension_loaded('xdebug');
+
 			// Add superglobals
 
 			$superGlobals =

--- a/src/mako/error/handlers/views/detailed.tpl.php
+++ b/src/mako/error/handlers/views/detailed.tpl.php
@@ -201,7 +201,13 @@
 
 										<tr>
 											<td>{{$key + 1}}</td>
-											<td><pre>{{$argument}}</pre></td>
+											<td>
+												{% if($escapeVariables) %}
+													<pre>{{$argument}}</pre>
+												{% else %}
+													{{raw:$argument}}
+												{% endif %}
+											</td>
 										</tr>
 
 									{% endforeach %}


### PR DESCRIPTION
When the detailed error view is shown by the error handler, it shows the arguments for each entry in the stack trace in a `<pre>` block. It uses `var_dump` to generate a readable version of the variable.

However, if the extension `xdebug` is present, it replaces the builtin `var_dump` with a more readable (and recursion-safe) one. That override already outputs sensible (and safe) HTML. The HTML escape from Mako comes after that, and causes a double escape as shown in the (slightly censored) screenshot below.

This patch checks whether `xdebug` is loaded and if so disables the output escaping. I use this in my own testing environment.

Mako version: 4.x and 5.x
PHP version: Any supported version will do

![problem](https://cloud.githubusercontent.com/assets/861864/20059334/0d6626c4-a4f6-11e6-88b5-4fbe518753cf.png)
