### PR TITLE
Ensure count() and countDistinct() return integers.

### DIFF
--- a/src/mako/database/query/Query.php
+++ b/src/mako/database/query/Query.php
@@ -1452,7 +1452,7 @@ class Query
 	 */
 	public function count($column = '*')
 	{
-		return $this->aggregate('COUNT(%s)', $column);
+		return (int) $this->aggregate('COUNT(%s)', $column);
 	}
 
 	/**
@@ -1463,7 +1463,7 @@ class Query
 	 */
 	public function countDistinct($column)
 	{
-		return $this->aggregate('COUNT(DISTINCT %s)', $column);
+		return (int) $this->aggregate('COUNT(DISTINCT %s)', $column);
 	}
 
 	/**


### PR DESCRIPTION
### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      | yes      |
| New feature? | no      |
| Other?       | no      |

##### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | no      |
| Has unit and/or integration tests?  | no      |

###  Description
---

SQLite returns a string containing the number, which in turn causes other code
to break if it does an exact comparison. For instance, the implementation of
the 'unique' rule expects count() to return an integer.
