### PR TITLE
Register route constraints using attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * The `protect` and `expose` methods of the ORM `ResultSet` class are now chainable.
 * Eager loaded relations can now be aliased.
 * Route middleware can now be registered using the new `Middleware` attribute (PHP 8.0+).
+* Route constraints can now be registered using the new `Constraint` attribute (PHP 8.0+).
 
 #### Deprecations
 

--- a/src/mako/http/routing/attributes/Constraint.php
+++ b/src/mako/http/routing/attributes/Constraint.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\http\routing\attributes;
+
+use Attribute;
+
+/**
+ * Constraint attribute.
+ */
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+class Constraint
+{
+    /**
+     * Constructor.
+     *
+     * @param array|string $constraint Constraint
+     */
+    public function __construct(
+        protected array|string $constraint
+    )
+    {}
+
+    /**
+     * Returns an array of constraints.
+     *
+     * @return array
+     */
+    public function getConstraints(): array
+    {
+        return (array) $this->constraint;
+    }
+}

--- a/tests/unit/http/routing/RouteTest.php
+++ b/tests/unit/http/routing/RouteTest.php
@@ -7,6 +7,7 @@
 
 namespace mako\tests\unit\http\routing;
 
+use mako\http\routing\attributes\Constraint;
 use mako\http\routing\attributes\Middleware;
 use mako\http\routing\Route;
 use mako\tests\TestCase;
@@ -17,10 +18,14 @@ use mako\tests\TestCase;
 
 #[Middleware('foo1')]
 #[Middleware('foo2')]
+#[Constraint('bar1')]
+#[Constraint('bar2')]
 class AttributeController
 {
 	#[Middleware('foo3')]
 	#[Middleware('foo4')]
+	#[Constraint('bar3')]
+	#[Constraint('bar4')]
 	public function method(): void
 	{
 
@@ -28,6 +33,8 @@ class AttributeController
 
 	#[Middleware('foo3')]
 	#[Middleware('foo4')]
+	#[Constraint('bar3')]
+	#[Constraint('bar4')]
 	public function __invoke(): void
 	{
 
@@ -396,5 +403,30 @@ class RouteTest extends TestCase
 		$route->middleware('foo0');
 
 		$this->assertSame(['foo0', 'foo1', 'foo2', 'foo3', 'foo4'], $route->getMiddleware());
+	}
+
+	/**
+	 *
+	 */
+	public function testAttributeConstraints(): void
+	{
+		if(PHP_VERSION_ID < 80000)
+		{
+			$this->markTestSkipped('This feature requires PHP 8.0+');
+		}
+
+		$route = new Route(['GET'], '/', [AttributeController::class, 'method']);
+
+		$route->constraint('bar0');
+
+		$this->assertSame(['bar0', 'bar1', 'bar2', 'bar3', 'bar4'], $route->getConstraints());
+
+		//
+
+		$route = new Route(['GET'], '/', AttributeController::class);
+
+		$route->constraint('bar0');
+
+		$this->assertSame(['bar0', 'bar1', 'bar2', 'bar3', 'bar4'], $route->getConstraints());
 	}
 }

--- a/tests/unit/http/routing/attributes/ConstraintTest.php
+++ b/tests/unit/http/routing/attributes/ConstraintTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\tests\unit\http\routing\middleware;
+
+use mako\http\routing\attributes\Constraint;
+use mako\tests\TestCase;
+
+/**
+ * @group unit
+ */
+class ConstraintTest extends TestCase
+{
+	/**
+	 *{@inheritDoc}
+	 */
+	public function setup(): void
+	{
+		if(PHP_VERSION_ID < 80000)
+		{
+			$this->markTestSkipped('This feature requires PHP 8.0+');
+		}
+	}
+
+	/**
+	 *
+	 */
+	public function testWithArray(): void
+	{
+		$constraint = new Constraint(['foobar', 'barfoo']);
+
+		$this->assertSame(['foobar', 'barfoo'], $constraint->getConstraints());
+	}
+
+	/**
+	 *
+	 */
+	public function testWithString(): void
+	{
+		$constraint = new Constraint('foobar');
+
+		$this->assertSame(['foobar'], $constraint->getConstraints());
+	}
+}


### PR DESCRIPTION
<!--
Please use the provided template when creating pull requests 🙂
-->

### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      | -      |
| New feature? | Yes      |
| Other?       | -      |

##### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | No      |
| Has unit and/or integration tests?  | Yes      |

###  Description
---

This feature makes it possible to register route constraints using attributes on controller classes and methods when using PHP 8.0+.
