### PR TITLE
New bus library

### DIFF
--- a/src/mako/application/services/BusService.php
+++ b/src/mako/application/services/BusService.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\application\services;
+
+use mako\bus\command\CommandBus;
+use mako\bus\command\CommandBusInterface;
+use mako\bus\event\EventBus;
+use mako\bus\event\EventBusInterface;
+use mako\bus\query\QueryBus;
+use mako\bus\query\QueryBusInterface;
+
+/**
+ * Bus service.
+ */
+abstract class BusService extends Service
+{
+	/**
+	 * Should the command bus be registered?
+	 */
+	protected bool $registerCommandBus = true;
+
+	/**
+	 * Should the event bus be registered?
+	 */
+	protected bool $registerEventBus = true;
+
+	/**
+	 * Should the query bus be registered?
+	 */
+	protected bool $registerQueryBus = true;
+
+	/**
+	 * Returns an array of command handlers.
+	 *
+	 * @return array<string, callable|string>
+	 */
+	abstract protected function getCommandHandlers(): array;
+
+	/**
+	 * Returns an array of event handlers.
+	 *
+	 * @return array<string, callable|string>
+	 */
+	abstract protected function getEventHandlers(): array;
+
+	/**
+	 * Returns an array of query handlers.
+	 *
+	 * @return array<string, callable|string>
+	 */
+	abstract protected function getQueryHandlers(): array;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register(): void
+	{
+		// Register command bus
+
+		if($this->registerCommandBus)
+		{
+			$commandHandlers = $this->getCommandHandlers();
+
+			$this->container->registerSingleton([CommandBusInterface::class, 'commandBus'], static function ($container) use ($commandHandlers)
+			{
+				$commandBus = new CommandBus($container);
+
+				foreach($commandHandlers as $command => $handler)
+				{
+					$commandBus->registerHandler($command, $handler);
+				}
+
+				return $commandBus;
+			});
+		}
+
+		// Register event bus
+
+		if($this->registerEventBus)
+		{
+			$eventHandlers = $this->getEventHandlers();
+
+			$this->container->registerSingleton([EventBusInterface::class, 'eventBus'], static function ($container) use ($eventHandlers)
+			{
+				$eventBus = new EventBus($container);
+
+				foreach($eventHandlers as $event => $handler)
+				{
+					$eventBus->registerHandler($event, $handler);
+				}
+
+				return $eventBus;
+			});
+		}
+
+		// Register query bus
+
+		if($this->registerQueryBus)
+		{
+			$queryHandlers = $this->getQueryHandlers();
+
+			$this->container->registerSingleton([QueryBusInterface::class, 'queryBus'], static function ($container) use ($queryHandlers)
+			{
+				$queryBus = new QueryBus($container);
+
+				foreach($queryHandlers as $query => $handler)
+				{
+					$queryBus->registerHandler($query, $handler);
+				}
+
+				return $queryBus;
+			});
+		}
+	}
+}

--- a/src/mako/application/services/BusService.php
+++ b/src/mako/application/services/BusService.php
@@ -39,21 +39,30 @@ abstract class BusService extends Service
 	 *
 	 * @return array<string, callable|string>
 	 */
-	abstract protected function getCommandHandlers(): array;
+	protected function getCommandHandlers(): array
+	{
+		return [];
+	}
 
 	/**
 	 * Returns an array of event handlers.
 	 *
 	 * @return array<string, callable|string>
 	 */
-	abstract protected function getEventHandlers(): array;
+	protected function getEventHandlers(): array
+	{
+		return [];
+	}
 
 	/**
 	 * Returns an array of query handlers.
 	 *
 	 * @return array<string, callable|string>
 	 */
