### PR TITLE
Added support for PHP 7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 7.0
 
 before_script: 
   - curl -s http://getcomposer.org/installer | php

--- a/src/mako/Redis.php
+++ b/src/mako/Redis.php
@@ -4,7 +4,7 @@ namespace mako;
 
 use \Closure;
 use \mako\Config;
-use \mako\String;
+use \mako\Str;
 use \RuntimeException;
 
 /**
@@ -265,7 +265,7 @@ class Redis
 	{
 		// Build command
 		
-		$arguments = array_merge(explode(' ', strtoupper(str_replace('_', ' ', String::camel2underscored($name)))), $arguments);
+		$arguments = array_merge(explode(' ', strtoupper(str_replace('_', ' ', Str::camel2underscored($name)))), $arguments);
 
 		$command = '*' . count($arguments) . static::CRLF;
 

--- a/src/mako/Str.php
+++ b/src/mako/Str.php
@@ -12,7 +12,7 @@ use \mako\HTML;
  * @license    http://www.makoframework.com/license
  */
 
-class String
+class Str
 {
 	//---------------------------------------------
 	// Class properties
@@ -268,7 +268,7 @@ class String
 	 * @return  string
 	 */
 
-	public static function random($pool = String::ALNUM, $length = 32)
+	public static function random($pool = Str::ALNUM, $length = 32)
 	{
 		$string = '';
 

--- a/src/mako/Validate.php
+++ b/src/mako/Validate.php
@@ -4,7 +4,7 @@ namespace mako;
 
 use \mako\I18n;
 use \mako\UUID;
-use \mako\String;
+use \mako\Str;
 use \mako\Database;
 use \mako\security\Token;
 use \Closure;
@@ -624,7 +624,7 @@ class Validate
 	{
 		$name = str_replace('::', '_', $name);
 
-		static::$validators['validate' . String::underscored2camel($name, true)] = $validator;
+		static::$validators['validate' . Str::underscored2camel($name, true)] = $validator;
 	}
 
 	/**
@@ -750,7 +750,7 @@ class Validate
 			{
 				$package = empty($validator['package']) ? '' : $validator['package'] . '_';
 
-				if($this->{'validate' . String::underscored2camel($package . $validator['name'], true)}($this->input[$field], $validator['parameters']) === false)
+				if($this->{'validate' . Str::underscored2camel($package . $validator['name'], true)}($this->input[$field], $validator['parameters']) === false)
 				{
 					$this->errors[$field] = $this->getErrorMessage($field, $validator['package'], $validator['name'], $validator['parameters']);
 

--- a/src/mako/boot.php
+++ b/src/mako/boot.php
@@ -4,7 +4,7 @@
 // Define some constants
 //------------------------------------------------------------------------------------------
 
-define('MAKO_VERSION', '3.6.0');
+define('MAKO_VERSION', '3.7.0');
 define('MAKO_START', microtime(true));
 define('MAKO_MAGIC_QUOTES', get_magic_quotes_gpc());
 define('MAKO_IS_WINDOWS', (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN'));

--- a/src/mako/database/ORM.php
+++ b/src/mako/database/ORM.php
@@ -3,7 +3,7 @@
 namespace mako\database;
 
 use \mako\I18n;
-use \mako\String;
+use \mako\Str;
 use \mako\Validate;
 use \mako\Database;
 use \mako\database\orm\Hydrator;
@@ -234,7 +234,7 @@ abstract class ORM
 	{
 		if($this->tableName === null)
 		{
-			$this->tableName = I18n::pluralize(String::camel2underscored(end((explode('\\', get_class($this))))), null, $this->language);
+			$this->tableName = I18n::pluralize(Str::camel2underscored(end((explode('\\', get_class($this))))), null, $this->language);
 		}
 		
 		return $this->tableName;

--- a/src/mako/database/query/Compiler.php
+++ b/src/mako/database/query/Compiler.php
@@ -278,7 +278,7 @@ class Compiler
 
 		foreach($wheres as $where)
 		{
-			$sql[] = $where['separator'] . ' ' . $this->$where['type']($where);
+			$sql[] = $where['separator'] . ' ' . $this->{$where['type']}($where);
 		}
 
 		return ' WHERE ' . substr(implode(' ', $sql), 4); // substr to remove "AND "

--- a/src/mako/reactor/Task.php
+++ b/src/mako/reactor/Task.php
@@ -2,7 +2,7 @@
 
 namespace mako\reactor;
 
-use \mako\String;
+use \mako\Str;
 use \mako\reactor\CLI;
 use \ReflectionClass;
 use \ReflectionMethod;

--- a/src/mako/reactor/tasks/App.php
+++ b/src/mako/reactor/tasks/App.php
@@ -2,7 +2,7 @@
 
 namespace mako\reactor\tasks;
 
-use \mako\String;
+use \mako\Str;
 
 /**
  * App task.
@@ -116,7 +116,7 @@ class App extends \mako\reactor\Task
 			return $this->cli->stderr('Unable to generate a new secret. Make sure that the "app/config/application.php" file is writable.');
 		}
 
-		$secret = str_replace(array('"', '\''), array('|', '/'), String::random(String::ALNUM . String::SYMBOLS, 32));
+		$secret = str_replace(array('"', '\''), array('|', '/'), Str::random(Str::ALNUM . Str::SYMBOLS, 32));
 
 		$contents = file_get_contents($configFile);
 

--- a/src/mako/security/Password.php
+++ b/src/mako/security/Password.php
@@ -3,7 +3,7 @@
 namespace mako\security;
 
 use \Closure;
-use \mako\String;
+use \mako\Str;
 
 /**
  * Secure password hashing and validation.
@@ -87,7 +87,7 @@ class Password
 		}
 		else
 		{
-			$salt = String::random();
+			$salt = Str::random();
 		}
 
 		$salt = substr(str_replace('+', '.', base64_encode($salt)), 0, 22);

--- a/src/mako/view/compiler/Template.php
+++ b/src/mako/view/compiler/Template.php
@@ -222,7 +222,7 @@ class Template
 
 		foreach($this->compileOrder as $method)
 		{
-			$contents = $this->$method($contents);
+			$contents = $this->{$method}($contents);
 		}
 
 		// Store compiled template


### PR DESCRIPTION
I have an old website running Mako Framework **3.6**. Now I want to switch to PHP 7 but this is not supported.
For this reason I just created a new version **3.7** that support PHP 7.
Could you integrate this new branch in you project?