### PR TITLE
Option to hide session cookie from stack trace.

### DIFF
--- a/src/mako/error/handlers/web/DevelopmentHandler.php
+++ b/src/mako/error/handlers/web/DevelopmentHandler.php
@@ -100,6 +100,11 @@ class DevelopmentHandler implements HandlerInterface
 
 		$handler->handleUnconditionally(true);
 
+		$config = $this->app->getConfig();
+		if ($config->get('application.error_handler.hide_session_cookie')) {
+			$handler->blacklist('_COOKIE', $config->get('session.session_name'));
+		}
+
 		$handler->setApplicationPaths([$this->app->getPath()]);
 
 		$handler->setPageTitle('Error');


### PR DESCRIPTION
### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      | No      |
| New feature? | Yes      |
| Other?       | No      |

##### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | No      |
| Has unit and/or integration tests?  | No      |

###  Description
We run Mako for a small team of trusted users. When they encounter an error, they are often helpful enough to share a screenshot of the stack trace. By default, this screenshot contains a list of cookies, including the session cookie. Hence, sharing the screenshot entails a security breach, as our developers do not (and should not) have access to the production database. This PR uses the blacklist feature of Whoops to hide that cookie.