-	abstract protected function getQueryHandlers(): array;
+	protected function getQueryHandlers(): array
+	{
+		return [];
+	}
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/application/services/CommandBusService.php
+++ b/src/mako/application/services/CommandBusService.php
@@ -12,6 +12,8 @@ use mako\commander\CommandBusInterface;
 
 /**
  * Command bus service.
+ *
+ * @deprecated
  */
 class CommandBusService extends Service
 {

--- a/src/mako/application/services/EventService.php
+++ b/src/mako/application/services/EventService.php
@@ -11,6 +11,8 @@ use mako\event\Event;
 
 /**
  * Event service.
+ *
+ * @deprecated
  */
 class EventService extends Service
 {

--- a/src/mako/bus/HandlerInterface.php
+++ b/src/mako/bus/HandlerInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\bus;
+
+/**
+ * Handler interface.
+ */
+interface HandlerInterface
+{
+	/**
+	 * Registers an object handler.
+	 */
+	public function registerHandler(string $class, callable|string $handler): void;
+
+	/**
+	 * Handles an object instance.
+	 */
+	public function handle(object $object);
+}

--- a/src/mako/bus/command/CommandBus.php
+++ b/src/mako/bus/command/CommandBus.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\bus\command;
+
+use mako\bus\command\exceptions\CommandBusException;
+use mako\bus\traits\SingleHandlerTrait;
+use mako\syringe\Container;
+
+/**
+ * Command bus.
+ */
+class CommandBus implements CommandBusInterface
+{
+	use SingleHandlerTrait;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct(
+		protected Container $container
+	)
+	{}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function getUnableToResolveException(object $object): CommandBusException
+	{
+		return new CommandBusException(vsprintf('No handler has been registered for [ %s ] commands.', [$object::class]));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function handle(object $command): void
+	{
+		$this->getHandler($command)($command);
+	}
+}

--- a/src/mako/bus/command/CommandBusInterface.php
+++ b/src/mako/bus/command/CommandBusInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\bus\command;
+
+use mako\bus\HandlerInterface;
+
+/**
+ * Command bus interface.
+ */
+interface CommandBusInterface extends HandlerInterface
+{
+	/**
+	 * Registers a command handler.
+	 */
+	public function registerHandler(string $commandClass, callable|string $handler): void;
+
+	/**
+	 * Handles a command.
+	 */
+	public function handle(object $command): void;
+}

--- a/src/mako/bus/command/exceptions/CommandBusException.php
+++ b/src/mako/bus/command/exceptions/CommandBusException.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\bus\command\exceptions;
+
+use mako\bus\exceptions\BusException;
+
+/**
+ * Command bus exception.
+ */
+class CommandBusException extends BusException
+{
+
+}

--- a/src/mako/bus/event/EventBus.php
+++ b/src/mako/bus/event/EventBus.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\bus\event;
+
+use Generator;
+use mako\bus\traits\ResolveHandlerTrait;
+use mako\syringe\Container;
+
+/**
+ * Event bus.
+ */
+class EventBus implements EventBusInterface
+{
+	use ResolveHandlerTrait;
+
+	/**
+	 * Event handlers.
+	 */
+	protected array $handlers = [];
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct(
+		protected Container $container
+	)
+	{}
+
+    /**
+     * {@inheritDoc}
+     */
+    public function registerHandler(string $eventClass, callable|string $handler): void
+	{
+		$this->handlers[$eventClass][] = $handler;
+	}
+
+	/**
+	 * Yields the handlers for an event.
+	 */
+	protected function getHandlers(object $event): Generator
+	{
+		if(isset($this->handlers[$event::class]))
+		{
+			foreach($this->handlers[$event::class] as $handler)
+			{
+				yield $this->resolveHandler($handler);
+			}
+		}
+	}
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(object $event): void
+	{
+		/** @var callable $handler */
+		foreach($this->getHandlers($event) as $handler)
+		{
+			$handler($event);
+		}
+	}
+}

--- a/src/mako/bus/event/EventBusInterface.php
+++ b/src/mako/bus/event/EventBusInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\bus\event;
+
+use mako\bus\HandlerInterface;
+
+/**
+ * Event bus interface.
+ */
+interface EventBusInterface extends HandlerInterface
+{
+	/**
+	 * Registers an event handler.
+	 */
+	public function registerHandler(string $eventClass, callable|string $handler): void;
+
+	/**
+	 * Handles an event.
+	 */
+	public function handle(object $event): void;
+}

--- a/src/mako/bus/exceptions/BusException.php
+++ b/src/mako/bus/exceptions/BusException.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\bus\exceptions;
+
+use RuntimeException;
+
+/**
+ * Bus exception.
+ */
+class BusException extends RuntimeException
+{
+
+}

--- a/src/mako/bus/query/QueryBus.php
+++ b/src/mako/bus/query/QueryBus.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\bus\query;
+
+use mako\bus\query\exceptions\QueryBusException;
+use mako\bus\traits\SingleHandlerTrait;
+use mako\syringe\Container;
+
+/**
+ * Query bus.
+ */
+class QueryBus implements QueryBusInterface
+{
+	use SingleHandlerTrait;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct(
+		protected Container $container
+	)
+	{}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function getUnableToResolveException(object $object): QueryBusException
+	{
+		return new QueryBusException(vsprintf('No handler has been registered for [ %s ] queries.', [$object::class]));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function handle(object $query): mixed
+	{
+		return $this->getHandler($query)($query);
+	}
+}

--- a/src/mako/bus/query/QueryBusInterface.php
+++ b/src/mako/bus/query/QueryBusInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\bus\query;
+
+use mako\bus\HandlerInterface;
+
+/**
+ * Query bus interface.
+ */
+interface QueryBusInterface extends HandlerInterface
+{
+	/**
+	 * Registers a query handler.
+	 */
+	public function registerHandler(string $queryClass, callable|string $handler): void;
+
+	/**
+	 * Handles a query.
+	 */
+	public function handle(object $query): mixed;
+}

--- a/src/mako/bus/query/exceptions/QueryBusException.php
+++ b/src/mako/bus/query/exceptions/QueryBusException.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\bus\query\exceptions;
+
+use mako\bus\exceptions\BusException;
+
+/**
+ * Query bus exception.
+ */
+class QueryBusException extends BusException
+{
+
+}

--- a/src/mako/bus/traits/ResolveHandlerTrait.php
+++ b/src/mako/bus/traits/ResolveHandlerTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\bus\traits;
+
+use function is_callable;
+use function is_string;
+
+/**
+ * Resolve handler trait.
+ *
+ * @property \mako\syringe\Container $container
+ */
+trait ResolveHandlerTrait
+{
+	/**
+	 * Resolves the handler.
+	 */
+	protected function resolveHandler(callable|string $handler): callable
+	{
+		if(is_string($handler))
+		{
+			if(is_callable($handler))
+			{
+				return $handler;
+			}
+
+			return $this->container->get($handler);
+		}
+
+		return $handler;
+	}
+}

--- a/src/mako/bus/traits/SingleHandlerTrait.php
+++ b/src/mako/bus/traits/SingleHandlerTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\bus\traits;
+
+use mako\bus\exceptions\BusException;
+
+/**
+ * Single handler trait.
+ */
+trait SingleHandlerTrait
+{
+	use ResolveHandlerTrait;
+
+	/**
+	 *  Handlers.
+	 */
+	protected array $handlers = [];
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function registerHandler(string $className, callable|string $handler): void
+	{
+		$this->handlers[$className] = $handler;
+	}
+
+	/**
+	 * Returns the exception thrown when unable to resolve a handler.
+	 */
+	abstract protected function getUnableToResolveException(object $object): BusException;
+
+	/**
+	 * Gets the handler.
+	 */
+	protected function getHandler(object $object): callable
+	{
+		if(!isset($this->handlers[$object::class]))
+		{
+			throw $this->getUnableToResolveException($object);
+		}
+
+		$handler = $this->handlers[$object::class];
+
+		return $this->resolveHandler($handler);
+	}
+}

--- a/src/mako/commander/CommandBus.php
+++ b/src/mako/commander/CommandBus.php
@@ -17,6 +17,8 @@ use function substr_replace;
 
 /**
  * Command bus.
+ *
+ * @deprecated
  */
 class CommandBus implements CommandBusInterface
 {

--- a/src/mako/commander/CommandBusInterface.php
+++ b/src/mako/commander/CommandBusInterface.php
@@ -12,6 +12,8 @@ use mako\syringe\Container;
 
 /**
  * Command bus interface.
+ *
+ * @deprecated
  */
 interface CommandBusInterface
 {

--- a/src/mako/commander/CommandHandlerInterface.php
+++ b/src/mako/commander/CommandHandlerInterface.php
@@ -9,6 +9,8 @@ namespace mako\commander;
 
 /**
  * Command handler interface.
+ *
+ * @deprecated
  */
 interface CommandHandlerInterface
 {

--- a/src/mako/commander/CommandInterface.php
+++ b/src/mako/commander/CommandInterface.php
@@ -9,6 +9,8 @@ namespace mako\commander;
 
 /**
  * Command interface.
+ *
+ * @deprecated
  */
 interface CommandInterface
 {

--- a/src/mako/commander/SelfHandlingCommandInterface.php
+++ b/src/mako/commander/SelfHandlingCommandInterface.php
@@ -9,6 +9,8 @@ namespace mako\commander;
 
 /**
  * Self handling command interface.
+ *
+ * @deprecated
  */
 interface SelfHandlingCommandInterface
 {

--- a/src/mako/event/Event.php
+++ b/src/mako/event/Event.php
@@ -14,6 +14,8 @@ use function array_keys;
 
 /**
  * Event listener.
+ *
+ * @deprecated
  */
 class Event
 {

--- a/src/mako/event/EventHandlerInterface.php
+++ b/src/mako/event/EventHandlerInterface.php
@@ -9,6 +9,8 @@ namespace mako\event;
 
 /**
  * Event handler interface.
+ *
+ * @deprecated
  */
 interface EventHandlerInterface
 {

--- a/src/mako/syringe/Container.php
+++ b/src/mako/syringe/Container.php
@@ -26,7 +26,7 @@ use function is_int;
 use function vsprintf;
 
 /**
- * Inversion of control container.
+ * Dependecy injection container.
  */
 class Container
 {

--- a/src/mako/syringe/traits/ContainerAwareTrait.php
+++ b/src/mako/syringe/traits/ContainerAwareTrait.php
@@ -16,6 +16,9 @@ use function vsprintf;
  * Container aware trait.
  *
  * @property \mako\application\Application                      $app
+ * @property \mako\bus\command\CommandBusInterface              $commandBus
+ * @property \mako\bus\event\EventBusInterface                  $eventBus
+ * @property \mako\bus\query\QueryBusInterface                  $querydBus
  * @property \mako\cache\CacheManager                           $cache
  * @property \mako\cli\input\Input                              $input
  * @property \mako\cli\output\Output                            $output
@@ -32,6 +35,7 @@ use function vsprintf;
  * @property \mako\http\routing\Routes                          $routes
  * @property \mako\http\routing\URLBuilder                      $urlBuilder
  * @property \mako\i18n\I18n                                    $i18n
+ * @property \mako\logger\Logger                                $logger
  * @property \mako\pagination\PaginationFactoryInterface        $pagination
  * @property \mako\redis\ConnectionManager                      $redis
  * @property \mako\security\crypto\CryptoManager                $crypto
@@ -40,7 +44,6 @@ use function vsprintf;
  * @property \mako\utility\Humanizer                            $humanizer
  * @property \mako\validator\ValidatorFactory                   $validator
  * @property \mako\view\ViewFactory                             $view
- * @property \mako\logger\Logger                                $logger
  */
 trait ContainerAwareTrait
 {

--- a/tests/unit/bus/command/CommandBusTest.php
+++ b/tests/unit/bus/command/CommandBusTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\tests\unit\bus\command;
+
+use mako\bus\command\CommandBus;
+use mako\bus\command\exceptions\CommandBusException;
+use mako\syringe\Container;
+use mako\tests\TestCase;
+use Mockery;
+
+// --------------------------------------------------------------------------
+// START CLASSES
+// --------------------------------------------------------------------------
+
+class Spy
+{
+	public $peek;
+}
+
+readonly class CreateUserCommand
+{
+	public function __construct(
+		public string $username
+	)
+	{}
+}
+
+class CreateUserHandler
+{
+	public function __construct(
+		protected Spy $spy
+	)
+	{}
+
+	public function __invoke(CreateUserCommand $createUser): void
+	{
+		$this->spy->peek = $createUser->username;
+	}
+}
+
+function create_user_handler(CreateUserCommand $createUser): void
+{
+	assert($createUser->username === 'freost');
+}
+
+// --------------------------------------------------------------------------
+// END CLASSES
+// --------------------------------------------------------------------------
+
+/**
+ * @group unit
+ */
+class CommandBusTest extends TestCase
+{
+	/**
+	 *
+	 */
+	public function testClassHandler(): void
+	{
+		$spy = new Spy;
+
+		$createUserHandler = new CreateUserHandler($spy);
+
+		/** @var Container|\Mockery\MockInterface $container */
+		$container = Mockery::mock(Container::class);
+
+		$container->shouldReceive('get')->once()->with(CreateUserHandler::class)->andReturn($createUserHandler);
+
+		$bus = new CommandBus($container);
+
+		$bus->registerHandler(CreateUserCommand::class, CreateUserHandler::class);
+
+		$bus->handle(new CreateUserCommand('freost'));
+
+		$this->assertSame('freost', $spy->peek);
+	}
+
+	/**
+	 *
+	 */
+	public function testClosureHandler(): void
+	{
+		$spy = new Spy;
+
+		$createUserHandler = function (CreateUserCommand $createUser) use ($spy): void
+		{
+			$spy->peek = $createUser->username;
+		};
+
+		/** @var Container|\Mockery\MockInterface $container */
+		$container = Mockery::mock(Container::class);
+
+		$bus = new CommandBus($container);
+
+		$bus->registerHandler(CreateUserCommand::class, $createUserHandler);
+
+		$bus->handle(new CreateUserCommand('freost'));
+
+		$this->assertSame('freost', $spy->peek);
+	}
+
+	/**
+	 *
+	 */
+	public function testFunctionHandler(): void
+	{
+		/** @var Container|\Mockery\MockInterface $container */
+		$container = Mockery::mock(Container::class);
+
+		$bus = new CommandBus($container);
+
+		$bus->registerHandler(CreateUserCommand::class, __NAMESPACE__ . '\create_user_handler');
+
+		$bus->handle(new CreateUserCommand('freost'));
+
+		$this->assertTrue(true); // The test is done using php assertions
+	}
+
+	/**
+	 *
+	 */
+	public function testMissingHandler(): void
+	{
+		$this->expectException(CommandBusException::class);
+		$this->expectExceptionMessage('No handler has been registered for [ mako\tests\unit\bus\command\CreateUserCommand ] commands.');
+
+		/** @var Container|\Mockery\MockInterface $container */
+		$container = Mockery::mock(Container::class);
+
+		$bus = new CommandBus($container);
+
+		$bus->handle(new CreateUserCommand('freost'));
+	}
+}

--- a/tests/unit/bus/command/CommandBusTest.php
+++ b/tests/unit/bus/command/CommandBusTest.php
@@ -22,7 +22,7 @@ class Spy
 	public $peek;
 }
 
-readonly class CreateUserCommand
+class CreateUserCommand
 {
 	public function __construct(
 		public string $username

--- a/tests/unit/bus/event/EventBusTest.php
+++ b/tests/unit/bus/event/EventBusTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\tests\unit\bus\event;
+
+use mako\bus\event\EventBus;
+use mako\syringe\Container;
+use mako\tests\TestCase;
+use Mockery;
+
+// --------------------------------------------------------------------------
+// START CLASSES
+// --------------------------------------------------------------------------
+
+class Spy
+{
+	public $peek;
+}
+
+class UserCreatedEvent
+{
+	public function __construct(
+		public string $username
+	)
+	{}
+}
+
+class UserCreatedHandler
+{
+	public function __construct(
+		protected Spy $spy
+	)
+	{}
+
+	public function __invoke(UserCreatedEvent $userCreated): void
+	{
+		$this->spy->peek .= $userCreated->username;
+	}
+}
+
+// --------------------------------------------------------------------------
+// END CLASSES
+// --------------------------------------------------------------------------
+
+/**
+ * @group unit
+ */
+class EventBusTest extends TestCase
+{
+	/**
+	 *
+	 */
+	public function testSingleClassHandler(): void
+	{
+		$spy = new Spy;
+
+		$createUserHandler = new UserCreatedHandler($spy);
+
+		/** @var Container|\Mockery\MockInterface $container */
+		$container = Mockery::mock(Container::class);
+
+		$container->shouldReceive('get')->once()->with(CreateUserHandler::class)->andReturn($createUserHandler);
+
+		$bus = new EventBus($container);
+
+		$bus->registerHandler(UserCreatedEvent::class, CreateUserHandler::class);
+
+		$bus->handle(new UserCreatedEvent('freost'));
+
+		$this->assertSame('freost', $spy->peek);
+	}
+
+	/**
+	 *
+	 */
+	public function testMultipleClassHandlers(): void
+	{
+		$spy = new Spy;
+
+		$createUserHandler = new UserCreatedHandler($spy);
+
+		/** @var Container|\Mockery\MockInterface $container */
+		$container = Mockery::mock(Container::class);
+
+		$container->shouldReceive('get')->times(2)->with(CreateUserHandler::class)->andReturn($createUserHandler);
+
+		$bus = new EventBus($container);
+
+		$bus->registerHandler(UserCreatedEvent::class, CreateUserHandler::class);
+		$bus->registerHandler(UserCreatedEvent::class, CreateUserHandler::class);
+
+		$bus->handle(new UserCreatedEvent('freost'));
+
+		$this->assertSame('freostfreost', $spy->peek);
+	}
+
+	/**
+	 *
+	 */
+	public function testClosureHandler(): void
+	{
+		$spy = new Spy;
+
+		$createUserHandler = function (UserCreatedEvent $createUser) use ($spy): void
+		{
+			$spy->peek = $createUser->username;
+		};
+
+		/** @var Container|\Mockery\MockInterface $container */
+		$container = Mockery::mock(Container::class);
+
+		$bus = new EventBus($container);
+
+		$bus->registerHandler(UserCreatedEvent::class, $createUserHandler);
+
+		$bus->handle(new UserCreatedEvent('freost'));
+
+		$this->assertSame('freost', $spy->peek);
+	}
+
+	/**
+	 *
+	 */
+	public function testMissingHandler(): void
+	{
+		/** @var Container|\Mockery\MockInterface $container */
+		$container = Mockery::mock(Container::class);
+
+		$container->shouldNotReceive('get');
+
+		$bus = new EventBus($container);
+
+		$bus->handle(new UserCreatedEvent('freost'));
+	}
+}

--- a/tests/unit/bus/query/QueryBusTest.php
+++ b/tests/unit/bus/query/QueryBusTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\tests\unit\bus\query;
+
+use mako\bus\query\exceptions\QueryBusException;
+use mako\bus\query\QueryBus;
+use mako\syringe\Container;
+use mako\tests\TestCase;
+use Mockery;
+
+// --------------------------------------------------------------------------
+// START CLASSES
+// --------------------------------------------------------------------------
+
+readonly class GetUserQuery
+{
+	public function __construct(
+		public string $username
+	)
+	{}
+}
+
+class GetUserHandler
+{
+	public function __invoke(GetUserQuery $getUser): GetUserQuery
+	{
+		return $getUser;
+	}
+}
+
+function create_user_handler(GetUserQuery $getUser): GetUserQuery
+{
+	return $getUser;
+}
+
+// --------------------------------------------------------------------------
+// END CLASSES
+// --------------------------------------------------------------------------
+
+/**
+ * @group unit
+ */
+class QueryBusTest extends TestCase
+{
+	/**
+	 *
+	 */
+	public function testClassHandler(): void
+	{
+		$query = new GetUserQuery('freost');
+
+		/** @var Container|\Mockery\MockInterface $container */
+		$container = Mockery::mock(Container::class);
+
+		$container->shouldReceive('get')->once()->with(GetUserHandler::class)->andReturn(new GetUserHandler);
+
+		$bus = new QueryBus($container);
+
+		$bus->registerHandler(GetUserQuery::class, GetUserHandler::class);
+
+		$result = $bus->handle($query);
+
+		$this->assertSame($query, $result);
+	}
+
+	/**
+	 *
+	 */
+	public function testClosureHandler(): void
+	{
+		$query = new GetUserQuery('freost');
+
+		/** @var Container|\Mockery\MockInterface $container */
+		$container = Mockery::mock(Container::class);
+
+		$bus = new QueryBus($container);
+
+		$bus->registerHandler(GetUserQuery::class, fn (GetUserQuery $getUser): GetUserQuery => $getUser);
+
+		$result = $bus->handle($query);
+
+		$this->assertSame($query, $result);
+	}
+
+	/**
+	 *
+	 */
+	public function testFunctionHandler(): void
+	{
+		$query = new GetUserQuery('freost');
+
+		/** @var Container|\Mockery\MockInterface $container */
+		$container = Mockery::mock(Container::class);
+
+		$bus = new QueryBus($container);
+
+		$bus->registerHandler(GetUserQuery::class, __NAMESPACE__ . '\create_user_handler');
+
+		$result = $bus->handle($query);
+
+		$this->assertSame($query, $result);
+	}
+
+	/**
+	 *
+	 */
+	public function testMissingHandler(): void
+	{
+		$this->expectException(QueryBusException::class);
+		$this->expectExceptionMessage('No handler has been registered for [ mako\tests\unit\bus\query\GetUserQuery ] queries.');
+
+		/** @var Container|\Mockery\MockInterface $container */
+		$container = Mockery::mock(Container::class);
+
+		$bus = new QueryBus($container);
+
+		$bus->handle(new GetUserQuery('freost'));
+	}
+}

--- a/tests/unit/bus/query/QueryBusTest.php
+++ b/tests/unit/bus/query/QueryBusTest.php
@@ -17,7 +17,7 @@ use Mockery;
 // START CLASSES
 // --------------------------------------------------------------------------
 
-readonly class GetUserQuery
+class GetUserQuery
 {
 	public function __construct(
 		public string $username


### PR DESCRIPTION
<!--
Please use the provided template when creating pull requests 🙂
-->

### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      | -      |
| New feature? | Yes      |
| Other?       | -      |

### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | No      |
| Has unit and/or integration tests?  | Yes      |

###  Description
---

A new and more flexible bus library that replaces the existing command bus and event libraries. The old libraries are deprecated and will be removed in Mako 10.
