### PR TITLE
Fix migration rollback action

### DIFF
--- a/src/mako/application/cli/commands/migrations/RollbackTrait.php
+++ b/src/mako/application/cli/commands/migrations/RollbackTrait.php
@@ -59,6 +59,6 @@ trait RollbackTrait
 
 		$this->write('Rolled back the following migrations:' . PHP_EOL);
 
-		$this->outputMigrationList($migrations);
+		$this->outputMigrationList($migrations->getItems());
 	}
 }


### PR DESCRIPTION
When trying to rollback migrations everything works fine except in the last step when the command tries to output reverted migrations list.

The 'outputMigrationList' method expects an array parameter but an object is parsed instead.