### PR TITLE
Added shorthand options to commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added `Container::hasInstanceOf()` method.
 * It is now possible to send additional arguments to authorization policy methods.
 * Added bitonal filter to the image library ([#258](https://github.com/mako-framework/framework/pull/258)).
+* Added shorthand options to commands, for example `-p` for `--port`.
 
 > Check out the upgrade guide for details on how to upgrade from `6.0.*.`
 

--- a/src/mako/application/cli/commands/cache/Clear.php
+++ b/src/mako/application/cli/commands/cache/Clear.php
@@ -36,6 +36,7 @@ class Clear extends Command
 			'configuration' =>
 			[
 				'optional'    => true,
+				'shorthand'   => 'c',
 				'description' => 'Configuration name',
 			],
 		],

--- a/src/mako/application/cli/commands/cache/Remove.php
+++ b/src/mako/application/cli/commands/cache/Remove.php
@@ -36,11 +36,13 @@ class Remove extends Command
 			'key' =>
 			[
 				'optional'    => false,
+				'shorthand'   => 'k',
 				'description' => 'Cache key',
 			],
 			'configuration' =>
 			[
 				'optional'    => true,
+				'shorthand'   => 'c',
 				'description' => 'Configuration name',
 			],
 		],

--- a/src/mako/application/cli/commands/migrations/Create.php
+++ b/src/mako/application/cli/commands/migrations/Create.php
@@ -36,11 +36,13 @@ class Create extends Command
 			'package' =>
 			[
 				'optional'    => true,
+				'shorthand'   => 'p',
 				'description' => 'Package name',
 			],
 			'description' =>
 			[
 				'optional'    => true,
+				'shorthand'   => 'd',
 				'description' => 'Migration description',
 			],
 		],

--- a/src/mako/application/cli/commands/migrations/Down.php
+++ b/src/mako/application/cli/commands/migrations/Down.php
@@ -31,11 +31,13 @@ class Down extends Command
 			'batches' =>
 			[
 				'optional'    => true,
+				'shorthand'   => 'b',
 				'description' => 'Number of batches to roll back',
 			],
 			'database' =>
 			[
 				'optional'    => true,
+				'shorthand'   => 'd',
 				'description' => 'Sets which database connection to use',
 			],
 		],

--- a/src/mako/application/cli/commands/migrations/Reset.php
+++ b/src/mako/application/cli/commands/migrations/Reset.php
@@ -31,11 +31,13 @@ class Reset extends Command
 			'force' =>
 			[
 				'optional'    => true,
+				'shorthand'   => 'f',
 				'description' => 'Force the schema reset?',
 			],
 			'database' =>
 			[
 				'optional'    => true,
+				'shorthand'   => 'd',
 				'description' => 'Sets which database connection to use',
 			],
 		],

--- a/src/mako/application/cli/commands/migrations/Status.php
+++ b/src/mako/application/cli/commands/migrations/Status.php
@@ -30,11 +30,13 @@ class Status extends Command
 			'database' =>
 			[
 				'optional'    => true,
+				'shorthand'   => 'd',
 				'description' => 'Sets which database connection to use',
 			],
 			'exit-code' =>
 			[
 				'optional'    => true,
+				'shorthand'   => 'e',
 				'description' => 'Exits with 1 if there are outstanding migrations and 0 if there are none',
 			],
 		],

--- a/src/mako/application/cli/commands/migrations/Up.php
+++ b/src/mako/application/cli/commands/migrations/Up.php
@@ -27,6 +27,7 @@ class Up extends Command
 			'database' =>
 			[
 				'optional'    => true,
+				'shorthand'   => 'd',
 				'description' => 'Sets which database connection to use',
 			],
 		],

--- a/src/mako/application/cli/commands/server/Server.php
+++ b/src/mako/application/cli/commands/server/Server.php
@@ -47,16 +47,19 @@ class Server extends Command
 			'port' =>
 			[
 				'optional'    => true,
+				'shorthand'   => 'p',
 				'description' => 'Port to run the server on',
 			],
 			'address' =>
 			[
 				'optional'    => true,
+				'shorthand'   => 'a',
 				'description' => 'Address to run the server on',
 			],
 			'docroot' =>
 			[
 				'optional'    => true,
+				'shorthand'   => 'd',
 				'description' => 'Path to the document root',
 			],
 		],

