### PR TITLE
Cast all aggregate functions to correct type.

### DIFF
--- a/src/mako/database/query/Query.php
+++ b/src/mako/database/query/Query.php
@@ -1406,7 +1406,7 @@ class Query
 	 */
 	public function min($column)
 	{
-		return $this->aggregate('MIN(%s)', $column);
+		return (int) $this->aggregate('MIN(%s)', $column);
 	}
 
 	/**
@@ -1417,7 +1417,7 @@ class Query
 	 */
 	public function max($column)
 	{
-		return $this->aggregate('MAX(%s)', $column);
+		return (int) $this->aggregate('MAX(%s)', $column);
 	}
 
 	/**
@@ -1428,7 +1428,7 @@ class Query
 	 */
 	public function sum($column)
 	{
-		return $this->aggregate('SUM(%s)', $column);
+		return (int) $this->aggregate('SUM(%s)', $column);
 	}
 
 	/**
@@ -1439,7 +1439,7 @@ class Query
 	 */
 	public function avg($column)
 	{
-		return $this->aggregate('AVG(%s)', $column);
+		return (float) $this->aggregate('AVG(%s)', $column);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Please use the provided template when creating pull requests 🙂
-->

### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      | Yes      |
| New feature? | No      |
| Other?       | No      |

##### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | No      |
| Has unit and/or integration tests?  | No      |

###  Description
---
The return values of aggregate functions are originally returned as strings. For databases as SQLite this can compile into SQL like `SELECT 2>'1';`, which returns `false`. Correct typing results into `SELECT 2>1;`, giving true.

Fixes #248 
...
