### PR TITLE
Register route middleware using attributes

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
           php-version:
-            - "7.4"
+            - "8.0"
     steps:
       - name: "Checkout code"
         uses: "actions/checkout@v3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added `CamelCasedTrait` ORM trait that enables camel cased interaction with ORM objects.
 * The `protect` and `expose` methods of the ORM `ResultSet` class are now chainable.
 * Eager loaded relations can now be aliased.
+* Route middleware can now be registered using the `Middleware` attribute on controller methods (PHP 8.0+).
 
 #### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Added `CamelCasedTrait` ORM trait that enables camel cased interaction with ORM objects.
 * The `protect` and `expose` methods of the ORM `ResultSet` class are now chainable.
 * Eager loaded relations can now be aliased.
-* Route middleware can now be registered using the `Middleware` attribute on controller methods (PHP 8.0+).
+* Route middleware can now be registered using the new `Middleware` attribute (PHP 8.0+).
 
 #### Deprecations
 

--- a/src/mako/http/routing/Dispatcher.php
+++ b/src/mako/http/routing/Dispatcher.php
@@ -246,32 +246,25 @@ class Dispatcher
 	/**
 	 * Executes a closure action.
 	 *
-	 * @param  \Closure            $closure    Closure
+	 * @param  \Closure            $action     Closure
 	 * @param  array               $parameters Parameters
 	 * @return \mako\http\Response
 	 */
-	protected function executeClosure(Closure $closure, array $parameters): Response
+	protected function executeClosure(Closure $action, array $parameters): Response
 	{
-		return $this->response->setBody($this->container->call($closure, $parameters));
+		return $this->response->setBody($this->container->call($action, $parameters));
 	}
 
 	/**
 	 * Executes a controller action.
 	 *
-	 * @param  array|string        $controller Controller
+	 * @param  array|string        $action     Controller
 	 * @param  array               $parameters Parameters
 	 * @return \mako\http\Response
 	 */
-	protected function executeController($controller, array $parameters): Response
+	protected function executeController($action, array $parameters): Response
 	{
-		if(is_array($controller))
-		{
-			[$controller, $method] = $controller;
-		}
-		else
-		{
-			$method = '__invoke';
-		}
+		[$controller, $method] = is_array($action) ? $action : [$action, '__invoke'];
 
 		$controller = $this->container->get($controller);
 

--- a/src/mako/http/routing/Route.php
+++ b/src/mako/http/routing/Route.php
@@ -8,6 +8,7 @@
 namespace mako\http\routing;
 
 use Closure;
+use mako\http\routing\attributes\Middleware;
 use ReflectionMethod;
 
 use function in_array;

--- a/src/mako/http/routing/Route.php
+++ b/src/mako/http/routing/Route.php
@@ -173,7 +173,7 @@ class Route
 			/** @var \mako\http\routing\attributes\Middleware $middlewareAttribute */
 			$middlewareAttribute = $attribute->newInstance();
 
-			$middleware = [...$middleware, $middlewareAttribute->getMiddleware()];
+			$middleware = [...$middleware, ...$middlewareAttribute->getMiddleware()];
 		}
 
 		return $middleware;

--- a/src/mako/http/routing/Route.php
+++ b/src/mako/http/routing/Route.php
@@ -9,6 +9,7 @@ namespace mako\http\routing;
 
 use Closure;
 use mako\http\routing\attributes\Middleware;
+use ReflectionClass;
 use ReflectionMethod;
 
 use function in_array;
@@ -165,6 +166,14 @@ class Route
 		$middleware = [];
 
 		[$class, $method] = is_array($this->action) ? $this->action : [$this->action, '__invoke'];