--- a/src/mako/cli/input/Input.php
+++ b/src/mako/cli/input/Input.php
@@ -29,6 +29,13 @@ class Input
 	const NAMED_ARGUMENT_REGEX = '/--([a-z0-9-_]+)(=(.*))?/iu';
 
 	/**
+	 * Regex that matches shorthand arguments.
+	 *
+	 * @var string
+	 */
+	const SHORTHAND_ARGUMENT_REGEX = '/-[a-z](=(.*))?/iu';
+
+	/**
 	 * Reader.
 	 *
 	 * @var \mako\cli\input\reader\ReaderInterface
@@ -72,6 +79,12 @@ class Input
 			if(preg_match(static::NAMED_ARGUMENT_REGEX, $argument) === 1)
 			{
 				[$name, $value] = explode('=', substr($argument, 2), 2) + [null, null];
+
+				$parsed[$name] = $value === null ? true : $value;
+			}
+			elseif(preg_match(static::SHORTHAND_ARGUMENT_REGEX, $argument) === 1)
+			{
+				[$name, $value] = explode('=', substr($argument, 1), 2) + [null, null];
 
 				$parsed[$name] = $value === null ? true : $value;
 			}

--- a/src/mako/reactor/Reactor.php
+++ b/src/mako/reactor/Reactor.php
@@ -299,18 +299,36 @@ class Reactor
 	}
 
 	/**
-	 * Converst the argument and options arrays to table rows.
+	 * Converts the argument and options arrays to table rows.
 	 *
-	 * @param  array $input Argument or option array
+	 * @param  array $input Argument array
 	 * @return array
 	 */
