### PR TITLE
Truly remove the 'exists' property from ORM.

### DIFF
--- a/src/mako/database/midgard/ORM.php
+++ b/src/mako/database/midgard/ORM.php
@@ -1036,7 +1036,7 @@ abstract class ORM implements JsonSerializable
 
 			if($deleted)
 			{
-				$this->isPersisted = $this->exists = false;
+				$this->isPersisted = false;
 				$this->original    = [];
 				$this->related     = [];
 			}


### PR DESCRIPTION
<!--
Please use the provided template when creating pull requests 🙂
-->

### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      | Yes      |
| New feature? | No      |
| Other?       | No      |

##### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | No      |
| Has unit and/or integration tests?  | No      |

###  Description
---
The property `exists` had been removed from the ORM, except in one location. This caused a bug where a record that was removed would suddenly have a new column named `exists` with value `FALSE`. The present PR removes the last occurrence.
...
