### PR TITLE
Implement an opt-out for atomic get/set in APCU.

### DIFF
--- a/src/mako/cache/CacheManager.php
+++ b/src/mako/cache/CacheManager.php
@@ -68,7 +68,8 @@ class CacheManager extends AdapterManager
 	 */
 	protected function apcuFactory(array $configuration): APCU
 	{
-		return (new APCU)->setPrefix($configuration['prefix'] ?? '');
+		return (new APCU)->useAtomicGetSet($configuration['atomicGetSet'] ?? true)
+            ->setPrefix($configuration['prefix'] ?? '');
 	}
 
 	/**


### PR DESCRIPTION
<!--
Please use the provided template when creating pull requests 🙂
-->

### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      | Yes, see #244       |
| New feature? | Yes      |
| Other?       | -      |

##### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | No      |
| Has unit and/or integration tests?  | No |

###  Description
---

This patch introduces a configuration option `atomicGetSet` for the APCU cache store, which defaults to true. If false, the store will fall back on `Store::getOrElse` rather than using `apcu_entry`. The default behaviour is the current behaviour.