-	protected function convertArgumentsAndOptionsArrayToRows(array $input): array
+	protected function convertArgumentsToRows(array $input): array
 	{
 		$rows = [];
 
 		foreach($input as $name => $info)
 		{
 			$rows[] = [$name, $info['description'], var_export($info['optional'], true)];
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Converts the argument and options arrays to table rows.
+	 *
+	 * @param  array $input Option array
+	 * @return array
+	 */
+	protected function convertOptionsToRows(array $input): array
+	{
+		$rows = [];
+
+		foreach($input as $name => $info)
+		{
+			$rows[] = [$name, (isset($info['shorthand']) ? '-' . $info['shorthand'] : ''), $info['description'], var_export($info['optional'], true)];
 		}
 
 		return $rows;
@@ -342,12 +360,12 @@ class Reactor
 
 		if(!empty($arguments = $commandInstance->getCommandArguments()))
 		{
-			$this->drawTable('Arguments:', ['Name', 'Description', 'Optional'], $this->convertArgumentsAndOptionsArrayToRows($arguments));
+			$this->drawTable('Arguments:', ['Name', 'Description', 'Optional'], $this->convertArgumentsToRows($arguments));
 		}
 
 		if(!empty($options = $commandInstance->getCommandOptions()))
 		{
-			$this->drawTable('Options:', ['Name', 'Description', 'Optional'], $this->convertArgumentsAndOptionsArrayToRows($options));
+			$this->drawTable('Options:', ['Name', 'Shorthand', 'Description', 'Optional'], $this->convertOptionsToRows($options));
 		}
 
 		return CommandInterface::STATUS_SUCCESS;

--- a/tests/unit/reactor/CommandTest.php
+++ b/tests/unit/reactor/CommandTest.php
@@ -25,6 +25,7 @@ class Foo extends Command
 			'option' =>
 			[
 				'optional'    => true,
+				'shorthand'   => 'o',
 				'description' => 'Option description.',
 			],
 		],
@@ -150,7 +151,7 @@ class CommandTest extends TestCase
 
 		$foo = new Foo($input, $output);
 
-		$this->assertEquals(['option' => ['optional' => true, 'description' => 'Option description.']], $foo->getCommandOptions());
+		$this->assertEquals(['option' => ['optional' => true, 'shorthand' => 'o', 'description' => 'Option description.']], $foo->getCommandOptions());
 
 		//
 

--- a/tests/unit/reactor/DispatcherTest.php
+++ b/tests/unit/reactor/DispatcherTest.php
@@ -33,7 +33,7 @@ class DispatcherTest extends TestCase
 
 		$command->shouldReceive('getCommandArguments')->once()->andReturn([]);
 
-		$command->shouldReceive('getCommandOptions')->once()->andReturn([]);
+		$command->shouldReceive('getCommandOptions')->twice()->andReturn([]);
 
 		$container->shouldReceive('get')->once()->with('foo\bar\Command')->andReturn($command);
 
@@ -59,7 +59,7 @@ class DispatcherTest extends TestCase
 
 		$command->shouldReceive('getCommandArguments')->once()->andReturn([]);
 
-		$command->shouldReceive('getCommandOptions')->once()->andReturn([]);
+		$command->shouldReceive('getCommandOptions')->twice()->andReturn([]);
 
 		$container->shouldReceive('get')->once()->with('foo\bar\Command')->andReturn($command);
 
@@ -68,6 +68,58 @@ class DispatcherTest extends TestCase
 		$dispatcher = new Dispatcher($container);
 
 		$exitCode = $dispatcher->dispatch('foo\bar\Command', ['foo_snake' => 1, 'bar_snake' => 2], []);
+
+		$this->assertSame(0, $exitCode);
+	}
+
+	/**
+	 *
+	 */
+	public function testDispatchWithShorthandArguments(): void
+	{
+		$container = Mockery::mock('mako\syringe\Container');
+
+		$command = Mockery::mock('mako\reactor\CommandInterface');
+
+		$command->shouldReceive('isStrict')->once()->andReturn(false);
+
+		$command->shouldReceive('getCommandArguments')->once()->andReturn([]);
+
+		$command->shouldReceive('getCommandOptions')->twice()->andReturn(['fooSnake' => ['shorthand' => 'f']]);
+
+		$container->shouldReceive('get')->once()->with('foo\bar\Command')->andReturn($command);
+
+		$container->shouldReceive('call')->once()->with([$command, 'execute'], ['fooSnake' => 1, 'barSnake' => 2]);
+
+		$dispatcher = new Dispatcher($container);
+
+		$exitCode = $dispatcher->dispatch('foo\bar\Command', ['f' => 1, 'bar_snake' => 2], []);
+
+		$this->assertSame(0, $exitCode);
+	}
+
+	/**
+	 *
+	 */
+	public function testDispatchWithMixedShorthandArguments(): void
+	{
+		$container = Mockery::mock('mako\syringe\Container');
+
+		$command = Mockery::mock('mako\reactor\CommandInterface');
+
+		$command->shouldReceive('isStrict')->once()->andReturn(false);
+
+		$command->shouldReceive('getCommandArguments')->once()->andReturn([]);
+
+		$command->shouldReceive('getCommandOptions')->twice()->andReturn(['fooSnake' => ['shorthand' => 'f'], 'barSnake' => ['shorthand' => 'b']]);
+
+		$container->shouldReceive('get')->once()->with('foo\bar\Command')->andReturn($command);
+
+		$container->shouldReceive('call')->once()->with([$command, 'execute'], ['fooSnake' => 1, 'barSnake' => 2]);
+
+		$dispatcher = new Dispatcher($container);
+
+		$exitCode = $dispatcher->dispatch('foo\bar\Command', ['f' => 1, 'b' => 2], []);
 
 		$this->assertSame(0, $exitCode);
 	}
@@ -85,7 +137,7 @@ class DispatcherTest extends TestCase
 
 		$command->shouldReceive('getCommandArguments')->once()->andReturn([]);
 
-		$command->shouldReceive('getCommandOptions')->once()->andReturn([]);
+		$command->shouldReceive('getCommandOptions')->twice()->andReturn([]);
 
 		$container->shouldReceive('get')->once()->with('foo\bar\Command')->andReturn($command);
 
@@ -111,7 +163,7 @@ class DispatcherTest extends TestCase
 
 		$command->shouldReceive('getCommandArguments')->once()->andReturn([]);
 
-		$command->shouldReceive('getCommandOptions')->once()->andReturn([]);
+		$command->shouldReceive('getCommandOptions')->twice()->andReturn([]);
 
 		$container->shouldReceive('get')->once()->with('foo\bar\Command')->andReturn($command);
 
@@ -141,7 +193,7 @@ class DispatcherTest extends TestCase
 
 		$command->shouldReceive('getCommandArguments')->once()->andReturn(['arg2' => []]);
 
-		$command->shouldReceive('getCommandOptions')->once()->andReturn([]);
+		$command->shouldReceive('getCommandOptions')->twice()->andReturn([]);
 
 		$container->shouldReceive('get')->once()->with('foo\bar\Command')->andReturn($command);
 
@@ -167,7 +219,7 @@ class DispatcherTest extends TestCase
 
 		$command->shouldReceive('getCommandArguments')->once()->andReturn([]);
 
-		$command->shouldReceive('getCommandOptions')->once()->andReturn(['foo' => []]);
+		$command->shouldReceive('getCommandOptions')->twice()->andReturn(['foo' => []]);
 
 		$container->shouldReceive('get')->once()->with('foo\bar\Command')->andReturn($command);
 
@@ -176,6 +228,41 @@ class DispatcherTest extends TestCase
 		try
 		{
 			$dispatcher->dispatch('foo\bar\Command', ['bar' => null], []);
+		}
+		catch(InvalidOptionException $e)
+		{
+			$this->assertNull($e->getSuggestion());
+
+			throw $e;
+		}
+	}
+
+	/**
+	 *
+	 */
+	public function testDispatchWithInvalidShorthandOptions(): void
+	{
+		$this->expectException(InvalidOptionException::class);
+
+		$this->expectExceptionMessage('Invalid shorthand option [ b ].');
+
+		$container = Mockery::mock('mako\syringe\Container');
+
+		$command = Mockery::mock('mako\reactor\CommandInterface');
+
+		$command->shouldReceive('isStrict')->once()->andReturn(true);
+
+		$command->shouldReceive('getCommandArguments')->once()->andReturn([]);
+
+		$command->shouldReceive('getCommandOptions')->twice()->andReturn(['foo' => []]);
+
+		$container->shouldReceive('get')->once()->with('foo\bar\Command')->andReturn($command);
+
+		$dispatcher = new Dispatcher($container);
+
+		try
+		{
+			$dispatcher->dispatch('foo\bar\Command', ['b' => null], []);
 		}
 		catch(InvalidOptionException $e)
 		{
@@ -202,7 +289,7 @@ class DispatcherTest extends TestCase
 
 		$command->shouldReceive('getCommandArguments')->once()->andReturn([]);
 
-		$command->shouldReceive('getCommandOptions')->once()->andReturn(['foo' => []]);
+		$command->shouldReceive('getCommandOptions')->twice()->andReturn(['foo' => []]);
 
 		$container->shouldReceive('get')->once()->with('foo\bar\Command')->andReturn($command);
 

--- a/tests/unit/reactor/ReactorTest.php
+++ b/tests/unit/reactor/ReactorTest.php
@@ -563,11 +563,11 @@ EOF;
 		$output->shouldReceive('writeLn')->once()->with('<yellow>Options:</yellow>');
 
 		$optionsTable = <<<EOF
-------------------------------------------------------------------------------
-| <green>Name</green> | <green>Description</green> | <green>Optional</green> |
-------------------------------------------------------------------------------
-| option              | Option description.        | true                    |
-------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------------
+| <green>Name</green> | <green>Shorthand</green> | <green>Description</green> | <green>Optional</green> |
+---------------------------------------------------------------------------------------------------------
+| option              | -o                       | Option description.        | true                    |
+---------------------------------------------------------------------------------------------------------
 
 EOF;
 
@@ -581,7 +581,7 @@ EOF;
 
 		$command->shouldReceive('getCommandArguments')->once()->andReturn(['arg2' => ['optional' => true, 'description' => 'Argument description.']]);
 
-		$command->shouldReceive('getCommandOptions')->once()->andReturn(['option' => ['optional' => true, 'description' => 'Option description.']]);
+		$command->shouldReceive('getCommandOptions')->once()->andReturn(['option' => ['shorthand' => 'o', 'optional' => true, 'description' => 'Option description.']]);
 
 		//
 


### PR DESCRIPTION
### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      | No      |
| New feature? | Yes      |
| Other?       | No      |

##### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | No      |
| Has unit and/or integration tests?  | Yes      |

###  Description
---
Inspired by Pythons [argparse](https://docs.python.org/3/library/argparse.html) and similar cli programs with support for 'shorthand' arguments (using `-p` instead of `--port` as a cli argument, for example), I've implemented a similar feature for Mako.

The helptext also shows the shorthand:

```
Options:

-----------------------------------------------------------------
| Name    | Shorthand | Description                  | Optional |
-----------------------------------------------------------------
| port    | -p        | Port to run the server on    | true     |
| address | -a        | Address to run the server on | true     |
| docroot | -d        | Path to the document root    | true     |
-----------------------------------------------------------------
```

But of course, more importantly, I'd like to discuss this with you all:
1. Is this a feature that we/you want included? It's definitely not very necessary, but handy for commands with many many arguments/options.
2. Should it be implemented differently? It's a POC right now, some refactoring might need to take place.



