### PR TITLE
Escape shell arguments for server and hiddeninput.exe

### DIFF
--- a/src/mako/application/cli/commands/server/Server.php
+++ b/src/mako/application/cli/commands/server/Server.php
@@ -114,6 +114,11 @@ class Server extends Command
 
 		// Start the server
 
-		passthru(PHP_BINDIR . "/php -S {$address}:{$availablePort} -t {$docroot} " . __DIR__ . '/router.php');
+		passthru(
+                    escapeshellcmd(PHP_BINDIR . '/php') .
+                    " -S " . escapeshellarg("{$address}:{$availablePort}") .
+                    " -t " . escapeshellarg($docroot) .
+                    ' ' . escapeshellarg(__DIR__ . "/router.php")
+                );
 	}
 }

--- a/src/mako/application/cli/commands/server/Server.php
+++ b/src/mako/application/cli/commands/server/Server.php
@@ -115,10 +115,10 @@ class Server extends Command
 		// Start the server
 
 		passthru(
-                    escapeshellcmd(PHP_BINDIR . '/php') .
-                    " -S " . escapeshellarg("{$address}:{$availablePort}") .
-                    " -t " . escapeshellarg($docroot) .
-                    ' ' . escapeshellarg(__DIR__ . "/router.php")
-                );
+			escapeshellcmd(PHP_BINDIR . '/php') .
+			" -S " . escapeshellarg("{$address}:{$availablePort}") .
+			" -t " . escapeshellarg($docroot) .
+			' ' . escapeshellarg(__DIR__ . "/router.php")
+		);
 	}
 }

--- a/src/mako/cli/input/helpers/Secret.php
+++ b/src/mako/cli/input/helpers/Secret.php
@@ -60,7 +60,11 @@ class Secret extends Question
 
 			if(DIRECTORY_SEPARATOR === '\\')
 			{
-				$answer = trim(shell_exec(__DIR__ . '/resources/hiddeninput.exe'));
+				$answer = trim(
+					shell_exec(
+						escapeshellcmd(__DIR__ . '/resources/hiddeninput.exe')
+					)
+				);
 			}
 			else
 			{


### PR DESCRIPTION
fixes #281

### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      | Yes      |
| New feature? | No      |
| Other?       | No      |

##### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | No      |
| Has unit and/or integration tests?  | No      |

###  Description
---
Fixes issue #281, uses php's `escapeshellcmd()` and `escapeshellarg()` on commands/args that I think needed them.