### PR TITLE
Add missing method declaration

### DIFF
--- a/src/mako/gatekeeper/Authentication.php
+++ b/src/mako/gatekeeper/Authentication.php
@@ -23,6 +23,7 @@ use mako\gatekeeper\adapters\AdapterInterface;
  * @method null|\mako\gatekeeper\entities\user\UserEntityInterface    getUser()
  * @method bool                                                       isGuest()
  * @method bool                                                       isLoggedIn()
+ * @method bool                                                       basicAuth()
  */
 class Authentication
 {


### PR DESCRIPTION
Add a missing (but documented) method declaration to the Authentication class to make it more IDE friendly.