### PR TITLE
isSecure checks the X-Forwarded-Proto and X-Forwarded-Port headers

### DIFF
--- a/src/mako/http/Request.php
+++ b/src/mako/http/Request.php
@@ -586,8 +586,7 @@ class Request
 	public function isSecure(): bool
 	{
 		return filter_var($this->server->get('HTTPS', false), FILTER_VALIDATE_BOOLEAN)
-			|| $this->server->get('HTTP_X_FORWARDED_PROTO') === 'https'
-			|| $this->server->get('HTTP_X_FORWARDED_PORT') === '443';
+			|| $this->server->get('HTTP_X_FORWARDED_PROTO') === 'https';
 	}
 
 	/**

--- a/src/mako/http/Request.php
+++ b/src/mako/http/Request.php
@@ -585,7 +585,9 @@ class Request
 	 */
 	public function isSecure(): bool
 	{
-		return filter_var($this->server->get('HTTPS', false), FILTER_VALIDATE_BOOLEAN);
+		return filter_var($this->server->get('HTTPS', false), FILTER_VALIDATE_BOOLEAN)
+			|| $this->server->get('HTTP_X_FORWARDED_PROTO') === 'https'
+			|| $this->server->get('HTTP_X_FORWARDED_PORT') === '443';
 	}
 
 	/**

--- a/tests/unit/http/RequestTest.php
+++ b/tests/unit/http/RequestTest.php
@@ -260,6 +260,25 @@ class RequestTest extends TestCase
 		$request = new Request(['server' => $server]);
 
 		$this->assertTrue($request->isSecure());
+
+		//
+
+		$server['HTTPS'] = 'false';
+		$server['HTTP_X_FORWARDED_PROTO'] = 'https';
+
+		$request = new Request(['server' => $server]);
+
+		$this->assertTrue($request->isSecure());
+
+		//
+
+		$server['HTTPS'] = 'false';
+		$server['HTTP_X_FORWARDED_PROTO'] = null;
+		$server['HTTP_X_FORWARDED_PORT'] = '443';
+
+		$request = new Request(['server' => $server]);
+
+		$this->assertTrue($request->isSecure());
 	}
 
 	/**
@@ -352,6 +371,29 @@ class RequestTest extends TestCase
 		$request = new Request(['server' => $server]);
 
 		$this->assertEquals('http://example.local/foo/bar', $request->getBaseURL());
+
+		//
+
+		$server = $this->getServerData();
+
+		$server['HTTPS'] = 'off';
+		$server['HTTP_X_FORWARDED_PROTO'] = 'https';
+
+		$request = new Request(['server' => $server]);
+
+		$this->assertEquals('https://example.local', $request->getBaseURL());
+
+		//
+
+		$server = $this->getServerData();
+
+		$server['HTTPS'] = 'off';
+		$server['HTTP_X_FORWARDED_PROTO'] = null;
+		$server['HTTP_X_FORWARDED_PORT'] = '443';
+
+		$request = new Request(['server' => $server]);
+
+		$this->assertEquals('https://example.local', $request->getBaseURL());
 	}
 
 	/**

--- a/tests/unit/http/RequestTest.php
+++ b/tests/unit/http/RequestTest.php
@@ -269,16 +269,6 @@ class RequestTest extends TestCase
 		$request = new Request(['server' => $server]);
 
 		$this->assertTrue($request->isSecure());
-
-		//
-
-		$server['HTTPS'] = 'false';
-		$server['HTTP_X_FORWARDED_PROTO'] = null;
-		$server['HTTP_X_FORWARDED_PORT'] = '443';
-
-		$request = new Request(['server' => $server]);
-
-		$this->assertTrue($request->isSecure());
 	}
 
 	/**
@@ -378,18 +368,6 @@ class RequestTest extends TestCase
 
 		$server['HTTPS'] = 'off';
 		$server['HTTP_X_FORWARDED_PROTO'] = 'https';
-
-		$request = new Request(['server' => $server]);
-
-		$this->assertEquals('https://example.local', $request->getBaseURL());
-
-		//
-
-		$server = $this->getServerData();
-
-		$server['HTTPS'] = 'off';
-		$server['HTTP_X_FORWARDED_PROTO'] = null;
-		$server['HTTP_X_FORWARDED_PORT'] = '443';
 
 		$request = new Request(['server' => $server]);
 


### PR DESCRIPTION
<!--
Please use the provided template when creating pull requests 🙂
-->

### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      | -      |
| New feature? | -      |
| Other?       | yes      |

##### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | -      |
| Has unit and/or integration tests?  | yes      |

###  Description
---
If the site is being run behind a proxy or loadbalancer that handles the TLS connection instead of the webserver, `isSecure` will no return as `true`
...
