### PR TITLE
Collection::map() improvement

### DIFF
--- a/src/mako/utility/Collection.php
+++ b/src/mako/utility/Collection.php
@@ -317,7 +317,11 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	 */
 	public function map(callable $callable)
 	{
-		return new static(array_map($callable, $this->items));
+		$keys = array_keys($this->items);
+
+		$values = array_map($callable, $this->items, $keys);
+
+		return new static(array_combine($keys, $values));
 	}
 
 	/**

--- a/src/mako/utility/Collection.php
+++ b/src/mako/utility/Collection.php
@@ -339,4 +339,25 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 		return new static(array_filter($this->items, $callable));
 	}
+
+	/**
+	 * Reject item based on the given criteria.
+	 * 
+	 * @param  mixed $criteria Filter
+	 * @return \mako\utility\Collection
+	 */
+	public function reject($criteria)
+	{
+		if (! is_callable($criteria)) {
+			return $this->reject(function($value) use ($criteria)
+			{
+			    return $value === $criteria;
+			});
+		}
+
+		return $this->map(function($value, $key) use ($criteria)  
+		{
+		    return $criteria($value, $key) ? null : $value;
+		})->filter();
+	}
 }

--- a/src/mako/utility/Collection.php
+++ b/src/mako/utility/Collection.php
@@ -339,25 +339,4 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 		return new static(array_filter($this->items, $callable));
 	}
-
-	/**
-	 * Reject item based on the given criteria.
-	 * 
-	 * @param  mixed $criteria Filter
-	 * @return \mako\utility\Collection
-	 */
-	public function reject($criteria)
-	{
-		if (! is_callable($criteria)) {
-			return $this->reject(function($value) use ($criteria)
-			{
-			    return $value === $criteria;
-			});
-		}
-
-		return $this->map(function($value, $key) use ($criteria)  
-		{
-		    return $criteria($value, $key) ? null : $value;
-		})->filter();
-	}
 }

--- a/tests/unit/utility/CollectionTest.php
+++ b/tests/unit/utility/CollectionTest.php
@@ -431,16 +431,30 @@ class CollectionTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testMap()
 	{
-		$collection = new Collection([1, 2, 3]);
+		$collection = new Collection(['first' => 1, 'second' => 2, 'third' => 3]);
 
-		$mapped = $collection->map(function($value)
+		$mapped1 = $collection->map(function($value) 
 		{
-			return $value + 1;
+		    return $value + 1;
 		});
 
-		$this->assertSame([2, 3, 4], $mapped->getItems());
+		$this->assertSame(['first' => 2, 'second' => 3, 'third' => 4], $mapped1->getItems());
 
-		$this->assertSame([1, 2, 3], $collection->getItems());
+		// With key passes as second argument.
+		$mapped2 = $collection->map(function($value, $key)
+		{
+			return $key . ':' . ($value + 1);
+		});
+
+		$this->assertSame([
+			'first' => 'first:2', 
+			'second' => 'second:3', 
+			'third' => 'third:4'
+		], $mapped2->getItems());
+
+		$this->assertSame(
+			['first' => 1, 'second' => 2, 'third' => 3], $collection->getItems()
+		);
 	}
 
 	/**

--- a/tests/unit/utility/CollectionTest.php
+++ b/tests/unit/utility/CollectionTest.php
@@ -484,39 +484,4 @@ class CollectionTest extends PHPUnit_Framework_TestCase
 		$this->assertSame([1, 2, 3], $collection->getValues());
 
 	}
-
-	/**
-	 *
-	 */
-	public function testReject()
-	{
-		$collection = new Collection([1, 2, 3]);
-
-		$result = $collection->reject(function($value) 
-		{
-		    return $value > 2;
-		});
-
-		$this->assertSame([1, 2], $result->getItems());
-		$this->assertSame([1, 2, 3], $collection->getItems());
-
-		// Also works with key
-		$collection = new Collection(['foo' => 1, 'bar' => 2, 3 => 3]);
-		
-		$result = $collection->reject(function($value, $key) 
-		{
-		    return is_int($key);
-		});
-
-		$this->assertSame(['foo' => 1, 'bar' => 2], $result->getItems());
-		$this->assertSame(['foo' => 1, 'bar' => 2, 3 => 3], $collection->getItems());
-
-		// Also works with single value
-		$collection = new Collection([1, 2, 3]);
-
-		$result = $collection->reject(3);
-
-		$this->assertSame([1, 2], $result->getItems());
-		$this->assertSame([1, 2, 3], $collection->getItems());
-	}
 }

--- a/tests/unit/utility/CollectionTest.php
+++ b/tests/unit/utility/CollectionTest.php
@@ -484,4 +484,39 @@ class CollectionTest extends PHPUnit_Framework_TestCase
 		$this->assertSame([1, 2, 3], $collection->getValues());
 
 	}
+
+	/**
+	 *
+	 */
+	public function testReject()
+	{
+		$collection = new Collection([1, 2, 3]);
+
+		$result = $collection->reject(function($value) 
+		{
+		    return $value > 2;
+		});
+
+		$this->assertSame([1, 2], $result->getItems());
+		$this->assertSame([1, 2, 3], $collection->getItems());
+
+		// Also works with key
+		$collection = new Collection(['foo' => 1, 'bar' => 2, 3 => 3]);
+		
+		$result = $collection->reject(function($value, $key) 
+		{
+		    return is_int($key);
+		});
+
+		$this->assertSame(['foo' => 1, 'bar' => 2], $result->getItems());
+		$this->assertSame(['foo' => 1, 'bar' => 2, 3 => 3], $collection->getItems());
+
+		// Also works with single value
+		$collection = new Collection([1, 2, 3]);
+
+		$result = $collection->reject(3);
+
+		$this->assertSame([1, 2], $result->getItems());
+		$this->assertSame([1, 2, 3], $collection->getItems());
+	}
 }


### PR DESCRIPTION
This PR makes closure that get passes into Collection::map() method can accept key as a second argument.

This PR also adds new Collection::reject() method, which is basically a reverse of Collection::filter() method, but can also works with a single value.