+
+		foreach((new ReflectionClass($class))->getAttributes(Middleware::class) as $attribute)
+		{
+			/** @var \mako\http\routing\attributes\Middleware $middlewareAttribute */
+			$middlewareAttribute = $attribute->newInstance();
+
+			$middleware = [...$middleware, ...$middlewareAttribute->getMiddleware()];
+		}
 
 		foreach((new ReflectionMethod($class, $method))->getAttributes(Middleware::class) as $attribute)
 		{

--- a/src/mako/http/routing/Route.php
+++ b/src/mako/http/routing/Route.php
@@ -162,13 +162,11 @@ class Route
 	 */
 	protected function getActionAttributeMiddleware(): array
 	{
-		[$class, $method] = is_array($this->action) ? $this->action : [$this->action, '__invoke'];
-
 		$middleware = [];
 
-		$reflection = new ReflectionMethod($class, $method);
+		[$class, $method] = is_array($this->action) ? $this->action : [$this->action, '__invoke'];
 
-		foreach($reflection->getAttributes(Middleware::class) as $attribute)
+		foreach((new ReflectionMethod($class, $method))->getAttributes(Middleware::class) as $attribute)
 		{
 			/** @var \mako\http\routing\attributes\Middleware $middlewareAttribute */
 			$middlewareAttribute = $attribute->newInstance();

--- a/src/mako/http/routing/Route.php
+++ b/src/mako/http/routing/Route.php
@@ -191,7 +191,7 @@ class Route
 			return $this->middleware;
 		}
 
-		return [...$this->middleware, $this->getActionAttributeMiddleware()];
+		return [...$this->middleware, ...$this->getActionAttributeMiddleware()];
 	}
 
 	/**

--- a/src/mako/http/routing/attributes/Middleware.php
+++ b/src/mako/http/routing/attributes/Middleware.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace mako\http\routing\attributes;
-
-use Attribute;
-
 /**
  * @copyright Frederic G. Østby
  * @license   http://www.makoframework.com/license
  */
+
+namespace mako\http\routing\attributes;
+
+use Attribute;
 
 /**
  * Middleware attribute.

--- a/src/mako/http/routing/attributes/Middleware.php
+++ b/src/mako/http/routing/attributes/Middleware.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace mako\http\routing\attributes;
+
+use Attribute;
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+/**
+ * Middleware attribute.
+ */
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
+class Middleware
+{
+    /**
+     * Constructor.
+     *
+     * @param array|string $middleware Middleware
+     */
+    public function __construct(
+        protected array|string $middleware
+    )
+    {}
+
+    /**
+     * Returns an array of middleware.
+     *
+     * @return array
+     */
+    public function getMiddleware(): array
+    {
+        return (array) $this->middleware;
+    }
+}

--- a/src/mako/http/routing/attributes/Middleware.php
+++ b/src/mako/http/routing/attributes/Middleware.php
@@ -12,7 +12,7 @@ use Attribute;
 /**
  * Middleware attribute.
  */
-#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
 class Middleware
 {
     /**

--- a/tests/unit/http/routing/RouteTest.php
+++ b/tests/unit/http/routing/RouteTest.php
@@ -7,8 +7,36 @@
 
 namespace mako\tests\unit\http\routing;
 
+use mako\http\routing\attributes\Middleware;
 use mako\http\routing\Route;
 use mako\tests\TestCase;
+
+// --------------------------------------------------------------------------
+// START CLASSES
+// --------------------------------------------------------------------------
+
+#[Middleware('foo1')]
+#[Middleware('foo2')]
+class AttributeController
+{
+	#[Middleware('foo3')]
+	#[Middleware('foo4')]
+	public function method(): void
+	{
+
+	}
+
+	#[Middleware('foo3')]
+	#[Middleware('foo4')]
+	public function __invoke(): void
+	{
+
+	}
+}
+
+// --------------------------------------------------------------------------
+// END CLASSES
+// --------------------------------------------------------------------------
 
 /**
  * @group unit
@@ -343,5 +371,30 @@ class RouteTest extends TestCase
 		$this->assertTrue($route->getParameter('nope', true));
 
 		$this->assertSame($parameters, $route->getParameters());
+	}
+
+	/**
+	 *
+	 */
+	public function testAttributeMiddleware(): void
+	{
+		if(PHP_VERSION_ID < 80000)
+		{
+			$this->markTestSkipped('This feature requires PHP 8.0+');
+		}
+
+		$route = new Route(['GET'], '/', [AttributeController::class, 'method']);
+
+		$route->middleware('foo0');
+
+		$this->assertSame(['foo0', 'foo1', 'foo2', 'foo3', 'foo4'], $route->getMiddleware());
+
+		//
+
+		$route = new Route(['GET'], '/', AttributeController::class);
+
+		$route->middleware('foo0');
+
+		$this->assertSame(['foo0', 'foo1', 'foo2', 'foo3', 'foo4'], $route->getMiddleware());
 	}
 }

--- a/tests/unit/http/routing/attributes/MiddlewareTest.php
+++ b/tests/unit/http/routing/attributes/MiddlewareTest.php
@@ -16,6 +16,17 @@ use mako\tests\TestCase;
 class MiddlewareTest extends TestCase
 {
 	/**
+	 *{@inheritDoc}
+	 */
+	public function setup(): void
+	{
+		if(PHP_VERSION_ID < 80000)
+		{
+			$this->markTestSkipped('This feature requires PHP 8.0+');
+		}
+	}
+
+	/**
 	 *
 	 */
 	public function testWithArray(): void
@@ -35,7 +46,3 @@ class MiddlewareTest extends TestCase
 		$this->assertSame(['foobar'], $middleware->getMiddleware());
 	}
 }
-
-/*
- *
- */

--- a/tests/unit/http/routing/attributes/MiddlewareTest.php
+++ b/tests/unit/http/routing/attributes/MiddlewareTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\tests\unit\http\routing\middleware;
+
+use mako\http\routing\attributes\Middleware;
+use mako\tests\TestCase;
+
+/**
+ * @group unit
+ */
+class MiddlewareTest extends TestCase
+{
+	/**
+	 *
+	 */
+	public function testWithArray(): void
+	{
+		$middleware = new Middleware(['foobar', 'barfoo']);
+
+		$this->assertSame(['foobar', 'barfoo'], $middleware->getMiddleware());
+	}
+
+	/**
+	 *
+	 */
+	public function testWithString(): void
+	{
+		$middleware = new Middleware('foobar');
+
+		$this->assertSame(['foobar'], $middleware->getMiddleware());
+	}
+}
+
+/*
+ *
+ */


### PR DESCRIPTION
<!--
Please use the provided template when creating pull requests 🙂
-->

### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      | -      |
| New feature? | Yes      |
| Other?       | -      |

##### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | No      |
| Has unit and/or integration tests?  | Yes      |

###  Description
---

This feature makes it possible to register route middleware using attributes on controller classes and methods when using PHP 8.0+.