### PR TITLE
Add class property types and remove redundant docblock info

### DIFF
--- a/src/mako/application/Application.php
+++ b/src/mako/application/Application.php
@@ -416,7 +416,7 @@ abstract class Application
 	 *
 	 * @return $this
 	 */
-	public function boot()
+	public function boot(): static
 	{
 		// Set up the framework core
 

--- a/src/mako/application/Application.php
+++ b/src/mako/application/Application.php
@@ -38,57 +38,41 @@ abstract class Application
 
 	/**
 	 * Application start time.
-	 *
-	 * @var float
 	 */
-	protected $startTime;
+	protected float $startTime;
 
 	/**
 	 * Container.
-	 *
-	 * @var \mako\syringe\Container
 	 */
-	protected $container;
+	protected Container $container;
 
 	/**
 	 * Config instance.
-	 *
-	 * @var \mako\config\Config
 	 */
-	protected $config;
+	protected Config $config;
 
 	/**
 	 * Application charset.
-	 *
-	 * @var string
 	 */
-	protected $charset;
+	protected string $charset;
 
 	/**
 	 * Application language.
-	 *
-	 * @var string
 	 */
-	protected $language;
+	protected string $language;
 
 	/**
 	 * Application storage path.
-	 *
-	 * @var string
 	 */
-	protected $storagePath;
+	protected string $storagePath;
 
 	/**
 	 * Booted packages.
-	 *
-	 * @var array
 	 */
-	protected $packages = [];
+	protected array $packages = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string $applicationPath Application path
 	 */
 	final protected function __construct(
 		protected string $applicationPath
@@ -99,10 +83,6 @@ abstract class Application
 
 	/**
 	 * Starts the application and returns a singleton instance of the application.
-	 *
-	 *
-	 * @param  string $applicationPath Application path
-	 * @return static
 	 */
 	public static function start(string $applicationPath): static
 	{
@@ -118,8 +98,6 @@ abstract class Application
 
 	/**
 	 * Returns a singleton instance of the application.
-	 *
-	 * @return static
 	 */
 	public static function instance(): static
 	{
@@ -133,8 +111,6 @@ abstract class Application
 
 	/**
 	 * Returns the application start time.
-	 *
-	 * @return float
 	 */
 	public function getStartTime(): float
 	{
@@ -143,8 +119,6 @@ abstract class Application
 
 	/**
 	 * Returns the container instance.
-	 *
-	 * @return \mako\syringe\Container
 	 */
 	public function getContainer(): Container
 	{
@@ -153,8 +127,6 @@ abstract class Application
 
 	/**
 	 * Returns the config instance.
-	 *
-	 * @return \mako\config\Config
 	 */
 	public function getConfig(): Config
 	{
@@ -163,8 +135,6 @@ abstract class Application
 
 	/**
 	 * Returns the application charset.
-	 *
-	 * @return string
 	 */
 	public function getCharset(): string
 	{
@@ -173,8 +143,6 @@ abstract class Application
 
 	/**
 	 * Returns the application language.
-	 *
-	 * @return string
 	 */
 	public function getLanguage(): string
 	{
@@ -183,8 +151,6 @@ abstract class Application
 
 	/**
 	 * Sets the application language settings.
-	 *
-	 * @param array $language Application language settings
 	 */
 	public function setLanguage(array $language): void
 	{
@@ -198,8 +164,6 @@ abstract class Application
 
 	/**
 	 * Gets the application path.
-	 *
-	 * @return string
 	 */
 	public function getPath(): string
 	{
@@ -208,8 +172,6 @@ abstract class Application
 
 	/**
 	 * Gets the application storage path.
-	 *
-	 * @return string
 	 */
 	public function getStoragePath(): string
 	{
@@ -218,8 +180,6 @@ abstract class Application
 
 	/**
 	 * Returns all the application packages.
-	 *
-	 * @return array
 	 */
 	public function getPackages(): array
 	{
@@ -228,9 +188,6 @@ abstract class Application
 
 	/**
 	 * Returns a package by its name.
-	 *
-	 * @param  string                    $package Package name
-	 * @return \mako\application\Package
 	 */
 	public function getPackage(string $package): Package
 	{
@@ -244,9 +201,6 @@ abstract class Application
 
 	/**
 	 * Returns the application namespace.
-	 *
-	 * @param  bool   $prefix Prefix the namespace with a slash?
-	 * @return string
 	 */
 	public function getNamespace(bool $prefix = false)
 	{
@@ -262,8 +216,6 @@ abstract class Application
 
 	/**
 	 * Is the application running in the CLI?
-	 *
-	 * @return bool
 	 */
 	public function isCommandLine(): bool
 	{
@@ -272,8 +224,6 @@ abstract class Application
 
 	/**
 	 * Returns the Mako environment. NULL is returned if no environment is specified.
-	 *
-	 * @return string|null
 	 */
 	public function getEnvironment(): ?string
 	{
@@ -312,8 +262,6 @@ abstract class Application
 
 	/**
 	 * Registers services in the container.
-	 *
-	 * @param string $type Service type
 	 */
 	protected function serviceRegistrar(string $type): void
 	{
@@ -373,8 +321,6 @@ abstract class Application
 
 	/**
 	 * Boots packages.
-	 *
-	 * @param string $type Package type
 	 */
 	protected function packageBooter(string $type): void
 	{
@@ -425,8 +371,6 @@ abstract class Application
 
 	/**
 	 * Creates a container instance.
-	 *
-	 * @return \mako\syringe\Container
 	 */
 	protected function containerFactory(): Container
 	{
@@ -435,8 +379,6 @@ abstract class Application
 
 	/**
 	 * Creates a configuration instance.
-	 *
-	 * @return \mako\config\Config
 	 */
 	protected function configFactory(): Config
 	{

--- a/src/mako/application/Application.php
+++ b/src/mako/application/Application.php
@@ -202,7 +202,7 @@ abstract class Application
 	/**
 	 * Returns the application namespace.
 	 */
-	public function getNamespace(bool $prefix = false)
+	public function getNamespace(bool $prefix = false): string
 	{
 		$namespace = basename(rtrim($this->applicationPath, '\\'));
 

--- a/src/mako/application/Package.php
+++ b/src/mako/application/Package.php
@@ -31,22 +31,22 @@ abstract class Package
 	/**
 	 * Package name.
 	 */
-	protected string $packageName = '';
+	protected string $packageName;
 
 	/**
 	 * Package path.
 	 */
-	protected string|null $path = null;
+	protected string $path;
 
 	/**
 	 * File namespace.
 	 */
-	protected string|null $fileNamespace = null;
+	protected string $fileNamespace;
 
 	/**
 	 * Class namespace.
 	 */
-	protected string|null $classNamespace = null;
+	protected string $classNamespace;
 
 	/**
 	 * Commands.
@@ -74,7 +74,7 @@ abstract class Package
 	 */
 	public function getFileNamespace(): string
 	{
-		if($this->fileNamespace === null)
+		if(empty($this->fileNamespace))
 		{
 			$this->fileNamespace = str_replace('/', '-', strtolower($this->packageName));
 		}
@@ -87,7 +87,7 @@ abstract class Package
 	 */
 	public function getClassNamespace(bool $prefix = false): string
 	{
-		if($this->classNamespace === null)
+		if(empty($this->classNamespace))
 		{
 			$this->classNamespace = substr(static::class, 0, strrpos(static::class, '\\'));
 		}
@@ -100,7 +100,7 @@ abstract class Package
 	 */
 	public function getPath(): string
 	{
-		if($this->path === null)
+		if(empty($this->path))
 		{
 			$this->path = dirname((new ReflectionClass($this))->getFileName(), 2);
 		}

--- a/src/mako/application/Package.php
+++ b/src/mako/application/Package.php
@@ -30,43 +30,31 @@ abstract class Package
 {
 	/**
 	 * Package name.
-	 *
-	 * @var string
 	 */
-	protected $packageName;
+	protected string $packageName = '';
 
 	/**
 	 * Package path.
-	 *
-	 * @var string
 	 */
-	protected $path;
+	protected string|null $path = null;
 
 	/**
 	 * File namespace.
-	 *
-	 * @var string
 	 */
-	protected $fileNamespace;
+	protected string|null $fileNamespace = null;
 
 	/**
 	 * Class namespace.
-	 *
-	 * @var string
 	 */
-	protected $classNamespace;
+	protected string|null $classNamespace = null;
 
 	/**
 	 * Commands.
-	 *
-	 * @var array
 	 */
-	protected $commands = [];
+	protected array $commands = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\syringe\Container $container Container
 	 */
 	public function __construct(
 		protected Container $container
@@ -75,8 +63,6 @@ abstract class Package
 
 	/**
 	 * Returns the package name.
-	 *
-	 * @return string
 	 */
 	public function getName(): string
 	{
@@ -85,8 +71,6 @@ abstract class Package
 
 	/**
 	 * Returns the package namespace.
-	 *
-	 * @return string
 	 */
 	public function getFileNamespace(): string
 	{
@@ -100,9 +84,6 @@ abstract class Package
 
 	/**
 	 * Returns the class namespace.
-	 *
-	 * @param  bool   $prefix Prefix the namespace with a slash?
-	 * @return string
 	 */
 	public function getClassNamespace(bool $prefix = false): string
 	{
@@ -116,8 +97,6 @@ abstract class Package
 
 	/**
 	 * Returns package path.
-	 *
-	 * @return string
 	 */
 	public function getPath(): string
 	{
@@ -131,8 +110,6 @@ abstract class Package
 
 	/**
 	 * Returns the path to the package configuration files.
-	 *
-	 * @return string
 	 */
 	public function getConfigPath(): string
 	{
@@ -141,8 +118,6 @@ abstract class Package
 
 	/**
 	 * Returns the path to the package i18n strings.
-	 *
-	 * @return string
 	 */
 	public function getI18nPath(): string
 	{
@@ -151,8 +126,6 @@ abstract class Package
 
 	/**
 	 * Returns the path to the package views.
-	 *
-	 * @return string
 	 */
 	public function getViewPath(): string
 	{
@@ -161,8 +134,6 @@ abstract class Package
 
 	/**
 	 * Returns the package commands.
-	 *
-	 * @return array
 	 */
 	public function getCommands(): array
 	{

--- a/src/mako/application/cli/Application.php
+++ b/src/mako/application/cli/Application.php
@@ -53,15 +53,11 @@ class Application extends BaseApplication
 {
 	/**
 	 * Reactor instance.
-	 *
-	 * @var \mako\reactor\Reactor
 	 */
-	protected $reactor;
+	protected Reactor $reactor;
 
 	/**
 	 * Creates a input instance.
-	 *
-	 * @return \mako\cli\input\Input
 	 */
 	protected function inputFactory(): Input
 	{
@@ -74,8 +70,6 @@ class Application extends BaseApplication
 
 	/**
 	 * Creates an output instance.
-	 *
-	 * @return \mako\cli\output\Output
 	 */
 	protected function outputFactory(): Output
 	{
@@ -84,8 +78,6 @@ class Application extends BaseApplication
 
 	/**
 	 * Creates a reactor instance.
-	 *
-	 * @return \mako\reactor\Reactor
 	 */
 	protected function reactorFactory(): Reactor
 	{
@@ -94,8 +86,6 @@ class Application extends BaseApplication
 
 	/**
 	 * Loads the reactor ASCII logo.
-	 *
-	 * @return string
 	 */
 	protected function loadLogo(): string
 	{
@@ -173,8 +163,6 @@ class Application extends BaseApplication
 
 	/**
 	 * Returns the application commands.
-	 *
-	 * @return array
 	 */
 	protected function getApplicationCommands(): array
 	{
@@ -207,8 +195,6 @@ class Application extends BaseApplication
 
 	/**
 	 * Returns all registered commands.
-	 *
-	 * @return array
 	 */
 	protected function getCommands(): array
 	{

--- a/src/mako/application/cli/commands/app/GenerateKey.php
+++ b/src/mako/application/cli/commands/app/GenerateKey.php
@@ -18,7 +18,7 @@ class GenerateKey extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $description = 'Generates a 256-bit encryption key.';
+	protected string|null $description = 'Generates a 256-bit encryption key.';
 
 	/**
 	 * Executes the command.

--- a/src/mako/application/cli/commands/app/GenerateKey.php
+++ b/src/mako/application/cli/commands/app/GenerateKey.php
@@ -18,7 +18,7 @@ class GenerateKey extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $description = 'Generates a 256-bit encryption key.';
+	protected string $description = 'Generates a 256-bit encryption key.';
 
 	/**
 	 * Executes the command.

--- a/src/mako/application/cli/commands/app/GeneratePreloader.php
+++ b/src/mako/application/cli/commands/app/GeneratePreloader.php
@@ -27,7 +27,7 @@ class GeneratePreloader extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $description = 'Generates a opcache preloader script.';
+	protected string $description = 'Generates a opcache preloader script.';
 
 	/**
 	 * Constructor.

--- a/src/mako/application/cli/commands/app/GeneratePreloader.php
+++ b/src/mako/application/cli/commands/app/GeneratePreloader.php
@@ -27,15 +27,10 @@ class GeneratePreloader extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $description = 'Generates a opcache preloader script.';
+	protected string|null $description = 'Generates a opcache preloader script.';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\input\Input         $input      Input
-	 * @param \mako\cli\output\Output       $output     Output
-	 * @param \mako\application\Application $app        Application
-	 * @param \mako\file\FileSystem         $fileSystem File system
 	 */
 	public function __construct(
 		Input $input,
@@ -61,8 +56,6 @@ class GeneratePreloader extends Command
 
 	/**
 	 * Gets returns an array of common framework classes.
-	 *
-	 * @return array
 	 */
 	protected function getCoreClasses(): array
 	{
@@ -71,9 +64,6 @@ class GeneratePreloader extends Command
 
 	/**
 	 * Returns an array of all the classes that should be preloaded.
-	 *
-	 * @param  bool  $ignoreCoreClasses Should the default selection of core classes be ignored?
-	 * @return array
 	 */
 	protected function getClasses(bool $ignoreCoreClasses): array
 	{
@@ -94,9 +84,6 @@ class GeneratePreloader extends Command
 
 	/**
 	 * Returns the path to where the opcache preloder script should be stored.
-	 *
-	 * @param  string|null $outputPath Output path
-	 * @return string
 	 */
 	protected function getOutputPath(?string $outputPath): string
 	{
@@ -105,10 +92,6 @@ class GeneratePreloader extends Command
 
 	/**
 	 * Generates an opcache preloader script.
-	 *
-	 * @param  bool        $ignoreCoreClasses Should the default selection of core classes be ignored?
-	 * @param  string|null $outputPath        Output path
-	 * @return int
 	 */
 	public function execute(bool $ignoreCoreClasses = false, ?string $outputPath = null): int
 	{

--- a/src/mako/application/cli/commands/app/GenerateSecret.php
+++ b/src/mako/application/cli/commands/app/GenerateSecret.php
@@ -26,6 +26,8 @@ class GenerateSecret extends Command
 
 	/**
 	 * Executes the command.
+	 *
+	 * @return int|void
 	 */
 	public function execute(Application $application, FileSystem $fileSystem)
 	{

--- a/src/mako/application/cli/commands/app/GenerateSecret.php
+++ b/src/mako/application/cli/commands/app/GenerateSecret.php
@@ -22,14 +22,10 @@ class GenerateSecret extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $description = 'Generates a new application secret.';
+	protected string|null $description = 'Generates a new application secret.';
 
 	/**
 	 * Executes the command.
-	 *
-	 * @param  \mako\application\Application $application Application instance
-	 * @param  \mako\file\FileSystem         $fileSystem  File system instance
-	 * @return int|void
 	 */
 	public function execute(Application $application, FileSystem $fileSystem)
 	{

--- a/src/mako/application/cli/commands/app/GenerateSecret.php
+++ b/src/mako/application/cli/commands/app/GenerateSecret.php
@@ -22,7 +22,7 @@ class GenerateSecret extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $description = 'Generates a new application secret.';
+	protected string $description = 'Generates a new application secret.';
 
 	/**
 	 * Executes the command.

--- a/src/mako/application/cli/commands/app/ListRoutes.php
+++ b/src/mako/application/cli/commands/app/ListRoutes.php
@@ -30,7 +30,7 @@ class ListRoutes extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $description = 'Lists all registered routes.';
+	protected string|null $description = 'Lists all registered routes.';
 
 	/**
 	 * {@inheritDoc}
@@ -46,9 +46,6 @@ class ListRoutes extends Command
 
 	/**
 	 * Returns a normalzed action name.
-	 *
-	 * @param  \mako\http\routing\Route $route Route
-	 * @return string
 	 */
 	protected function getNormalizedActionName(Route $route): string
 	{
@@ -70,10 +67,6 @@ class ListRoutes extends Command
 
 	/**
 	 * Returns TRUE if the route matches the filter and FALSE if not.
-	 *
-	 * @param  string                   $filter Filter
-	 * @param  \mako\http\routing\Route $route  Route
-	 * @return bool
 	 */
 	protected function routeMatches(string $filter, Route $route): bool
 	{
@@ -97,9 +90,6 @@ class ListRoutes extends Command
 
 	/**
 	 * Executes the command.
-	 *
-	 * @param \mako\http\routing\Routes $routes Route collection
-	 * @param string|null               $filter Route filter
 	 */
 	public function execute(Routes $routes, bool $detailed = false, ?string $filter = null): void
 	{

--- a/src/mako/application/cli/commands/app/ListRoutes.php
+++ b/src/mako/application/cli/commands/app/ListRoutes.php
@@ -30,7 +30,7 @@ class ListRoutes extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $description = 'Lists all registered routes.';
+	protected string $description = 'Lists all registered routes.';
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/application/cli/commands/cache/Clear.php
+++ b/src/mako/application/cli/commands/cache/Clear.php
@@ -18,7 +18,7 @@ class Clear extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $description = 'Clears the cache.';
+	protected string|null $description = 'Clears the cache.';
 
 	/**
 	 * {@inheritDoc}
@@ -33,10 +33,6 @@ class Clear extends Command
 
 	/**
 	 * Executes the command.
-	 *
-	 * @param  \mako\cache\CacheManager $cache         Cache manager
-	 * @param  string|null              $configuration Configuration name
-	 * @return int|void
 	 */
 	public function execute(CacheManager $cache, ?string $configuration = null)
 	{

--- a/src/mako/application/cli/commands/cache/Clear.php
+++ b/src/mako/application/cli/commands/cache/Clear.php
@@ -33,6 +33,8 @@ class Clear extends Command
 
 	/**
 	 * Executes the command.
+	 *
+	 * @return int|void
 	 */
 	public function execute(CacheManager $cache, ?string $configuration = null)
 	{

--- a/src/mako/application/cli/commands/cache/Clear.php
+++ b/src/mako/application/cli/commands/cache/Clear.php
@@ -18,7 +18,7 @@ class Clear extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $description = 'Clears the cache.';
+	protected string $description = 'Clears the cache.';
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/application/cli/commands/cache/Command.php
+++ b/src/mako/application/cli/commands/cache/Command.php
@@ -25,10 +25,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\input\Input   $input  Input
-	 * @param \mako\cli\output\Output $output Output
-	 * @param \mako\config\Config     $config Config
 	 */
 	public function __construct(
 		Input $input,
@@ -41,9 +37,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Checks if the configuration exists.
-	 *
-	 * @param  string $configuration Configuration name
-	 * @return bool
 	 */
 	protected function checkConfigurationExistence(string $configuration): bool
 	{

--- a/src/mako/application/cli/commands/cache/Remove.php
+++ b/src/mako/application/cli/commands/cache/Remove.php
@@ -18,7 +18,7 @@ class Remove extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $description = 'Removes the chosen key from the cache.';
+	protected string|null $description = 'Removes the chosen key from the cache.';
 
 	/**
 	 * {@inheritDoc}
@@ -34,11 +34,6 @@ class Remove extends Command
 
 	/**
 	 * Executes the command.
-	 *
-	 * @param  \mako\cache\CacheManager $cache         Cache manager
-	 * @param  string                   $key           Cache Key
-	 * @param  string|null              $configuration Configuration name
-	 * @return int|void
 	 */
 	public function execute(CacheManager $cache, string $key, ?string $configuration = null)
 	{

--- a/src/mako/application/cli/commands/cache/Remove.php
+++ b/src/mako/application/cli/commands/cache/Remove.php
@@ -18,7 +18,7 @@ class Remove extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $description = 'Removes the chosen key from the cache.';
+	protected string $description = 'Removes the chosen key from the cache.';
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/application/cli/commands/cache/Remove.php
+++ b/src/mako/application/cli/commands/cache/Remove.php
@@ -34,6 +34,8 @@ class Remove extends Command
 
 	/**
 	 * Executes the command.
+	 *
+	 * @return int|void
 	 */
 	public function execute(CacheManager $cache, string $key, ?string $configuration = null)
 	{

--- a/src/mako/application/cli/commands/migrations/Command.php
+++ b/src/mako/application/cli/commands/migrations/Command.php
@@ -33,13 +33,6 @@ abstract class Command extends BaseCommand
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\input\Input            $input       Input
-	 * @param \mako\cli\output\Output          $output      Output
-	 * @param \mako\application\Application    $application Application
-	 * @param \mako\file\FileSystem            $fileSystem  File system
-	 * @param \mako\database\ConnectionManager $database    Connection manager
-	 * @param \mako\syringe\Container          $container   Container
 	 */
 	public function __construct(
 		Input $input,
@@ -57,8 +50,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Returns the default connection name of the application.
-	 *
-	 * @return string
 	 */
 	protected function getDefaultConnectionName(): string
 	{
@@ -67,8 +58,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Returns the connection name for which we are running migrations.
-	 *
-	 * @return string
 	 */
 	protected function getConnectionName(): string
 	{
@@ -77,8 +66,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Returns a query builder instance.
-	 *
-	 * @return \mako\database\query\Query
 	 */
 	protected function getQuery(): Query
 	{
@@ -87,9 +74,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Returns the basename of the migration.
-	 *
-	 * @param  string $migration Task path
-	 * @return string
 	 */
 	protected function getBaseName($migration): string
 	{
@@ -98,8 +82,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Returns all application migrations.
-	 *
-	 * @return array
 	 */
 	protected function findApplicationMigrations(): array
 	{
@@ -115,8 +97,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Returns all package migrations.
-	 *
-	 * @return array
 	 */
 	protected function findPackageMigrations(): array
 	{
@@ -135,8 +115,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Finds all migrations.
-	 *
-	 * @return array
 	 */
 	protected function findMigrations(): array
 	{
@@ -145,9 +123,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Returns the fully qualified class name of a migration.
-	 *
-	 * @param  \mako\database\query\Result|\stdClass $migration Migration
-	 * @return string
 	 */
 	protected function getFullyQualifiedMigration(stdClass|Result $migration): string
 	{
@@ -161,8 +136,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Returns migrations filtered by connection name.
-	 *
-	 * @return array
 	 */
 	protected function getMigrationsFilteredByConnection(): array
 	{
@@ -189,9 +162,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Returns migrations that have been run.
-	 *
-	 * @param  int|null                       $batches Number of batches fetch
-	 * @return \mako\database\query\ResultSet
 	 */
 	protected function getMigrated(?int $batches = null): ResultSet
 	{
@@ -207,8 +177,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Returns an array of all outstanding migrations.
-	 *
-	 * @return array
 	 */
 	protected function getOutstanding(): array
 	{
@@ -235,8 +203,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Outputs a migration list.
-	 *
-	 * @param array $migrations Migrations
 	 */
 	protected function outputMigrationList(array $migrations): void
 	{
@@ -261,9 +227,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Returns a migration instance.
-	 *
-	 * @param  object                              $migration Migration meta
-	 * @return \mako\database\migrations\Migration
 	 */
 	protected function resolve(object $migration): Migration
 	{
@@ -272,12 +235,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Builds the migration wrapper closure.
-	 *
-	 * @param  object                              $migration         Migration meta
-	 * @param  \mako\database\migrations\Migration $migrationInstance Migration instance
-	 * @param  string                              $method            Migration method
-	 * @param  int|null                            $batch             Migration batch
-	 * @return \Closure
 	 */
 	protected function buildMigrationWrapper(object $migration, Migration $migrationInstance, string $method, ?int $batch = null): Closure
 	{
@@ -300,10 +257,6 @@ abstract class Command extends BaseCommand
 
 	/**
 	 * Executes a migration method.
-	 *
-	 * @param object   $migration Migration meta
-	 * @param string   $method    Migration method
-	 * @param int|null $batch     Batch
 	 */
 	protected function runMigration(object $migration, string $method, ?int $batch = null): void
 	{

--- a/src/mako/application/cli/commands/migrations/Command.php
+++ b/src/mako/application/cli/commands/migrations/Command.php
@@ -75,7 +75,7 @@ abstract class Command extends BaseCommand
 	/**
 	 * Returns the basename of the migration.
 	 */
-	protected function getBaseName($migration): string
+	protected function getBaseName(string $migration): string
 	{
 		return basename($migration, '.php');
 	}

--- a/src/mako/application/cli/commands/migrations/Create.php
+++ b/src/mako/application/cli/commands/migrations/Create.php
@@ -25,7 +25,7 @@ class Create extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $description = 'Creates a new migration.';
+	protected string $description = 'Creates a new migration.';
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/application/cli/commands/migrations/Create.php
+++ b/src/mako/application/cli/commands/migrations/Create.php
@@ -41,6 +41,8 @@ class Create extends Command
 
 	/**
 	 * Executes the command.
+	 *
+	 * @return int|void
 	 */
 	public function execute(Application $application, FileSystem $fileSystem, $package = null, $description = null)
 	{

--- a/src/mako/application/cli/commands/migrations/Create.php
+++ b/src/mako/application/cli/commands/migrations/Create.php
@@ -25,7 +25,7 @@ class Create extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $description = 'Creates a new migration.';
+	protected string|null $description = 'Creates a new migration.';
 
 	/**
 	 * {@inheritDoc}
@@ -41,12 +41,6 @@ class Create extends Command
 
 	/**
 	 * Executes the command.
-	 *
-	 * @param  \mako\application\Application $application Application instance
-	 * @param  \mako\file\FileSystem         $fileSystem  File system instance
-	 * @param  string                        $package     Package name
-	 * @param  string                        $description Migration description
-	 * @return int|void
 	 */
 	public function execute(Application $application, FileSystem $fileSystem, $package = null, $description = null)
 	{

--- a/src/mako/application/cli/commands/migrations/Down.php
+++ b/src/mako/application/cli/commands/migrations/Down.php
@@ -20,7 +20,7 @@ class Down extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $description = 'Rolls back the last batch of migrations.';
+	protected string $description = 'Rolls back the last batch of migrations.';
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/application/cli/commands/migrations/Down.php
+++ b/src/mako/application/cli/commands/migrations/Down.php
@@ -20,7 +20,7 @@ class Down extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $description = 'Rolls back the last batch of migrations.';
+	protected string|null $description = 'Rolls back the last batch of migrations.';
 
 	/**
 	 * {@inheritDoc}
@@ -36,8 +36,6 @@ class Down extends Command
 
 	/**
 	 * Executes the command.
-	 *
-	 * @param int $batches Number of batches to roll back
 	 */
 	public function execute(int $batches = 1): void
 	{

--- a/src/mako/application/cli/commands/migrations/Reset.php
+++ b/src/mako/application/cli/commands/migrations/Reset.php
@@ -20,7 +20,7 @@ class Reset extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $description = 'Resets the database schema.';
+	protected string $description = 'Resets the database schema.';
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/application/cli/commands/migrations/Reset.php
+++ b/src/mako/application/cli/commands/migrations/Reset.php
@@ -20,7 +20,7 @@ class Reset extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $description = 'Resets the database schema.';
+	protected string|null $description = 'Resets the database schema.';
 
 	/**
 	 * {@inheritDoc}
@@ -36,8 +36,6 @@ class Reset extends Command
 
 	/**
 	 * Executes the command.
-	 *
-	 * @param bool $force Force the schema reset?
 	 */
 	public function execute(bool $force = false): void
 	{

--- a/src/mako/application/cli/commands/migrations/Status.php
+++ b/src/mako/application/cli/commands/migrations/Status.php
@@ -20,7 +20,7 @@ class Status extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $description = 'Checks if there are any outstanding migrations.';
+	protected string|null $description = 'Checks if there are any outstanding migrations.';
 
 	/**
 	 * {@inheritDoc}
@@ -36,9 +36,6 @@ class Status extends Command
 
 	/**
 	 * Executes the command.
-	 *
-	 * @param  bool $exitCode Override exit code?
-	 * @return int
 	 */
 	public function execute($exitCode = false): int
 	{

--- a/src/mako/application/cli/commands/migrations/Status.php
+++ b/src/mako/application/cli/commands/migrations/Status.php
@@ -37,7 +37,7 @@ class Status extends Command
 	/**
 	 * Executes the command.
 	 */
-	public function execute($exitCode = false): int
+	public function execute(bool $exitCode = false): int
 	{
 		$migrations = $this->getOutstanding();
 

--- a/src/mako/application/cli/commands/migrations/Status.php
+++ b/src/mako/application/cli/commands/migrations/Status.php
@@ -20,7 +20,7 @@ class Status extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $description = 'Checks if there are any outstanding migrations.';
+	protected string $description = 'Checks if there are any outstanding migrations.';
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/application/cli/commands/migrations/Up.php
+++ b/src/mako/application/cli/commands/migrations/Up.php
@@ -17,7 +17,7 @@ class Up extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $description = 'Runs all outstanding migrations.';
+	protected string|null $description = 'Runs all outstanding migrations.';
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/application/cli/commands/migrations/Up.php
+++ b/src/mako/application/cli/commands/migrations/Up.php
@@ -17,7 +17,7 @@ class Up extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $description = 'Runs all outstanding migrations.';
+	protected string $description = 'Runs all outstanding migrations.';
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/application/cli/commands/migrations/resources/migration.template
+++ b/src/mako/application/cli/commands/migrations/resources/migration.template
@@ -11,7 +11,7 @@ class Migration_{{version}} extends Migration
 	 *
 	 * @var string
 	 */
-	protected $description = '{{description}}';
+	protected string $description = '{{description}}';
 
 	/**
 	 * Makes changes to the database structure.

--- a/src/mako/application/cli/commands/migrations/resources/migration.template
+++ b/src/mako/application/cli/commands/migrations/resources/migration.template
@@ -8,8 +8,6 @@ class Migration_{{version}} extends Migration
 {
 	/**
 	 * Description.
-	 *
-	 * @var string
 	 */
 	protected string $description = '{{description}}';
 

--- a/src/mako/application/cli/commands/migrations/traits/RollbackTrait.php
+++ b/src/mako/application/cli/commands/migrations/traits/RollbackTrait.php
@@ -14,8 +14,6 @@ trait RollbackTrait
 {
 	/**
 	 * Rolls back n batches.
-	 *
-	 * @param int|null $batches Number of batches to roll back
 	 */
 	public function rollback(?int $batches = null): void
 	{

--- a/src/mako/application/cli/commands/server/Server.php
+++ b/src/mako/application/cli/commands/server/Server.php
@@ -36,7 +36,7 @@ class Server extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $description = 'Starts the local development server.';
+	protected string $description = 'Starts the local development server.';
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/application/cli/commands/server/Server.php
+++ b/src/mako/application/cli/commands/server/Server.php
@@ -36,7 +36,7 @@ class Server extends Command
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $description = 'Starts the local development server.';
+	protected string|null $description = 'Starts the local development server.';
 
 	/**
 	 * {@inheritDoc}
@@ -53,9 +53,6 @@ class Server extends Command
 
 	/**
 	 * Tries to find an avaiable port closest to the desired port.
-	 *
-	 * @param  int      $port Desired port number
-	 * @return int|null
 	 */
 	protected function findAvailablePort(int $port): ?int
 	{
@@ -78,12 +75,6 @@ class Server extends Command
 
 	/**
 	 * Executes the command.
-	 *
-	 * @param  \mako\application\Application $application Application instance
-	 * @param  int                           $port        Port
-	 * @param  string                        $address     Address
-	 * @param  string|null                   $docroot     Document root
-	 * @return int|void
 	 */
 	public function execute(Application $application, int $port = 8000, string $address = 'localhost', ?string $docroot = null)
 	{

--- a/src/mako/application/services/HTTPService.php
+++ b/src/mako/application/services/HTTPService.php
@@ -22,8 +22,6 @@ class HTTPService extends Service
 {
 	/**
 	 * Returns path to the application routing.
-	 *
-	 * @return string
 	 */
 	protected function getRoutingPath(): string
 	{

--- a/src/mako/application/services/LoggerService.php
+++ b/src/mako/application/services/LoggerService.php
@@ -29,8 +29,6 @@ class LoggerService extends Service
 {
 	/**
 	 * Get information about the current user.
-	 *
-	 * @return array|null
 	 */
 	protected function getUserContext(): ?array
 	{
@@ -57,8 +55,6 @@ class LoggerService extends Service
 	}
 	/**
 	 * Get global logger context.
-	 *
-	 * @return array
 	 */
 	protected function getContext(): array
 	{
@@ -74,8 +70,6 @@ class LoggerService extends Service
 
 	/**
 	 * Returns the storage path.
-	 *
-	 * @return string
 	 */
 	protected function getStoragePath(): string
 	{
@@ -84,8 +78,6 @@ class LoggerService extends Service
 
 	/**
 	 * Returns a stream handler.
-	 *
-	 * @return \Monolog\Handler\StreamHandler
 	 */
 	protected function getStreamHandler(): StreamHandler
 	{
@@ -102,8 +94,6 @@ class LoggerService extends Service
 
 	/**
 	 * Returns a syslog handler.
-	 *
-	 * @return \Monolog\Handler\SyslogHandler
 	 */
 	protected function getSyslogHandler(): SyslogHandler
 	{
@@ -112,8 +102,6 @@ class LoggerService extends Service
 
 	/**
 	 * Returns a error log handler.
-	 *
-	 * @return \Monolog\Handler\ErrorLogHandler
 	 */
 	protected function getErrorLogHandler(): ErrorLogHandler
 	{
@@ -122,9 +110,6 @@ class LoggerService extends Service
 
 	/**
 	 * Returns a log handler.
-	 *
-	 * @param  string                            $handler Handler name
-	 * @return \Monolog\Handler\HandlerInterface
 	 */
 	protected function getHandler(string $handler): HandlerInterface
 	{

--- a/src/mako/application/services/Service.php
+++ b/src/mako/application/services/Service.php
@@ -18,10 +18,6 @@ abstract class Service
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\application\Application $app       Application
-	 * @param \mako\syringe\Container       $container Container
-	 * @param \mako\config\Config           $config    Config
 	 */
 	public function __construct(
 		protected Application $app,

--- a/src/mako/application/services/SessionService.php
+++ b/src/mako/application/services/SessionService.php
@@ -27,24 +27,14 @@ class SessionService extends Service
 {
 	/**
 	 * Returns a database store instance.
-	 *
-	 * @param  \mako\syringe\Container       $container      Container
-	 * @param  array                         $config         Store configuration
-	 * @param  array|bool                    $classWhitelist Class whitelist
-	 * @return \mako\session\stores\Database
 	 */
-	protected function getDatabaseStore(Container $container, array $config, array|bool $classWhitelist)
+	protected function getDatabaseStore(Container $container, array $config, array|bool $classWhitelist): Database
 	{
 		return new Database($container->get(DatabaseConnectionManager::class)->getConnection($config['configuration']), $config['table'], $classWhitelist);
 	}
 
 	/**
 	 * Returns a file store instance.
-	 *
-	 * @param  \mako\syringe\Container   $container      Container
-	 * @param  array                     $config         Store configuration
-	 * @param  array|bool                $classWhitelist Class whitelist
-	 * @return \mako\session\stores\File
 	 */
 	protected function getFileStore(Container $container, array $config, array|bool $classWhitelist): File
 	{
@@ -53,11 +43,6 @@ class SessionService extends Service
 
 	/**
 	 * Returns a null store instance.
-	 *
-	 * @param  \mako\syringe\Container        $container      Container
-	 * @param  array                          $config         Store configuration
-	 * @param  array|bool                     $classWhitelist Class whitelist
-	 * @return \mako\session\stores\NullStore
 	 */
 	protected function getNullStore(Container $container, array $config, array|bool $classWhitelist): NullStore
 	{
@@ -66,11 +51,6 @@ class SessionService extends Service
 
 	/**
 	 * Returns a redis store instance.
-	 *
-	 * @param  \mako\syringe\Container    $container      Container
-	 * @param  array                      $config         Store configuration
-	 * @param  array|bool                 $classWhitelist Class whitelist
-	 * @return \mako\session\stores\Redis
 	 */
 	protected function getRedisStore(Container $container, array $config, array|bool $classWhitelist): Redis
 	{
@@ -79,11 +59,6 @@ class SessionService extends Service
 
 	/**
 	 * Returns a session store instance.
-	 *
-	 * @param  \mako\syringe\Container             $container      Container
-	 * @param  array                               $config         Session configuration
-	 * @param  array|bool                          $classWhitelist Class whitelist
-	 * @return \mako\session\stores\StoreInterface
 	 */
 	protected function getStore(Container $container, array $config, array|bool $classWhitelist): StoreInterface
 	{

--- a/src/mako/application/services/ViewFactoryService.php
+++ b/src/mako/application/services/ViewFactoryService.php
@@ -18,8 +18,6 @@ class ViewFactoryService extends Service
 {
 	/**
 	 * Returns the storage path.
-	 *
-	 * @return string
 	 */
 	protected function getStoragePath(): string
 	{

--- a/src/mako/autoloading/AliasLoader.php
+++ b/src/mako/autoloading/AliasLoader.php
@@ -17,8 +17,6 @@ class AliasLoader
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param array $aliases Class aliases
 	 */
 	public function __construct(
 		protected array $aliases
@@ -27,9 +25,6 @@ class AliasLoader
 
 	/**
 	 * Autoloads aliased classes.
-	 *
-	 * @param  string $alias Class alias
-	 * @return bool
 	 */
 	public function load(string $alias): bool
 	{

--- a/src/mako/cache/CacheManager.php
+++ b/src/mako/cache/CacheManager.php
@@ -37,11 +37,6 @@ class CacheManager extends AdapterManager
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param string                  $default        Default connection name
-	 * @param array                   $configurations Configurations
-	 * @param \mako\syringe\Container $container      Container
-	 * @param array|bool              $classWhitelist Class whitelist
 	 */
 	public function __construct(
 		string $default,
@@ -55,9 +50,6 @@ class CacheManager extends AdapterManager
 
 	/**
 	 * APCU store factory.
-	 *
-	 * @param  array                   $configuration Configuration
-	 * @return \mako\cache\stores\APCU
 	 */
 	protected function apcuFactory(array $configuration): APCU
 	{
@@ -66,9 +58,6 @@ class CacheManager extends AdapterManager
 
 	/**
 	 * File store factory.
-	 *
-	 * @param  array                   $configuration Configuration
-	 * @return \mako\cache\stores\File
 	 */
 	protected function fileFactory(array $configuration): File
 	{
@@ -77,9 +66,6 @@ class CacheManager extends AdapterManager
 
 	/**
 	 * Database store factory.
-	 *
-	 * @param  array                       $configuration Configuration
-	 * @return \mako\cache\stores\Database
 	 */
 	protected function databaseFactory(array $configuration): Database
 	{
@@ -88,9 +74,6 @@ class CacheManager extends AdapterManager
 
 	/**
 	 * Memcache store factory.
-	 *
-	 * @param  array                       $configuration Configuration
-	 * @return \mako\cache\stores\Memcache
 	 */
 	protected function memcacheFactory(array $configuration): Memcache
 	{
@@ -99,9 +82,6 @@ class CacheManager extends AdapterManager
 
 	/**
 	 * Memcached store factory.
-	 *
-	 * @param  array                        $configuration Configuration
-	 * @return \mako\cache\stores\Memcached
 	 */
 	protected function memcachedFactory(array $configuration): Memcached
 	{
@@ -110,9 +90,6 @@ class CacheManager extends AdapterManager
 
 	/**
 	 * Memory store factory.
-	 *
-	 * @param  array                     $configuration Configuration
-	 * @return \mako\cache\stores\Memory
 	 */
 	protected function memoryFactory(array $configuration): Memory
 	{
@@ -121,9 +98,6 @@ class CacheManager extends AdapterManager
 
 	/**
 	 * Redis store factory.
-	 *
-	 * @param  array                    $configuration Configuration
-	 * @return \mako\cache\stores\Redis
 	 */
 	protected function redisFactory(array $configuration): Redis
 	{
@@ -132,9 +106,6 @@ class CacheManager extends AdapterManager
 
 	/**
 	 * Null store factory.
-	 *
-	 * @param  array                        $configuration Configuration
-	 * @return \mako\cache\stores\NullStore
 	 */
 	protected function nullFactory(array $configuration): NullStore
 	{
@@ -143,9 +114,6 @@ class CacheManager extends AdapterManager
 
 	/**
 	 * Windows cache store factory.
-	 *
-	 * @param  array                       $configuration Configuration
-	 * @return \mako\cache\stores\WinCache
 	 */
 	protected function wincacheFactory(array $configuration): WinCache
 	{
@@ -154,9 +122,6 @@ class CacheManager extends AdapterManager
 
 	/**
 	 * Returns a cache instance.
-	 *
-	 * @param  string                            $configuration Configuration name
-	 * @return \mako\cache\stores\StoreInterface
 	 */
 	protected function instantiate(string $configuration): StoreInterface
 	{
@@ -172,9 +137,6 @@ class CacheManager extends AdapterManager
 
 	/**
 	 * Returns an instance of the chosen cache store. Alias of CacheManager::getInstance().
-	 *
-	 * @param  string|null                       $configuration Configuration name
-	 * @return \mako\cache\stores\StoreInterface
 	 */
 	public function getStore(?string $configuration = null): StoreInterface
 	{

--- a/src/mako/cache/stores/Database.php
+++ b/src/mako/cache/stores/Database.php
@@ -21,10 +21,6 @@ class Database extends Store
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\database\connections\Connection $connection     Database connection
-	 * @param string                                $table          Database table
-	 * @param array|bool                            $classWhitelist Class whitelist
 	 */
 	public function __construct(
 		protected Connection $connection,
@@ -35,8 +31,6 @@ class Database extends Store
 
 	/**
 	 * Returns a query builder instance.
-	 *
-	 * @return \mako\database\query\Query
 	 */
 	protected function table(): Query
 	{

--- a/src/mako/cache/stores/File.php
+++ b/src/mako/cache/stores/File.php
@@ -24,10 +24,6 @@ class File extends Store
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\file\FileSystem $fileSystem     File system instance
-	 * @param string                $cachePath      Cache path
-	 * @param array|bool            $classWhitelist Class whitelist
 	 */
 	public function __construct(
 		protected FileSystem $fileSystem,
@@ -38,9 +34,6 @@ class File extends Store
 
 	/**
 	 * Returns the path to the cache file.
-	 *
-	 * @param  string $key Cache key
-	 * @return string
 	 */
 	protected function cacheFile(string $key): string
 	{

--- a/src/mako/cache/stores/IncrementDecrementInterface.php
+++ b/src/mako/cache/stores/IncrementDecrementInterface.php
@@ -15,8 +15,6 @@ interface IncrementDecrementInterface
 	/**
 	 * Increments a stored number.
 	 *
-	 * @param  string    $key  Cache key
-	 * @param  int       $step Step
 	 * @return false|int
 	 */
 	public function increment(string $key, int $step = 1);
@@ -24,8 +22,6 @@ interface IncrementDecrementInterface
 	/**
 	 * Decrements a stored number.
 	 *
-	 * @param  string    $key  Cache key
-	 * @param  int       $step Step
 	 * @return false|int
 	 */
 	public function decrement(string $key, int $step = 1);

--- a/src/mako/cache/stores/Memcache.php
+++ b/src/mako/cache/stores/Memcache.php
@@ -18,24 +18,16 @@ class Memcache extends Store
 {
 	/**
 	 * Memcache instance.
-	 *
-	 * @var \Memcache
 	 */
-	protected $memcache;
+	protected PHPMemcache $memcache;
 
 	/**
 	 * Compression level.
-	 *
-	 * @var int
 	 */
-	protected $compressionLevel = 0;
+	protected int $compressionLevel = 0;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array $servers      Memcache servers
-	 * @param int   $timeout      Timeout in seconds
-	 * @param bool  $compressData Compress data?
 	 */
 	public function __construct(array $servers, int $timeout = 1, bool $compressData = false)
 	{

--- a/src/mako/cache/stores/Memcached.php
+++ b/src/mako/cache/stores/Memcached.php
@@ -18,17 +18,11 @@ class Memcached extends Store implements IncrementDecrementInterface
 {
 	/**
 	 * Memcached instance.
-	 *
-	 * @var \Memcached
 	 */
-	protected $memcached;
+	protected PHPMemcached $memcached;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array $servers      Memcache servers
-	 * @param int   $timeout      Timeout in seconds
-	 * @param bool  $compressData Compress data?
 	 */
 	public function __construct(array $servers, int $timeout = 1, bool $compressData = false)
 	{

--- a/src/mako/cache/stores/Memory.php
+++ b/src/mako/cache/stores/Memory.php
@@ -16,10 +16,8 @@ class Memory extends Store implements IncrementDecrementInterface
 {
 	/**
 	 * Cache data.
-	 *
-	 * @var array
 	 */
-	protected $cache = [];
+	protected array $cache = [];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/cache/stores/Redis.php
+++ b/src/mako/cache/stores/Redis.php
@@ -20,9 +20,6 @@ class Redis extends Store implements IncrementDecrementInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\redis\Redis $redis          Redis client
-	 * @param array|bool        $classWhitelist Class whitelist
 	 */
 	public function __construct(
 		protected RedisClient $redis,

--- a/src/mako/cache/stores/Store.php
+++ b/src/mako/cache/stores/Store.php
@@ -22,7 +22,7 @@ abstract class Store implements StoreInterface
 	 *
 	 * @return $this
 	 */
-	public function setPrefix(string $prefix)
+	public function setPrefix(string $prefix): static
 	{
 		$this->prefix = $prefix;
 

--- a/src/mako/cache/stores/Store.php
+++ b/src/mako/cache/stores/Store.php
@@ -14,15 +14,12 @@ abstract class Store implements StoreInterface
 {
 	/**
 	 * Prefix.
-	 *
-	 * @var string|null
 	 */
-	protected $prefix;
+	protected string|null $prefix = null;
 
 	/**
 	 * Sets the cache key prefix.
 	 *
-	 * @param  string $prefix Prefix
 	 * @return $this
 	 */
 	public function setPrefix(string $prefix)
@@ -34,8 +31,6 @@ abstract class Store implements StoreInterface
 
 	/**
 	 * Returns the cache key prefix.
-	 *
-	 * @return string|null
 	 */
 	public function getPrefix(): ?string
 	{
@@ -44,9 +39,6 @@ abstract class Store implements StoreInterface
 
 	/**
 	 * Returns a prefixed key.
-	 *
-	 * @param  string $key Key
-	 * @return string
 	 */
 	protected function getPrefixedKey(string $key): string
 	{
@@ -68,11 +60,6 @@ abstract class Store implements StoreInterface
 
 	/**
 	 * Fetch data from the cache and replace it. NULL will be returned if the item does not exist.
-	 *
-	 * @param  string $key  Cache key
-	 * @param  mixed  $data The data to store
-	 * @param  int    $ttl  Time to live
-	 * @return mixed
 	 */
 	public function getAndPut(string $key, mixed $data, int $ttl = 0): mixed
 	{
@@ -85,9 +72,6 @@ abstract class Store implements StoreInterface
 
 	/**
 	 * Fetch data from the cache and remove it. NULL will be returned if the item does not exist.
-	 *
-	 * @param  string $key Cache key
-	 * @return mixed
 	 */
 	public function getAndRemove(string $key): mixed
 	{

--- a/src/mako/cache/stores/StoreInterface.php
+++ b/src/mako/cache/stores/StoreInterface.php
@@ -14,62 +14,36 @@ interface StoreInterface
 {
 	/**
 	 * Store data in the cache.
-	 *
-	 * @param  string $key  Cache key
-	 * @param  mixed  $data The data to store
-	 * @param  int    $ttl  Time to live
-	 * @return bool
 	 */
 	public function put(string $key, mixed $data, int $ttl = 0): bool;
 
 	/**
 	 * Store data in the cache if it doesn't already exist.
-	 *
-	 * @param  string $key  Cache key
-	 * @param  mixed  $data The data to store
-	 * @param  int    $ttl  Time to live
-	 * @return bool
 	 */
 	public function putIfNotExists(string $key, mixed $data, int $ttl = 0): bool;
 
 	/**
 	 * Returns TRUE if the cache key exists and FALSE if not.
-	 *
-	 * @param  string $key Cache key
-	 * @return bool
 	 */
 	public function has(string $key): bool;
 
 	/**
 	 * Fetch data from the cache. NULL will be returned if the item does not exist.
-	 *
-	 * @param  string $key Cache key
-	 * @return mixed
 	 */
 	public function get(string $key): mixed;
 
 	/**
 	 * Fetch data from the cache or store it if it doesn't already exist.
-	 *
-	 * @param  string   $key      Cache key
-	 * @param  callable $callable Callable that returns the data we want to store
-	 * @param  int      $ttl      Time to live
-	 * @return mixed
 	 */
 	public function getOrElse(string $key, callable $callable, int $ttl = 0): mixed;
 
 	/**
 	 * Delete data from the cache.
-	 *
-	 * @param  string $key Cache key
-	 * @return bool
 	 */
 	public function remove(string $key): bool;
 
 	/**
 	 * Clears the cache.
-	 *
-	 * @return bool
 	 */
 	public function clear(): bool;
 }

--- a/src/mako/chrono/Time.php
+++ b/src/mako/chrono/Time.php
@@ -31,8 +31,6 @@ class Time extends DateTime implements TimeInterface
 
 	/**
 	 * Returns an immutable instance of the current instance.
-	 *
-	 * @return \mako\chrono\TimeImmutable
 	 */
 	public function getImmutable(): TimeImmutable
 	{

--- a/src/mako/chrono/TimeImmutable.php
+++ b/src/mako/chrono/TimeImmutable.php
@@ -31,8 +31,6 @@ class TimeImmutable extends DateTimeImmutable implements TimeInterface
 
 	/**
 	 * Returns a mutable instance of the current instance.
-	 *
-	 * @return \mako\chrono\Time
 	 */
 	public function getMutable(): Time
 	{

--- a/src/mako/chrono/TimeInterface.php
+++ b/src/mako/chrono/TimeInterface.php
@@ -59,19 +59,12 @@ interface TimeInterface extends DateTimeInterface
 
 	/**
 	 * Returns a new instance set to the current time.
-	 *
-	 * @param  \DateTimeZone|string|null $timeZone A valid time zone or a DateTimeZone object
-	 * @return static
 	 */
 	public static function now(DateTimeZone|string|null $timeZone = null): static;
 
 	/**
 	 * Returns a new instance according to the specified date.
 	 *
-	 * @param  int                       $year     Year
-	 * @param  int|null                  $month    Month (1 to 12)
-	 * @param  int|null                  $day      Day of month (1 to 31)
-	 * @param  \DateTimeZone|string|null $timeZone A valid time zone or a DateTimeZone object
 	 * @return false|static
 	 */
 	public static function createFromDate(int $year, ?int $month = null, ?int $day = null, DateTimeZone|string|null $timeZone = null);
@@ -79,8 +72,6 @@ interface TimeInterface extends DateTimeInterface
 	/**
 	 * Returns a new instance according to the specified UNIX timestamp.
 	 *
-	 * @param  int                       $timestamp UNIX timestamp
-	 * @param  \DateTimeZone|string|null $timeZone  A valid time zone or a DateTimeZone object
 	 * @return false|static
 	 */
 	public static function createFromTimestamp(int $timestamp, DateTimeZone|string|null $timeZone = null);
@@ -88,8 +79,6 @@ interface TimeInterface extends DateTimeInterface
 	/**
 	 * Returns a new instance according to the specified DOS timestamp.
 	 *
-	 * @param  int                       $timestamp DOS timestamp
-	 * @param  \DateTimeZone|string|null $timeZone  A valid time zone or a DateTimeZone object
 	 * @return false|static
 	 */
 	public static function createFromDOSTimestamp(int $timestamp, DateTimeZone|string|null $timeZone = null);
@@ -97,9 +86,6 @@ interface TimeInterface extends DateTimeInterface
 	/**
 	 * Returns a new instance according to the specified time string.
 	 *
-	 * @param  string                    $format   The format that the passed in string should be in
-	 * @param  string                    $time     String representing the time
-	 * @param  \DateTimeZone|string|null $timeZone A valid time zone or a DateTimeZone object
 	 * @return false|static
 	 */
 	public static function createFromFormat(string $format, string $time, DateTimeZone|string|null $timeZone = null);
@@ -114,7 +100,6 @@ interface TimeInterface extends DateTimeInterface
 	/**
 	 * Sets the time zone.
 	 *
-	 * @param  \DateTimeZone|string $timeZone A valid time zone or a DateTimeZone object
 	 * @return $this|false|static
 	 */
 	public function setTimezone(DateTimeZone|string $timeZone);
@@ -122,7 +107,6 @@ interface TimeInterface extends DateTimeInterface
 	/**
 	 * Move forward in time by x seconds.
 	 *
-	 * @param  int                $seconds Number of seconds
 	 * @return $this|false|static
 	 */
 	public function forward(int $seconds);
@@ -130,36 +114,27 @@ interface TimeInterface extends DateTimeInterface
 	/**
 	 * Move backward in time by x seconds.
 	 *
-	 * @param  int                $seconds Number of seconds
 	 * @return $this|false|static
 	 */
 	public function rewind(int $seconds);
 
 	/**
 	 * Returns the DOS timestamp.
-	 *
-	 * @return int
 	 */
 	public function getDOSTimestamp(): int;
 
 	/**
 	 * Returns TRUE if the year is a leap year and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isLeapYear(): bool;
 
 	/**
 	 * Returns an array containing the number of days in each month of the year.
-	 *
-	 * @return array
 	 */
 	public function daysInMonths(): array;
 
 	/**
 	 * Returns the number of days in the current or specified month.
-	 *
-	 * @return int
 	 */
 	public function daysInMonth(): int;
 }

--- a/src/mako/chrono/TimeZone.php
+++ b/src/mako/chrono/TimeZone.php
@@ -20,8 +20,6 @@ class TimeZone extends DateTimeZone
 	/**
 	 * Returns a list of time zones where the key is
 	 * a valid PHP time zone while the value is a presentable name.
-	 *
-	 * @return array
 	 */
 	public static function getTimeZones(): array
 	{
@@ -38,8 +36,6 @@ class TimeZone extends DateTimeZone
 	/**
 	 * Returns an array of grouped time zones where the key is
 	 * a valid PHP time zone while the value is a presentable name.
-	 *
-	 * @return array
 	 */
 	public static function getGroupedTimeZones(): array
 	{

--- a/src/mako/chrono/stopwatch/Lap.php
+++ b/src/mako/chrono/stopwatch/Lap.php
@@ -16,22 +16,16 @@ class Lap
 {
 	/**
 	 * Start time.
-	 *
-	 * @var float
 	 */
-	protected $started = 0.0;
+	protected float $started = 0.0;
 
 	/**
 	 * Stop time.
-	 *
-	 * @var float
 	 */
-	protected $stopped = 0.0;
+	protected float $stopped = 0.0;
 
 	/**
 	 * Returns the lap start time.
-	 *
-	 * @return float
 	 */
 	public function getStartTime(): float
 	{
@@ -40,8 +34,6 @@ class Lap
 
 	/**
 	 * Returns the lap stop time.
-	 *
-	 * @return float
 	 */
 	public function getStopTime(): float
 	{
@@ -50,8 +42,6 @@ class Lap
 
 	/**
 	 * Returns TRUE if the lap is still running and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isRunning(): bool
 	{
@@ -61,9 +51,9 @@ class Lap
 	/**
 	 * Starts the lap.
 	 *
-	 * @return \mako\chrono\stopwatch\Lap
+	 * @return $this
 	 */
-	public function start(): Lap
+	public function start(): static
 	{
 		$this->started = microtime(true);
 
@@ -72,8 +62,6 @@ class Lap
 
 	/**
 	 * Stops the lap and returns the elapsed time.
-	 *
-	 * @return float
 	 */
 	public function stop(): float
 	{

--- a/src/mako/chrono/stopwatch/Stopwatch.php
+++ b/src/mako/chrono/stopwatch/Stopwatch.php
@@ -18,15 +18,11 @@ class Stopwatch
 {
 	/**
 	 * Laps.
-	 *
-	 * @var array
 	 */
-	protected $laps = [];
+	protected array $laps = [];
 
 	/**
 	 * Returns the laps.
-	 *
-	 * @return array
 	 */
 	public function getLaps(): array
 	{
@@ -35,8 +31,6 @@ class Stopwatch
 
 	/**
 	 * Returns the number of laps.
-	 *
-	 * @return int
 	 */
 	public function getLapCount(): int
 	{
@@ -45,8 +39,6 @@ class Stopwatch
 
 	/**
 	 * Returns TRUE if the stopwatch is still running and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isRunning(): bool
 	{
@@ -56,9 +48,9 @@ class Stopwatch
 	/**
 	 * Starts the stopwatch.
 	 *
-	 * @return \mako\chrono\stopwatch\Stopwatch
+	 * @return $this
 	 */
-	public function start(): Stopwatch
+	public function start(): static
 	{
 		$this->laps[] = (new Lap)->start();
 
@@ -67,8 +59,6 @@ class Stopwatch
 
 	/**
 	 * Starts a new lap and returns the time of the previous lap.
-	 *
-	 * @return float
 	 */
 	public function lap(): float
 	{
@@ -83,8 +73,6 @@ class Stopwatch
 
 	/**
 	 * Get elapsed time.
-	 *
-	 * @return float
 	 */
 	public function getElapsedTime(): float
 	{
@@ -95,8 +83,6 @@ class Stopwatch
 
 	/**
 	 * Stops the timer and returns the elapsed time.
-	 *
-	 * @return float
 	 */
 	public function stop(): float
 	{

--- a/src/mako/chrono/traits/TimeTrait.php
+++ b/src/mako/chrono/traits/TimeTrait.php
@@ -20,9 +20,6 @@ trait TimeTrait
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param string                    $time     A date/time string
-	 * @param \DateTimeZone|string|null $timeZone A valid time zone or a DateTimeZone object
 	 */
 	final public function __construct(string $time = 'now', DateTimeZone|string|null $timeZone = null)
 	{
@@ -36,9 +33,6 @@ trait TimeTrait
 
 	/**
 	 * Returns a new instance set to the current time.
-	 *
-	 * @param  \DateTimeZone|string|null $timeZone A valid time zone or a DateTimeZone object
-	 * @return static
 	 */
 	public static function now(DateTimeZone|string|null $timeZone = null): static
 	{
@@ -48,10 +42,6 @@ trait TimeTrait
 	/**
 	 * Returns a new instance according to the specified date.
 	 *
-	 * @param  int                       $year     Year
-	 * @param  int|null                  $month    Month (1 to 12)
-	 * @param  int|null                  $day      Day of month (1 to 31)
-	 * @param  \DateTimeZone|string|null $timeZone A valid time zone or a DateTimeZone object
 	 * @return false|static
 	 */
 	public static function createFromDate(int $year, ?int $month = null, ?int $day = null, DateTimeZone|string|null $timeZone = null)
@@ -68,8 +58,6 @@ trait TimeTrait
 	/**
 	 * Returns a new instance according to the specified UNIX timestamp.
 	 *
-	 * @param  int                       $timestamp UNIX timestamp
-	 * @param  \DateTimeZone|string|null $timeZone  A valid time zone or a DateTimeZone object
 	 * @return false|static
 	 */
 	public static function createFromTimestamp(int $timestamp, DateTimeZone|string|null $timeZone = null)
@@ -80,8 +68,6 @@ trait TimeTrait
 	/**
 	 * Returns a new instance according to the specified DOS timestamp.
 	 *
-	 * @param  int                       $timestamp DOS timestamp
-	 * @param  \DateTimeZone|string|null $timeZone  A valid time zone or a DateTimeZone object
 	 * @return false|static
 	 */
 	public static function createFromDOSTimestamp(int $timestamp, DateTimeZone|string|null $timeZone = null)
@@ -101,9 +87,6 @@ trait TimeTrait
 	/**
 	 * Returns a new instance according to the specified time string.
 	 *
-	 * @param  string                    $format   The format that the passed in string should be in
-	 * @param  string                    $time     String representing the time
-	 * @param  \DateTimeZone|string|null $timeZone A valid time zone or a DateTimeZone object
 	 * @return false|static
 	 */
 	#[\ReturnTypeWillChange]
@@ -129,7 +112,6 @@ trait TimeTrait
 	/**
 	 * Sets the time zone.
 	 *
-	 * @param  \DateTimeZone|string $timeZone A valid time zone or a DateTimeZone object
 	 * @return $this|false|static
 	 */
 	#[\ReturnTypeWillChange]
@@ -146,7 +128,6 @@ trait TimeTrait
 	/**
 	 * Move forward in time by x seconds.
 	 *
-	 * @param  int                $seconds Number of seconds
 	 * @return $this|false|static
 	 */
 	public function forward(int $seconds)
@@ -157,7 +138,6 @@ trait TimeTrait
 	/**
 	 * Move backward in time by x seconds.
 	 *
-	 * @param  int                $seconds Number of seconds
 	 * @return $this|false|static
 	 */
 	public function rewind(int $seconds)
@@ -167,8 +147,6 @@ trait TimeTrait
 
 	/**
 	 * Returns the DOS timestamp.
-	 *
-	 * @return int
 	 */
 	public function getDOSTimestamp(): int
 	{
@@ -189,8 +167,6 @@ trait TimeTrait
 
 	/**
 	 * Returns TRUE if the year is a leap year and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isLeapYear(): bool
 	{
@@ -206,8 +182,6 @@ trait TimeTrait
 
 	/**
 	 * Returns an array containing the number of days in each month of the year.
-	 *
-	 * @return array
 	 */
 	public function daysInMonths(): array
 	{
@@ -230,8 +204,6 @@ trait TimeTrait
 
 	/**
 	 * Returns the number of days in the current or specified month.
-	 *
-	 * @return int
 	 */
 	public function daysInMonth(): int
 	{

--- a/src/mako/classes/ClassFinder.php
+++ b/src/mako/classes/ClassFinder.php
@@ -68,7 +68,7 @@ class ClassFinder
 	 *
 	 * @return $this
 	 */
-	public function includeClasses()
+	public function includeClasses(): static
 	{
 		$this->includeClasses = true;
 
@@ -80,7 +80,7 @@ class ClassFinder
 	 *
 	 * @return $this
 	 */
-	public function excludeClasses()
+	public function excludeClasses(): static
 	{
 		$this->includeClasses = false;
 
@@ -92,7 +92,7 @@ class ClassFinder
 	 *
 	 * @return $this
 	 */
-	public function includeAbstractClasses()
+	public function includeAbstractClasses(): static
 	{
 		$this->includeAbstractClasses = true;
 
@@ -104,7 +104,7 @@ class ClassFinder
 	 *
 	 * @return $this
 	 */
-	public function excludeAbstractClasses()
+	public function excludeAbstractClasses(): static
 	{
 		$this->includeAbstractClasses = false;
 
@@ -116,7 +116,7 @@ class ClassFinder
 	 *
 	 * @return $this
 	 */
-	public function includeInterfaces()
+	public function includeInterfaces(): static
 	{
 		$this->includeInterfaces = true;
 
@@ -128,7 +128,7 @@ class ClassFinder
 	 *
 	 * @return $this
 	 */
-	public function excludeInterfaces()
+	public function excludeInterfaces(): static
 	{
 		$this->includeInterfaces = false;
 
@@ -140,7 +140,7 @@ class ClassFinder
 	 *
 	 * @return $this
 	 */
-	public function includeTraits()
+	public function includeTraits(): static
 	{
 		$this->includeTraits = true;
 
@@ -152,7 +152,7 @@ class ClassFinder
 	 *
 	 * @return $this
 	 */
-	public function excludeTraits()
+	public function excludeTraits(): static
 	{
 		$this->includeTraits = false;
 

--- a/src/mako/classes/ClassFinder.php
+++ b/src/mako/classes/ClassFinder.php
@@ -32,36 +32,26 @@ class ClassFinder
 
 	/**
 	 * Should classes be included?
-	 *
-	 * @var bool
 	 */
-	protected $includeClasses = true;
+	protected bool $includeClasses = true;
 
 	/**
 	 * Should abstract classes be included?
-	 *
-	 * @var bool
 	 */
-	protected $includeAbstractClasses = true;
+	protected bool $includeAbstractClasses = true;
 
 	/**
 	 * Should interfaces be included?
-	 *
-	 * @var bool
 	 */
-	protected $includeInterfaces = true;
+	protected bool $includeInterfaces = true;
 
 	/**
 	 * Should traits be included?
-	 *
-	 * @var bool
 	 */
-	protected $includeTraits = true;
+	protected bool $includeTraits = true;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\file\Finder $finder Finder instance
 	 */
 	public function __construct(
 		protected Finder $finder
@@ -171,8 +161,6 @@ class ClassFinder
 
 	/**
 	 * Returns the tokens we're searching for.
-	 *
-	 * @return array
 	 */
 	protected function getAllowedClasslikeTokens(): array
 	{
@@ -198,9 +186,6 @@ class ClassFinder
 
 	/**
 	 * Finds the class in a PHP file.
-	 *
-	 * @param  string      $path Path to PHP file
-	 * @return string|null
 	 */
 	protected function findClassInFile(string $path): ?string
 	{
@@ -248,8 +233,6 @@ class ClassFinder
 
 	/**
 	 * Returns all the classes.
-	 *
-	 * @return \Generator
 	 */
 	protected function findClasses(): Generator
 	{
@@ -265,8 +248,6 @@ class ClassFinder
 
 	/**
 	 * Returns all the classes.
-	 *
-	 * @return \Generator
 	 */
 	public function find(): Generator
 	{
@@ -275,9 +256,6 @@ class ClassFinder
 
 	/**
 	 * Returns all the classes implementing the interface.
-	 *
-	 * @param  string     $interfaceName Interface name
-	 * @return \Generator
 	 */
 	public function findImplementing(string $interfaceName): Generator
 	{
@@ -292,9 +270,6 @@ class ClassFinder
 
 	/**
 	 * Returns all the classes extending the class.
-	 *
-	 * @param  string     $className Class name
-	 * @return \Generator
 	 */
 	public function findExtending(string $className): Generator
 	{
@@ -309,9 +284,6 @@ class ClassFinder
 
 	/**
 	 * Returns all the classes using the trait.
-	 *
-	 * @param  string     $traitName Trait name
-	 * @return \Generator
 	 */
 	public function findUsing(string $traitName): Generator
 	{

--- a/src/mako/classes/ClassInspector.php
+++ b/src/mako/classes/ClassInspector.php
@@ -20,10 +20,6 @@ class ClassInspector
 {
 	/**
 	 * Returns an array of all the parent classes of the class.
-	 *
-	 * @param  object|string $class    Class name or class instance
-	 * @param  bool          $autoload Should the class be autoloaded?
-	 * @return array
 	 */
 	public static function getParents(object|string $class, bool $autoload = true): array
 	{
@@ -32,10 +28,6 @@ class ClassInspector
 
 	/**
 	 * Returns an array of all the interfaces that the class implements.
-	 *
-	 * @param  object|string $class    Class name or class instance
-	 * @param  bool          $autoload Should the class be autoloaded?
-	 * @return array
 	 */
 	public static function getInterfaces(object|string $class, bool $autoload = true): array
 	{
@@ -44,10 +36,6 @@ class ClassInspector
 
 	/**
 	 * Returns an array of all traits used by the class.
-	 *
-	 * @param  object|string $class    Class name or class instance
-	 * @param  bool          $autoload Should the class be autoloaded?
-	 * @return array
 	 */
 	public static function getTraits(object|string $class, bool $autoload = true): array
 	{

--- a/src/mako/classes/preload/PreloaderGenerator.php
+++ b/src/mako/classes/preload/PreloaderGenerator.php
@@ -29,10 +29,8 @@ class PreloaderGenerator
 {
 	/**
 	 * Preloader template.
-	 *
-	 * @var string
 	 */
-	protected $template = <<<'EOF'
+	protected string $template = <<<'EOF'
 	<?php
 
 	$files = %s;
@@ -46,9 +44,6 @@ class PreloaderGenerator
 
 	/**
 	 * Get class names from reflection type.
-	 *
-	 * @param  \ReflectionType $type Reflection type
-	 * @return array
 	 */
 	protected function getTypeClasses(ReflectionType $type): array
 	{
@@ -102,9 +97,6 @@ class PreloaderGenerator
 
 	/**
 	 * Adds missing user defined dependencies to the class array.
-	 *
-	 * @param  iterable $classes An iterable of class names
-	 * @return array
 	 */
 	protected function addMissingDependencies(iterable $classes): array
 	{
@@ -193,9 +185,6 @@ class PreloaderGenerator
 
 	/**
 	 * Returns an array containing the file paths of the provided classes.
-	 *
-	 * @param  array $classes An array of class names
-	 * @return array
 	 */
 	protected function getClassFilePaths(array $classes): array
 	{
@@ -204,9 +193,6 @@ class PreloaderGenerator
 
 	/**
 	 * Generates a preloader.
-	 *
-	 * @param  iterable $classes An iterable of class names
-	 * @return string
 	 */
 	public function generatePreloader(iterable $classes): string
 	{

--- a/src/mako/cli/Environment.php
+++ b/src/mako/cli/Environment.php
@@ -33,15 +33,11 @@ class Environment
 
 	/**
 	 * Do we have ANSI support?
-	 *
-	 * @var bool
 	 */
-	protected $hasAnsiSupport;
+	protected bool|null $hasAnsiSupport = null;
 
 	/**
 	 * Attempts to get dimensions for Windows.
-	 *
-	 * @return array|null
 	 */
 	protected function getDimensionsForWindows(): ?array
 	{
@@ -50,8 +46,6 @@ class Environment
 
 	/**
 	 * Attempts to get dimensions for Unix-like platforms.
-	 *
-	 * @return array|null
 	 */
 	protected function getDimensionsForUnixLike(): ?array
 	{
@@ -78,8 +72,6 @@ class Environment
 
 	/**
 	 * Returns the console dimensions (width & height).
-	 *
-	 * @return array
 	 */
 	public function getDimensions(): array
 	{
@@ -90,8 +82,6 @@ class Environment
 
 	/**
 	 * Returns the console width.
-	 *
-	 * @return int
 	 */
 	public function getWidth(): int
 	{
@@ -100,8 +90,6 @@ class Environment
 
 	/**
 	 * Returns the console height.
-	 *
-	 * @return int
 	 */
 	public function getHeight(): int
 	{
@@ -110,8 +98,6 @@ class Environment
 
 	/**
 	 * Do we have ANSI support?
-	 *
-	 * @return bool
 	 */
 	public function hasAnsiSupport(): bool
 	{

--- a/src/mako/cli/input/Input.php
+++ b/src/mako/cli/input/Input.php
@@ -17,9 +17,6 @@ class Input
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\input\reader\ReaderInterface $reader    Reader instance
-	 * @param \mako\cli\input\arguments\ArgvParser   $arguments Argument parser
 	 */
 	public function __construct(
 		protected ReaderInterface $reader,
@@ -29,8 +26,6 @@ class Input
 
 	/**
 	 * Reads and returns user input.
-	 *
-	 * @return string
 	 */
 	public function read(): string
 	{
@@ -39,8 +34,6 @@ class Input
 
 	/**
 	 * Returns the argument parser.
-	 *
-	 * @return \mako\cli\input\arguments\ArgvParser
 	 */
 	public function getArgumentParser(): ArgvParser
 	{
@@ -49,8 +42,6 @@ class Input
 
 	/**
 	 * Returns all the arguments passed to the script.
-	 *
-	 * @return array
 	 */
 	public function getArguments(): array
 	{
@@ -59,10 +50,6 @@ class Input
 
 	/**
 	 * Returns the argument associated with the given name.
-	 *
-	 * @param  int|string $name    Parameter number or name
-	 * @param  mixed      $default Default value
-	 * @return mixed
 	 */
 	public function getArgument(int|string $name, mixed $default = null): mixed
 	{

--- a/src/mako/cli/input/arguments/Argument.php
+++ b/src/mako/cli/input/arguments/Argument.php
@@ -75,39 +75,26 @@ class Argument
 
 	/**
 	 * Argument alias.
-	 *
-	 * @var string|null
 	 */
-	protected $alias;
+	protected string|null $alias = null;
 
 	/**
 	 * Is the argument positional?
-	 *
-	 * @var bool
 	 */
-	protected $isPositional;
+	protected bool $isPositional;
 
 	/**
 	 * Argument options.
-	 *
-	 * @var int
 	 */
-	protected $options;
+	protected int $options;
 
 	/**
 	 * Default value.
-	 *
-	 * @var mixed
 	 */
-	protected $default;
+	protected mixed $default;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array|string $name        Argument name
-	 * @param string       $description Argument description
-	 * @param int          $options     Argument options
-	 * @param mixed        $default     Default return value (only used by optional arguments)
 	 */
 	public function __construct(
 		protected array|string $name,
@@ -138,8 +125,6 @@ class Argument
 
 	/**
 	 * Gets the default return value.
-	 *
-	 * @return mixed
 	 */
 	public function getDefaultValue(): mixed
 	{
@@ -148,9 +133,6 @@ class Argument
 
 	/**
 	 * Returns a validated argument name.
-	 *
-	 * @param  string $name Argument name
-	 * @return string
 	 */
 	protected function getValidatedName(string $name): string
 	{
@@ -164,9 +146,6 @@ class Argument
 
 	/**
 	 * Returns a validated alias.
-	 *
-	 * @param  string $alias Alias
-	 * @return string
 	 */
 	protected function getValidatedAlias(string $alias): string
 	{
@@ -180,9 +159,6 @@ class Argument
 
 	/**
 	 * Parse the argument name.
-	 *
-	 * @param  array|string $name Argument name
-	 * @return array
 	 */
 	protected function parseName(array|string $name): array
 	{
@@ -198,9 +174,6 @@ class Argument
 
 	/**
 	 * Returns validated options.
-	 *
-	 * @param  int $options Argument options
-	 * @return int
 	 */
 	protected function getValidatedOptions(int $options): int
 	{
@@ -234,8 +207,6 @@ class Argument
 
 	/**
 	 * Returns the argument name.
-	 *
-	 * @return string
 	 */
 	public function getName(): string
 	{
@@ -244,8 +215,6 @@ class Argument
 
 	/**
 	 * Returns the normalized argument name.
-	 *
-	 * @return string
 	 */
 	public function getNormalizedName(): string
 	{
@@ -254,8 +223,6 @@ class Argument
 
 	/**
 	 * Returns the argument alias.
-	 *
-	 * @return string|null
 	 */
 	public function getAlias(): ?string
 	{
@@ -264,8 +231,6 @@ class Argument
 
 	/**
 	 * Returns the argument description.
-	 *
-	 * @return string
 	 */
 	public function getDescription(): string
 	{
@@ -274,8 +239,6 @@ class Argument
 
 	/**
 	 * Is the argument positional?
-	 *
-	 * @return bool
 	 */
 	public function isPositional(): bool
 	{
@@ -284,8 +247,6 @@ class Argument
 
 	/**
 	 * Is the argument an integer?
-	 *
-	 * @return bool
 	 */
 	public function isInt(): bool
 	{
@@ -294,8 +255,6 @@ class Argument
 
 	/**
 	 * Is the argument a float?
-	 *
-	 * @return bool
 	 */
 	public function isFloat(): bool
 	{
@@ -304,8 +263,6 @@ class Argument
 
 	/**
 	 * Is the argument a boolean?
-	 *
-	 * @return bool
 	 */
 	public function isBool(): bool
 	{
@@ -314,8 +271,6 @@ class Argument
 
 	/**
 	 * Is the argument an array?
-	 *
-	 * @return bool
 	 */
 	public function isArray(): bool
 	{
@@ -324,8 +279,6 @@ class Argument
 
 	/**
 	 * Is the argument optional?
-	 *
-	 * @return bool
 	 */
 	public function isOptional(): bool
 	{

--- a/src/mako/cli/input/arguments/ArgvParser.php
+++ b/src/mako/cli/input/arguments/ArgvParser.php
@@ -46,44 +46,31 @@ class ArgvParser
 
 	/**
 	 * Arguments.
-	 *
-	 * @var array
 	 */
-	protected $arguments = [];
+	protected array $arguments = [];
 
 	/**
 	 * Map.
-	 *
-	 * @var array
 	 */
-	protected $map = [];
+	protected array $map = [];
 
 	/**
 	 * Positional arguments.
-	 *
-	 * @var array
 	 */
-	protected $positionals = [];
+	protected array $positionals = [];
 
 	/**
 	 * Parsed arguments.
-	 *
-	 * @var array
 	 */
-	protected $parsed = [];
+	protected array $parsed = [];
 
 	/**
 	 * Should unknown arguments be ignored?
-	 *
-	 * @var bool
 	 */
-	protected $ignoreUnknownArguments = false;
+	protected bool $ignoreUnknownArguments = false;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array $argv      Argv
-	 * @param array $arguments Array of arguments
 	 */
 	public function __construct(
 		protected array $argv,
@@ -95,8 +82,6 @@ class ArgvParser
 
 	/**
 	 * Returns the registered arguments.
-	 *
-	 * @return array
 	 */
 	public function getArguments(): array
 	{
@@ -105,9 +90,6 @@ class ArgvParser
 
 	/**
 	 * Tries to find a suggestion for the invalid argument name.
-	 *
-	 * @param  string      $name Invalid argument name
-	 * @return string|null
 	 */
 	protected function findArgumentSuggestion(string $name): ?string
 	{
@@ -116,9 +98,6 @@ class ArgvParser
 
 	/**
 	 * Returns an argument based on its name.
-	 *
-	 * @param  string                                  $name Argument name
-	 * @return \mako\cli\input\arguments\Argument|null
 	 */
 	protected function getArgument(string $name): ?Argument
 	{
@@ -137,8 +116,6 @@ class ArgvParser
 
 	/**
 	 * Clears the parsed argument cache.
-	 *
-	 * @return \mako\cli\input\arguments\ArgvParser
 	 */
 	public function clearCache(): ArgvParser
 	{
@@ -149,8 +126,6 @@ class ArgvParser
 
 	/**
 	 * Add argument.
-	 *
-	 * @param \mako\cli\input\arguments\Argument $argument Argument
 	 */
 	public function addArgument(Argument $argument): void
 	{
@@ -197,8 +172,6 @@ class ArgvParser
 
 	/**
 	 * Add arguments.
-	 *
-	 * @param array $arguments Array of arguments
 	 */
 	public function addArguments(array $arguments): void
 	{
@@ -210,11 +183,6 @@ class ArgvParser
 
 	/**
 	 * Casts the value to the desired type.
-	 *
-	 * @param  \mako\cli\input\arguments\Argument $argument Argument
-	 * @param  string|null                        $token    Token
-	 * @param  bool|string                        $value    Value
-	 * @return bool|float|int|string
 	 */
 	protected function castValue(Argument $argument, ?string $token, bool|string $value): bool|float|int|string
 	{
@@ -242,10 +210,6 @@ class ArgvParser
 
 	/**
 	 * Store the value.
-	 *
-	 * @param \mako\cli\input\arguments\Argument $argument Argument
-	 * @param string|null                        $token    Token
-	 * @param bool|string|null                   $value    Value
 	 */
 	protected function storeValue(Argument $argument, ?string $token, bool|string|null $value): void
 	{
@@ -268,11 +232,6 @@ class ArgvParser
 
 	/**
 	 * Stores option values.
-	 *
-	 * @param \mako\cli\input\arguments\Argument $argument Argument
-	 * @param string                             $token    Token
-	 * @param string|null                        $value    Value
-	 * @param array                              &$tokens  Remaining tokens
 	 */
 	protected function storeOptionValue(Argument $argument, string $token, ?string $value, array &$tokens): void
 	{
@@ -298,9 +257,6 @@ class ArgvParser
 
 	/**
 	 * Parses an option.
-	 *
-	 * @param string $token   Token
-	 * @param array  &$tokens Remaining tokens
 	 */
 	protected function parseOption(string $token, array &$tokens): void
 	{
@@ -321,9 +277,6 @@ class ArgvParser
 
 	/**
 	 * Parses an alias.
-	 *
-	 * @param string $token   Token
-	 * @param array  &$tokens Remaining tokens
 	 */
 	protected function parseAlias(string $token, array &$tokens): void
 	{
@@ -356,11 +309,6 @@ class ArgvParser
 
 	/**
 	 * Parses a positional argument.
-	 *
-	 * @param string $token        Token
-	 * @param array  &$positionals Remaining positional arguments
-	 * @param array  &$tokens      Remaining tokens
-	 * @param bool   $parseOptions Are we still parsing options?
 	 */
 	protected function parsePositional(string $token, array &$positionals, array &$tokens, bool $parseOptions): void
 	{
@@ -391,9 +339,6 @@ class ArgvParser
 
 	/**
 	 * Parses the arguments.
-	 *
-	 * @param  bool  $ignoreUnknownArguments Should unknown arguments be ignored?
-	 * @return array
 	 */
 	public function parse(bool $ignoreUnknownArguments = false): array
 	{
@@ -451,11 +396,6 @@ class ArgvParser
 
 	/**
 	 * Returns the value of a parsed argument.
-	 *
-	 * @param  string $argument               Argument name
-	 * @param  mixed  $default                Default value
-	 * @param  bool   $ignoreUnknownArguments Should unknown arguments be ignored?
-	 * @return mixed
 	 */
 	public function getArgumentValue(string $argument, mixed $default = null, bool $ignoreUnknownArguments = false): mixed
 	{

--- a/src/mako/cli/input/arguments/exceptions/InvalidArgumentException.php
+++ b/src/mako/cli/input/arguments/exceptions/InvalidArgumentException.php
@@ -16,11 +16,6 @@ class InvalidArgumentException extends ArgumentException
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param string          $message    The Exception message to throw
-	 * @param string|null     $suggestion Suggestion
-	 * @param int             $code       The Exception code
-	 * @param \Throwable|null $previous   The previous exception used for the exception chaining
 	 */
 	public function __construct(string $message, ?string $suggestion = null, int $code = 0, ?Throwable $previous = null)
 	{

--- a/src/mako/cli/input/helpers/Confirmation.php
+++ b/src/mako/cli/input/helpers/Confirmation.php
@@ -20,9 +20,6 @@ class Confirmation extends Question
 {
 	/**
 	 * Returns an array where all array keys lower case.
-	 *
-	 * @param  array $array Array
-	 * @return array
 	 */
 	protected function normalizeKeys(array $array): array
 	{
@@ -38,10 +35,6 @@ class Confirmation extends Question
 
 	/**
 	 * Returns a slash-separated list of valid options where the default one is highlighted as upper-case.
-	 *
-	 * @param  array  $options Answer options
-	 * @param  string $default Default answer
-	 * @return string
 	 */
 	protected function getOptions(array $options, string $default): string
 	{
@@ -57,11 +50,6 @@ class Confirmation extends Question
 
 	/**
 	 * Asks user for confirmation and returns value corresponding to the chosen value.
-	 *
-	 * @param  string     $question Question to ask
-	 * @param  string     $default  Default answer
-	 * @param  array|null $options  Answer options
-	 * @return bool
 	 */
 	public function ask(string $question, $default = 'n', ?array $options = null): mixed
 	{

--- a/src/mako/cli/input/helpers/Question.php
+++ b/src/mako/cli/input/helpers/Question.php
@@ -19,9 +19,6 @@ class Question
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\input\Input   $input  Input instance
-	 * @param \mako\cli\output\Output $output Output instance
 	 */
 	public function __construct(
 		protected Input $input,
@@ -31,10 +28,6 @@ class Question
 
 	/**
 	 * Writes question to output and returns user input.
-	 *
-	 * @param  string $question Question to ask
-	 * @param  mixed  $default  Default if no input is entered
-	 * @return mixed
 	 */
 	public function ask(string $question, mixed $default = null): mixed
 	{

--- a/src/mako/cli/input/helpers/Secret.php
+++ b/src/mako/cli/input/helpers/Secret.php
@@ -21,15 +21,11 @@ class Secret extends Question
 {
 	/**
 	 * Do we have stty support?
-	 *
-	 * @var bool
 	 */
-	protected static $hasStty;
+	protected static bool $hasStty;
 
 	/**
 	 * Do we have stty support?
-	 *
-	 * @return bool
 	 */
 	protected function hasStty(): bool
 	{
@@ -45,11 +41,6 @@ class Secret extends Question
 
 	/**
 	 * Writes question to output and returns hidden user input.
-	 *
-	 * @param  string $question Question to ask
-	 * @param  mixed  $default  Default if no input is entered
-	 * @param  bool   $fallback Fall back to non-hidden input?
-	 * @return mixed
 	 */
 	public function ask(string $question, mixed $default = null, bool $fallback = false): mixed
 	{

--- a/src/mako/cli/input/helpers/Select.php
+++ b/src/mako/cli/input/helpers/Select.php
@@ -20,9 +20,6 @@ class Select
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\input\Input   $input  Input instance
-	 * @param \mako\cli\output\Output $output Output instance
 	 */
 	public function __construct(
 		protected Input $input,
@@ -32,9 +29,6 @@ class Select
 
 	/**
 	 * Returns a list of options.
-	 *
-	 * @param  array  $options Options
-	 * @return string
 	 */
 	protected function buildOptionsList(array $options): string
 	{
@@ -50,10 +44,6 @@ class Select
 
 	/**
 	 * Prints out a list of options and returns the array key of the chosen value.
-	 *
-	 * @param  string $question Question to ask
-	 * @param  array  $options  Numeric array of options to choose from
-	 * @return int
 	 */
 	public function ask(string $question, array $options): int
 	{

--- a/src/mako/cli/input/reader/ReaderInterface.php
+++ b/src/mako/cli/input/reader/ReaderInterface.php
@@ -14,8 +14,6 @@ interface ReaderInterface
 {
 	/**
 	 * Reads and returns user input.
-	 *
-	 * @return string
 	 */
 	public function read(): string;
 }

--- a/src/mako/cli/output/Output.php
+++ b/src/mako/cli/output/Output.php
@@ -34,18 +34,11 @@ class Output
 
 	/**
 	 * Is the output muted?
-	 *
-	 * @var bool
 	 */
-	protected $muted = false;
+	protected bool $muted = false;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\output\writer\WriterInterface            $standard    Standard writer
-	 * @param \mako\cli\output\writer\WriterInterface            $error       Error writer
-	 * @param \mako\cli\output\formatter\FormatterInterface|null $formatter   Formatter
-	 * @param \mako\cli\Environment                              $environment Environment
 	 */
 	public function __construct(
 		protected WriterInterface $standard,
@@ -57,9 +50,6 @@ class Output
 
 	/**
 	 * Returns the chosen writer.
-	 *
-	 * @param  int                                     $writer Writer
-	 * @return \mako\cli\output\writer\WriterInterface
 	 */
 	public function getWriter(int $writer = Output::STANDARD): WriterInterface
 	{
@@ -68,8 +58,6 @@ class Output
 
 	/**
 	 * Sets the formatter.
-	 *
-	 * @param \mako\cli\output\formatter\FormatterInterface $formatter Formatter
 	 */
 	public function setFormatter(FormatterInterface $formatter): void
 	{
@@ -78,8 +66,6 @@ class Output
 
 	/**
 	 * Returns the formatter.
-	 *
-	 * @return \mako\cli\output\formatter\FormatterInterface|null
 	 */
 	public function getFormatter(): ?FormatterInterface
 	{
@@ -88,8 +74,6 @@ class Output
 
 	/**
 	 * Returns the environment.
-	 *
-	 * @return \mako\cli\Environment
 	 */
 	public function getEnvironment(): Environment
 	{
@@ -114,8 +98,6 @@ class Output
 
 	/**
 	 * Is the output muted?
-	 *
-	 * @return bool
 	 */
 	public function isMuted(): bool
 	{
@@ -124,9 +106,6 @@ class Output
 
 	/**
 	 * Writes string to output.
-	 *
-	 * @param string $string String to write
-	 * @param int    $writer Output type
 	 */
 	public function write(string $string, int $writer = Output::STANDARD): void
 	{
@@ -152,8 +131,6 @@ class Output
 
 	/**
 	 * Writes string to output using the error writer.
-	 *
-	 * @param string $string String to write
 	 */
 	public function error(string $string): void
 	{
@@ -162,9 +139,6 @@ class Output
 
 	/**
 	 * Appends newline to string and writes it to output.
-	 *
-	 * @param string $string String to write
-	 * @param int    $writer Output type
 	 */
 	public function writeLn(string $string, int $writer = Output::STANDARD): void
 	{
@@ -173,8 +147,6 @@ class Output
 
 	/**
 	 * Appends newline to string and writes it to output using the error writer.
-	 *
-	 * @param string $string String to write
 	 */
 	public function errorLn(string $string): void
 	{
@@ -183,9 +155,6 @@ class Output
 
 	/**
 	 * Dumps a value to the output.
-	 *
-	 * @param mixed $value  Value
-	 * @param int   $writer Output type
 	 */
 	public function dump(mixed $value, int $writer = Output::STANDARD): void
 	{
@@ -216,8 +185,6 @@ class Output
 
 	/**
 	 * Clears n lines.
-	 *
-	 * @param int $lines Number of lines to clear
 	 */
 	public function clearLines(int $lines): void
 	{

--- a/src/mako/cli/output/formatter/Formatter.php
+++ b/src/mako/cli/output/formatter/Formatter.php
@@ -49,10 +49,8 @@ class Formatter implements FormatterInterface
 
 	/**
 	 * Styles.
-	 *
-	 * @var array
 	 */
-	protected $styles =
+	protected array $styles =
 	[
 		// Clear styles
 
@@ -92,23 +90,16 @@ class Formatter implements FormatterInterface
 
 	/**
 	 * User styles.
-	 *
-	 * @var array
 	 */
-	protected $userStyles = [];
+	protected array $userStyles = [];
 
 	/**
 	 * Open tags.
-	 *
-	 * @var array
 	 */
-	protected $openTags = [];
+	protected array $openTags = [];
 
 	/**
 	 * Adds a user defined style.
-	 *
-	 * @param string       $name  Style name
-	 * @param array|string $style Style or array of styles
 	 */
 	public function addStyle(string $name, array|string $style): void
 	{
@@ -117,9 +108,6 @@ class Formatter implements FormatterInterface
 
 	/**
 	 * Returns the tag name.
-	 *
-	 * @param  string $tag Tag
-	 * @return string
 	 */
 	protected function getTagName(string $tag): string
 	{
@@ -128,9 +116,6 @@ class Formatter implements FormatterInterface
 
 	/**
 	 * Returns TRUE if the tag is a closing tag and FALSE if not.
-	 *
-	 * @param  string $tag Tag to check
-	 * @return bool
 	 */
 	protected function isOpeningTag(string $tag): bool
 	{
@@ -139,8 +124,6 @@ class Formatter implements FormatterInterface
 
 	/**
 	 * Returns ANSI SGR escape sequence for style reset.
-	 *
-	 * @return string
 	 */
 	protected function getSgrResetSequence(): string
 	{
@@ -149,9 +132,6 @@ class Formatter implements FormatterInterface
 
 	/**
 	 * Returns style codes associated with the tag name.
-	 *
-	 * @param  string $tag Tag name
-	 * @return array
 	 */
 	protected function getStyleCodes(string $tag): array
 	{
@@ -176,9 +156,6 @@ class Formatter implements FormatterInterface
 
 	/**
 	 * Returns ANSI SGR escape sequence for the chosen style(s).
-	 *
-	 * @param  string $tag Style name
-	 * @return string
 	 */
 	protected function getSgrStyleSequence(string $tag): string
 	{
@@ -190,9 +167,6 @@ class Formatter implements FormatterInterface
 	/**
 	 * Returns ANSI SGR escape sequence(s) for the chosen style(s) and
 	 * adds the tag name to the array of open tags.
-	 *
-	 * @param  string $tag Tag name
-	 * @return string
 	 */
 	protected function openStyle(string $tag): string
 	{
@@ -204,9 +178,6 @@ class Formatter implements FormatterInterface
 	/**
 	 * Returns ANSI SGR escape sequence for style reset and
 	 * ANSI SGR escape sequence for parent style if the closed tag was nested.
-	 *
-	 * @param  string $tag Tag name
-	 * @return string
 	 */
 	protected function closeStyle(string $tag): string
 	{
@@ -240,9 +211,6 @@ class Formatter implements FormatterInterface
 
 	/**
 	 * Strips escape character from escaped tags.
-	 *
-	 * @param  string $string Input string
-	 * @return string
 	 */
 	protected function removeTagEscapeCharacter(string $string): string
 	{
@@ -313,9 +281,6 @@ class Formatter implements FormatterInterface
 
 	/**
 	 * Returns a string where all SGR sequences have been stripped.
-	 *
-	 * @param  string $string String to strip
-	 * @return string
 	 */
 	public function stripSGR(string $string): string
 	{

--- a/src/mako/cli/output/formatter/FormatterInterface.php
+++ b/src/mako/cli/output/formatter/FormatterInterface.php
@@ -14,25 +14,16 @@ interface FormatterInterface
 {
 	/**
 	 * Returns formatted string.
-	 *
-	 * @param  string $string String to format
-	 * @return string
 	 */
 	public function format(string $string): string;
 
 	/**
 	 * Returns a string where all formatting tags have been escaped.
-	 *
-	 * @param  string $string String to format
-	 * @return string
 	 */
 	public function escape(string $string): string;
 
 	/**
 	 * Returns a string where all formatting tags have been stripped.
-	 *
-	 * @param  string $string String to strip
-	 * @return string
 	 */
 	public function stripTags(string $string): string;
 }

--- a/src/mako/cli/output/helpers/Alert.php
+++ b/src/mako/cli/output/helpers/Alert.php
@@ -7,6 +7,7 @@
 
 namespace mako\cli\output\helpers;
 
+use mako\cli\output\formatter\FormatterInterface;
 use mako\cli\output\Output;
 
 use function explode;
@@ -66,23 +67,16 @@ class Alert
 
 	/**
 	 * Alert width.
-	 *
-	 * @var int
 	 */
-	protected $width;
+	protected int $width;
 
 	/**
 	 * Formatter.
-	 *
-	 * @var \mako\cli\output\formatter\FormatterInterface|null
 	 */
-	protected $formatter;
+	protected FormatterInterface|null $formatter = null;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\output\Output $output Output instance
-	 * @param int|null                $width  Alert width
 	 */
 	public function __construct(
 		protected Output $output,
@@ -96,10 +90,6 @@ class Alert
 
 	/**
 	 * Wraps a string to a given number of characters.
-	 *
-	 * @param  string $string String
-	 * @param  int    $width  Max line width
-	 * @return string
 	 */
 	protected function wordWrap(string $string, int $width): string
 	{
@@ -108,9 +98,6 @@ class Alert
 
 	/**
 	 * Escapes style tags if we have a formatter.
-	 *
-	 * @param  string $string string
-	 * @return string
 	 */
 	protected function escape(string $string): string
 	{
@@ -124,9 +111,6 @@ class Alert
 
 	/**
 	 * Formats the string.
-	 *
-	 * @param  string $string String
-	 * @return string
 	 */
 	protected function format(string $string): string
 	{
@@ -146,10 +130,6 @@ class Alert
 
 	/**
 	 * Renders an alert.
-	 *
-	 * @param  string $message  Message
-	 * @param  string $template Alert template
-	 * @return string
 	 */
 	public function render(string $message, string $template = Alert::DEFAULT): string
 	{
@@ -158,10 +138,6 @@ class Alert
 
 	/**
 	 * Draws an alert.
-	 *
-	 * @param string $message  Message
-	 * @param string $template Alert template
-	 * @param int    $writer   Output writer
 	 */
 	public function draw(string $message, string $template = Alert::DEFAULT, int $writer = Output::STANDARD): void
 	{

--- a/src/mako/cli/output/helpers/Bell.php
+++ b/src/mako/cli/output/helpers/Bell.php
@@ -18,8 +18,6 @@ class Bell
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\output\Output $output Output instance
 	 */
 	public function __construct(
 		protected Output $output
@@ -28,8 +26,6 @@ class Bell
 
 	/**
 	 * Rings the terminal bell n times.
-	 *
-	 * @param int $times Number of times to ring the bell
 	 */
 	public function ring(int $times = 1): void
 	{

--- a/src/mako/cli/output/helpers/Countdown.php
+++ b/src/mako/cli/output/helpers/Countdown.php
@@ -28,8 +28,6 @@ class Countdown
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\output\Output $output Output instance
 	 */
 	public function __construct(
 		protected Output $output
@@ -46,8 +44,6 @@ class Countdown
 
 	/**
 	 * Counts down from n.
-	 *
-	 * @param int $from Number of seconds to count down
 	 */
 	public function draw(int $from = 5): void
 	{

--- a/src/mako/cli/output/helpers/OrderedList.php
+++ b/src/mako/cli/output/helpers/OrderedList.php
@@ -7,6 +7,7 @@
 
 namespace mako\cli\output\helpers;
 
+use mako\cli\output\formatter\FormatterInterface;
 use mako\cli\output\Output;
 
 use function is_array;
@@ -21,22 +22,16 @@ class OrderedList
 {
 	/**
 	 * Padding.
-	 *
-	 * @var string
 	 */
-	protected $padding = '  ';
+	protected string $padding = '  ';
 
 	/**
 	 * Formatter instance.
-	 *
-	 * @var \mako\cli\output\formatter\FormatterInterface|null
 	 */
-	protected $formatter;
+	protected FormatterInterface|null $formatter = null;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\output\Output $output Output instance
 	 */
 	public function __construct(
 		protected Output $output
@@ -47,10 +42,6 @@ class OrderedList
 
 	/**
 	 * Calculates the maximum width of a marker in a list.
-	 *
-	 * @param  array  $items  Items
-	 * @param  string $marker Item marker
-	 * @return array
 	 */
 	protected function calculateWidth(array $items, string $marker): array
 	{
@@ -73,14 +64,6 @@ class OrderedList
 
 	/**
 	 * Builds a list item.
-	 *
-	 * @param  string $item         Item
-	 * @param  string $marker       Item marker
-	 * @param  int    $width        Item number width
-	 * @param  int    $number       Item number
-	 * @param  int    $nestingLevel Nesting level
-	 * @param  int    $parentWidth  Parent width
-	 * @return string
 	 */
 	protected function buildListItem(string $item, string $marker, int $width, int $number, int $nestingLevel, int $parentWidth): string
 	{
@@ -91,12 +74,6 @@ class OrderedList
 
 	/**
 	 * Builds an ordered list.
-	 *
-	 * @param  array  $items        Items
-	 * @param  string $marker       Item marker
-	 * @param  int    $nestingLevel Nesting level
-	 * @param  int    $parentWidth  Parent marker width
-	 * @return string
 	 */
 	protected function buildList(array $items, string $marker, int $nestingLevel = 0, int $parentWidth = 0): string
 	{
@@ -121,10 +98,6 @@ class OrderedList
 
 	/**
 	 * Renders an ordered list.
-	 *
-	 * @param  array  $items  Items
-	 * @param  string $marker Item marker
-	 * @return string
 	 */
 	public function render(array $items, string $marker = '%s.'): string
 	{
@@ -133,10 +106,6 @@ class OrderedList
 
 	/**
 	 * Draws an ordered list.
-	 *
-	 * @param array  $items  Items
-	 * @param string $marker Item marker
-	 * @param int    $writer Output writer
 	 */
 	public function draw(array $items, string $marker = '%s.', int $writer = Output::STANDARD): void
 	{

--- a/src/mako/cli/output/helpers/ProgressBar.php
+++ b/src/mako/cli/output/helpers/ProgressBar.php
@@ -25,59 +25,41 @@ class ProgressBar
 {
 	/**
 	 * Progressbar width.
-	 *
-	 * @var int
 	 */
-	protected $width = 20;
+	protected int $width = 20;
 
 	/**
 	 * String that represents the empty part of the progess bar.
-	 *
-	 * @var string
 	 */
-	protected $emptyTemplate = '-';
+	protected string $emptyTemplate = '-';
 
 	/**
 	 * String that represents the filled part of the progess bar.
-	 *
-	 * @var string
 	 */
-	protected $filledTemplate = '=';
+	protected string $filledTemplate = '=';
 
 	/**
 	 * Minimum time between redraw in seconds.
-	 *
-	 * @var float
 	 */
-	protected $minTimeBetweenRedraw;
+	protected float $minTimeBetweenRedraw;
 
 	/**
 	 * Time of last redraw.
-	 *
-	 * @var float
 	 */
-	protected $lastRedraw;
+	protected float|null $lastRedraw = null;
 
 	/**
 	 * Progress status.
-	 *
-	 * @var int
 	 */
-	protected $progress = 0;
+	protected int $progress = 0;
 
 	/**
 	 * Progress bar prefix.
-	 *
-	 * @var string
 	 */
-	protected $prefix;
+	protected string $prefix = '';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\output\Output $output               Output instance
-	 * @param int                     $items                Total number of items
-	 * @param float                   $minTimeBetweenRedraw Minimum time between redraw in seconds
 	 */
 	public function __construct(
 		protected Output $output,
@@ -90,8 +72,6 @@ class ProgressBar
 
 	/**
 	 * Sets the progress bar width.
-	 *
-	 * @param int $width Progress bar width
 	 */
 	public function setWidth(int $width): void
 	{
@@ -100,8 +80,6 @@ class ProgressBar
 
 	/**
 	 * Sets the string that represents the empty part of the progess bar.
-	 *
-	 * @param string $template Template
 	 */
 	public function setEmptyTemplate(string $template): void
 	{
@@ -110,8 +88,6 @@ class ProgressBar
 
 	/**
 	 * Sets the string that represents the filled part of the progess bar.
-	 *
-	 * @param string $template Template
 	 */
 	public function setFilledTemplate(string $template): void
 	{
@@ -120,8 +96,6 @@ class ProgressBar
 
 	/**
 	 * Sets the progress bar prefix.
-	 *
-	 * @param string $prefix Progress bar prefix
 	 */
 	public function setPrefix(string $prefix): void
 	{
@@ -130,9 +104,6 @@ class ProgressBar
 
 	/**
 	 * Builds the progressbar.
-	 *
-	 * @param  float  $percent Percent to fill
-	 * @return string
 	 */
 	protected function buildProgressBar(float $percent): string
 	{
@@ -179,8 +150,6 @@ class ProgressBar
 
 	/**
 	 * Return current unix timestamp with microseconds.
-	 *
-	 * @return float
 	 */
 	protected function getMicrotime(): float
 	{
@@ -189,8 +158,6 @@ class ProgressBar
 
 	/**
 	 * Should the progress bar be redrawn?
-	 *
-	 * @return bool
 	 */
 	protected function shouldRedraw(): bool
 	{

--- a/src/mako/cli/output/helpers/Table.php
+++ b/src/mako/cli/output/helpers/Table.php
@@ -8,6 +8,7 @@
 namespace mako\cli\output\helpers;
 
 use mako\cli\exceptions\CliException;
+use mako\cli\output\formatter\FormatterInterface;
 use mako\cli\output\helpers\traits\HelperTrait;
 use mako\cli\output\Output;
 
@@ -26,15 +27,11 @@ class Table
 
 	/**
 	 * Formatter.
-	 *
-	 * @var \mako\cli\output\formatter\FormatterInterface|null
 	 */
-	protected $formatter;
+	protected FormatterInterface|null $formatter = null;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\output\Output $output Output instance
 	 */
 	public function __construct(
 		protected Output $output
@@ -45,10 +42,6 @@ class Table
 
 	/**
 	 * Checks if the number of cells in each row matches the number of columns.
-	 *
-	 * @param  array $columnNames Array of column names
-	 * @param  array $rows        Array of rows
-	 * @return bool
 	 */
 	protected function isValidInput(array $columnNames, array $rows): bool
 	{
@@ -70,10 +63,6 @@ class Table
 
 	/**
 	 * Returns an array containing the maximum width of each column.
-	 *
-	 * @param  array $columnNames Array of column names
-	 * @param  array $rows        Array of rows
-	 * @return array
 	 */
 	protected function getColumnWidths(array $columnNames, array $rows): array
 	{
@@ -108,10 +97,6 @@ class Table
 
 	/**
 	 * Builds a row separator.
-	 *
-	 * @param  array  $columnWidths Array of column widths
-	 * @param  string $separator    Separator character
-	 * @return string
 	 */
 	protected function buildRowSeparator(array $columnWidths, string $separator = '-'): string
 	{
@@ -122,10 +107,6 @@ class Table
 
 	/**
 	 * Builds a table row.
-	 *
-	 * @param  array  $colums       Array of column values
-	 * @param  array  $columnWidths Array of column widths
-	 * @return string
 	 */
 	protected function buildTableRow(array $colums, array $columnWidths): string
 	{
@@ -141,10 +122,6 @@ class Table
 
 	/**
 	 * Renders a table.
-	 *
-	 * @param  array  $columnNames Array of column names
-	 * @param  array  $rows        Array of rows
-	 * @return string
 	 */
 	public function render(array $columnNames, array $rows): string
 	{
@@ -179,10 +156,6 @@ class Table
 
 	/**
 	 * Draws a table.
-	 *
-	 * @param array $columnNames Array of column names
-	 * @param array $rows        Array of rows
-	 * @param int   $writer      Output writer
 	 */
 	public function draw(array $columnNames, array $rows, int $writer = Output::STANDARD): void
 	{

--- a/src/mako/cli/output/helpers/UnorderedList.php
+++ b/src/mako/cli/output/helpers/UnorderedList.php
@@ -19,15 +19,11 @@ class UnorderedList
 {
 	/**
 	 * Padding.
-	 *
-	 * @var string
 	 */
-	protected $padding = '  ';
+	protected string $padding = '  ';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\output\Output $output Output instance
 	 */
 	public function __construct(
 		protected Output $output
@@ -36,11 +32,6 @@ class UnorderedList
 
 	/**
 	 * Builds a list item.
-	 *
-	 * @param  string $item         Item
-	 * @param  string $marker       Item marker
-	 * @param  int    $nestingLevel Nesting level
-	 * @return string
 	 */
 	protected function buildListItem(string $item, string $marker, int $nestingLevel): string
 	{
@@ -49,11 +40,6 @@ class UnorderedList
 
 	/**
 	 * Builds an unordered list.
-	 *
-	 * @param  array  $items        Items
-	 * @param  string $marker       Item marker
-	 * @param  int    $nestingLevel Nesting level
-	 * @return string
 	 */
 	protected function buildList(array $items, string $marker, int $nestingLevel = 0): string
 	{
@@ -76,10 +62,6 @@ class UnorderedList
 
 	/**
 	 * Renders an unordered list.
-	 *
-	 * @param  array  $items  Items
-	 * @param  string $marker Item marker
-	 * @return string
 	 */
 	public function render(array $items, string $marker = '*'): string
 	{
@@ -88,10 +70,6 @@ class UnorderedList
 
 	/**
 	 * Draws an unordered list.
-	 *
-	 * @param array  $items  Items
-	 * @param string $marker Item marker
-	 * @param int    $writer Output writer
 	 */
 	public function draw(array $items, string $marker = '*', int $writer = Output::STANDARD): void
 	{

--- a/src/mako/cli/output/helpers/traits/HelperTrait.php
+++ b/src/mako/cli/output/helpers/traits/HelperTrait.php
@@ -18,9 +18,6 @@ trait HelperTrait
 {
 	/**
 	 * Returns the width of the string without formatting.
-	 *
-	 * @param  string $string String to strip
-	 * @return int
 	 */
 	protected function stringWidthWithoutFormatting(string $string): int
 	{

--- a/src/mako/cli/output/writer/Writer.php
+++ b/src/mako/cli/output/writer/Writer.php
@@ -24,10 +24,8 @@ abstract class Writer implements WriterInterface
 
 	/**
 	 * Is the stream direct?
-	 *
-	 * @var bool
 	 */
-	protected $isDirect;
+	protected bool|null $isDirect = null;
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/cli/output/writer/WriterInterface.php
+++ b/src/mako/cli/output/writer/WriterInterface.php
@@ -21,15 +21,11 @@ interface WriterInterface
 
 	/**
 	 * Returns TRUE if the output isn't redirected or piped and FALSE in all other situations.
-	 *
-	 * @return bool
 	 */
 	public function isDirect(): bool;
 
 	/**
 	 * Writes output.
-	 *
-	 * @param string $string String to write
 	 */
 	public function write(string $string): void;
 }

--- a/src/mako/common/AdapterManager.php
+++ b/src/mako/common/AdapterManager.php
@@ -24,24 +24,16 @@ abstract class AdapterManager
 
 	/**
 	 * Extensions.
-	 *
-	 * @var array
 	 */
-	protected $extensions = [];
+	protected array $extensions = [];
 
 	/**
 	 * Connections.
-	 *
-	 * @var array
 	 */
-	protected $instances = [];
+	protected array $instances = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string                  $default        Default connection name
-	 * @param array                   $configurations Configurations
-	 * @param \mako\syringe\Container $container      Container
 	 */
 	public function __construct(
 		protected string $default,
@@ -52,9 +44,6 @@ abstract class AdapterManager
 
 	/**
 	 * Adds extension.
-	 *
-	 * @param string          $name    Adapter name
-	 * @param \Closure|string $adapter Adapter
 	 */
 	public function extend(string $name, Closure|string $adapter): void
 	{
@@ -63,10 +52,6 @@ abstract class AdapterManager
 
 	/**
 	 * Factory.
-	 *
-	 * @param  string $adapterName   Adapter name
-	 * @param  array  $configuration Adapter configuration
-	 * @return mixed
 	 */
 	protected function factory(string $adapterName, array $configuration = []): mixed
 	{
@@ -91,17 +76,11 @@ abstract class AdapterManager
 
 	/**
 	 * Returns a new adapter instance.
-	 *
-	 * @param  string $configuration Configuration name
-	 * @return mixed
 	 */
 	abstract protected function instantiate(string $configuration): mixed;
 
 	/**
 	 * Returns an instance of the chosen adapter configuration.
-	 *
-	 * @param  string|null $configuration Configuration name
-	 * @return mixed
 	 */
 	public function getInstance(?string $configuration = null): mixed
 	{
@@ -117,10 +96,6 @@ abstract class AdapterManager
 
 	/**
 	 * Magic shortcut to the default configuration.
-	 *
-	 * @param  string $name      Method name
-	 * @param  array  $arguments Method arguments
-	 * @return mixed
 	 */
 	public function __call(string $name, array $arguments): mixed
 	{

--- a/src/mako/common/ConnectionManager.php
+++ b/src/mako/common/ConnectionManager.php
@@ -23,24 +23,16 @@ abstract class ConnectionManager
 
 	/**
 	 * Connections.
-	 *
-	 * @var array
 	 */
-	protected $connections = [];
+	protected array $connections = [];
 
 	/**
 	 * Connects to the chosen configuration and returns the connection.
-	 *
-	 * @param  string $connection Connection name
-	 * @return mixed
 	 */
 	abstract protected function connect(string $connection): mixed;
 
 	/**
 	 * Returns the chosen connection.
-	 *
-	 * @param  string|null $connection Connection name
-	 * @return mixed
 	 */
 	public function getConnection(?string $connection = null): mixed
 	{
@@ -56,8 +48,6 @@ abstract class ConnectionManager
 
 	/**
 	 * Closes the chosen connection.
-	 *
-	 * @param string|null $connection Connection name
 	 */
 	public function close(?string $connection = null): void
 	{
@@ -79,10 +69,6 @@ abstract class ConnectionManager
 
 	/**
 	 * Executes the passed closure using the chosen connection before closing it.
-	 *
-	 * @param  \Closure    $closure    Closure to execute
-	 * @param  string|null $connection Connection name
-	 * @return mixed
 	 */
 	public function executeAndClose(Closure $closure, ?string $connection = null): mixed
 	{
@@ -96,8 +82,6 @@ abstract class ConnectionManager
 	/**
 	 * Removes a configuration.
 	 * It will also close and remove any active connection linked to the configuration.
-	 *
-	 * @param string $name Connection name
 	 */
 	public function removeConfiguration(string $name): void
 	{
@@ -108,10 +92,6 @@ abstract class ConnectionManager
 
 	/**
 	 * Magic shortcut to the default connection.
-	 *
-	 * @param  string $name      Method name
-	 * @param  array  $arguments Method arguments
-	 * @return mixed
 	 */
 	public function __call(string $name, array $arguments): mixed
 	{

--- a/src/mako/common/traits/ConfigurableTrait.php
+++ b/src/mako/common/traits/ConfigurableTrait.php
@@ -23,9 +23,6 @@ trait ConfigurableTrait
 
 	/**
 	 * Adds a configuration.
-	 *
-	 * @param string $name          Connection name
-	 * @param array  $configuration Configuration
 	 */
 	public function addConfiguration(string $name, array $configuration): void
 	{
@@ -35,8 +32,6 @@ trait ConfigurableTrait
 	/**
 	 * Removes a configuration.
 	 * It will also remove any active connection linked to the configuration.
-	 *
-	 * @param string $name Connection name
 	 */
 	public function removeConfiguration(string $name): void
 	{

--- a/src/mako/common/traits/ConfigurableTrait.php
+++ b/src/mako/common/traits/ConfigurableTrait.php
@@ -14,9 +14,6 @@ trait ConfigurableTrait
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param string $default        Default connection name
-	 * @param array  $configurations Configurations
 	 */
 	public function __construct(
 		protected string $default,

--- a/src/mako/common/traits/ExtendableTrait.php
+++ b/src/mako/common/traits/ExtendableTrait.php
@@ -19,16 +19,11 @@ trait ExtendableTrait
 {
 	/**
 	 * Class extensions.
-	 *
-	 * @var array
 	 */
-	protected static $_extensions;
+	protected static array $_extensions = [];
 
 	/**
 	 * Adds a method to the class.
-	 *
-	 * @param string   $methodName Method name
-	 * @param \Closure $closure    Closure
 	 */
 	public static function addMethod(string $methodName, Closure $closure): void
 	{
@@ -37,10 +32,6 @@ trait ExtendableTrait
 
 	/**
 	 * Executes class extensions.
-	 *
-	 * @param  string $name      Method name
-	 * @param  array  $arguments Method arguments
-	 * @return mixed
 	 */
 	public function __call(string $name, array $arguments): mixed
 	{
@@ -54,10 +45,6 @@ trait ExtendableTrait
 
 	/**
 	 * Executes class extensions.
-	 *
-	 * @param  string $name      Method name
-	 * @param  array  $arguments Method arguments
-	 * @return mixed
 	 */
 	public static function __callStatic(string $name, array $arguments): mixed
 	{

--- a/src/mako/common/traits/FunctionParserTrait.php
+++ b/src/mako/common/traits/FunctionParserTrait.php
@@ -22,9 +22,6 @@ trait FunctionParserTrait
 {
 	/**
 	 * Splits function name and parameters into an array.
-	 *
-	 * @param  string $function Function
-	 * @return array
 	 */
 	protected function splitFunctionAndParameters(string $function): array
 	{
@@ -38,12 +35,7 @@ trait FunctionParserTrait
 
 	/**
 	 * Parses custom "function calls".
-	 *
 	 * The return value is an array consisting of the function name and parameters.
-	 *
-	 * @param  string    $function        Function
-	 * @param  bool|null $namedParameters Are we expecting named parameters?
-	 * @return array
 	 */
 	protected function parseFunction(string $function, ?bool $namedParameters = null): array
 	{

--- a/src/mako/common/traits/NamespacedFileLoaderTrait.php
+++ b/src/mako/common/traits/NamespacedFileLoaderTrait.php
@@ -22,29 +22,21 @@ trait NamespacedFileLoaderTrait
 {
 	/**
 	 * Default path.
-	 *
-	 * @var string
 	 */
-	protected $path;
+	protected string $path = '';
 
 	/**
 	 * File extension.
-	 *
-	 * @var string
 	 */
-	protected $extension = '.php';
+	protected string $extension = '.php';
 
 	/**
 	 * Namespaces.
-	 *
-	 * @var array
 	 */
-	protected $namespaces = [];
+	protected array $namespaces = [];
 
 	/**
 	 * Sets the default path.
-	 *
-	 * @param string $path Path
 	 */
 	public function setPath(string $path): void
 	{
@@ -53,8 +45,6 @@ trait NamespacedFileLoaderTrait
 
 	/**
 	 * Sets the extension.
-	 *
-	 * @param string $extension Extension
 	 */
 	public function setExtension(string $extension): void
 	{
@@ -63,9 +53,6 @@ trait NamespacedFileLoaderTrait
 
 	/**
 	 * Registers a namespace.
-	 *
-	 * @param string $namespace Namespace name
-	 * @param string $path      Namespace path
 	 */
 	public function registerNamespace(string $namespace, string $path): void
 	{
@@ -74,11 +61,6 @@ trait NamespacedFileLoaderTrait
 
 	/**
 	 * Returns the path to the file.
-	 *
-	 * @param  string      $file      Filename
-	 * @param  string|null $extension File extension
-	 * @param  string|null $suffix    Path suffix
-	 * @return string
 	 */
 	protected function getFilePath(string $file, ?string $extension = null, ?string $suffix = null): string
 	{
@@ -116,11 +98,6 @@ trait NamespacedFileLoaderTrait
 
 	/**
 	 * Returns an array of cascading file paths.
-	 *
-	 * @param  string      $file      Filename
-	 * @param  string|null $extension File extension
-	 * @param  string|null $suffix    Path suffix
-	 * @return array
 	 */
 	protected function getCascadingFilePaths(string $file, ?string $extension = null, ?string $suffix = null): array
 	{

--- a/src/mako/common/traits/SuggestionTrait.php
+++ b/src/mako/common/traits/SuggestionTrait.php
@@ -17,10 +17,6 @@ trait SuggestionTrait
 	/**
 	 * Returns the string that resembles the provided string the most.
 	 * NULL is returned if no string with a similarity of 66% or more is found.
-	 *
-	 * @param  string      $string       String
-	 * @param  array       $alternatives Alternatives
-	 * @return string|null
 	 */
 	protected function suggest(string $string, array $alternatives): ?string
 	{

--- a/src/mako/config/Config.php
+++ b/src/mako/config/Config.php
@@ -20,16 +20,11 @@ class Config
 {
 	/**
 	 * Configuration.
-	 *
-	 * @var array
 	 */
-	protected $configuration = [];
+	protected array $configuration = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\config\loaders\LoaderInterface $loader      Config loader
-	 * @param string|null                          $environment Environment name
 	 */
 	public function __construct(
 		protected LoaderInterface $loader,
@@ -39,8 +34,6 @@ class Config
 
 	/**
 	 * Returns the config loader.
-	 *
-	 * @return \mako\config\loaders\LoaderInterface
 	 */
 	public function getLoader(): LoaderInterface
 	{
@@ -49,8 +42,6 @@ class Config
 
 	/**
 	 * Returns the currently loaded configuration.
-	 *
-	 * @return array
 	 */
 	public function getLoadedConfiguration(): array
 	{
@@ -59,8 +50,6 @@ class Config
 
 	/**
 	 * Sets the environment.
-	 *
-	 * @param string $environment Environment name
 	 */
 	public function setEnvironment(string $environment): void
 	{
@@ -69,9 +58,6 @@ class Config
 
 	/**
 	 * Parses the config key.
-	 *
-	 * @param  string $key Config key
-	 * @return array
 	 */
 	protected function parseKey(string $key): array
 	{
@@ -80,8 +66,6 @@ class Config
 
 	/**
 	 * Loads the configuration file.
-	 *
-	 * @param string $file Filename
 	 */
 	protected function load(string $file): void
 	{
@@ -90,10 +74,6 @@ class Config
 
 	/**
 	 * Returns config value or entire config array from a file.
-	 *
-	 * @param  string $key     Config key
-	 * @param  mixed  $default Default value to return if config value doesn't exist
-	 * @return mixed
 	 */
 	public function get(string $key, mixed $default = null): mixed
 	{
@@ -109,9 +89,6 @@ class Config
 
 	/**
 	 * Sets a config value.
-	 *
-	 * @param string $key   Config key
-	 * @param mixed  $value Config value
 	 */
 	public function set(string $key, mixed $value): void
 	{
@@ -127,9 +104,6 @@ class Config
 
 	/**
 	 * Removes a value from the configuration.
-	 *
-	 * @param  string $key Config key
-	 * @return bool
 	 */
 	public function remove(string $key): bool
 	{

--- a/src/mako/config/loaders/Loader.php
+++ b/src/mako/config/loaders/Loader.php
@@ -23,10 +23,7 @@ class Loader implements LoaderInterface
 	use NamespacedFileLoaderTrait;
 
 	/**
-	 * Constructor.
-	 *
-	 * @param \mako\file\FileSystem $fileSystem File system instance
-	 * @param string                $path       Default path
+	 * Constructor.             $path       Default path.
 	 */
 	public function __construct(
 		protected FileSystem $fileSystem,

--- a/src/mako/config/loaders/LoaderInterface.php
+++ b/src/mako/config/loaders/LoaderInterface.php
@@ -14,10 +14,6 @@ interface LoaderInterface
 {
 	/**
 	 * Loads the configuration file.
-	 *
-	 * @param  string      $file        Filename
-	 * @param  string|null $environment Environment
-	 * @return array
 	 */
 	public function load(string $file, ?string $environment = null): array;
 }

--- a/src/mako/database/ConnectionManager.php
+++ b/src/mako/database/ConnectionManager.php
@@ -41,10 +41,8 @@ class ConnectionManager extends BaseConnectionManager
 {
 	/**
 	 * Driver aliases.
-	 *
-	 * @var array
 	 */
-	protected $driverAliases =
+	protected array $driverAliases =
 	[
 		'oracle' => ['oci', 'oracle'],
 		'sqlsrv' => ['dblib', 'sqlsrv', 'mssql'],
@@ -52,10 +50,8 @@ class ConnectionManager extends BaseConnectionManager
 
 	/**
 	 * Connections.
-	 *
-	 * @var array
 	 */
-	protected $connectionClasses =
+	protected array $connectionClasses =
 	[
 		'firebird' => FirebirdConnection::class,
 		'mysql'    => MySQLConnection::class,
@@ -67,10 +63,8 @@ class ConnectionManager extends BaseConnectionManager
 
 	/**
 	 * Query compilers.
-	 *
-	 * @var array
 	 */
-	protected $queryCompilerClasses =
+	protected array $queryCompilerClasses =
 	[
 		'firebird' => FirebirdCompiler::class,
 		'mysql'    => MySQLCompiler::class,
@@ -82,19 +76,14 @@ class ConnectionManager extends BaseConnectionManager
 
 	/**
 	 * Query builder helpers.
-	 *
-	 * @var array
 	 */
-	protected $queryBuilderHelperClasses =
+	protected array $queryBuilderHelperClasses =
 	[
 		'pgsql' => PostgresHelper::class,
 	];
 
 	/**
 	 * Returns the normalized driver name.
-	 *
-	 * @param  string $driver Driver name
-	 * @return string
 	 */
 	protected function normalizeDriverName(string $driver): string
 	{
@@ -111,9 +100,6 @@ class ConnectionManager extends BaseConnectionManager
 
 	/**
 	 * Returns the connection class.
-	 *
-	 * @param  string $driver Driver name
-	 * @return string
 	 */
 	protected function getConnectionClass(string $driver): string
 	{
@@ -122,9 +108,6 @@ class ConnectionManager extends BaseConnectionManager
 
 	/**
 	 * Retuns the query compiler class.
-	 *
-	 * @param  string $driver Driver name
-	 * @return string
 	 */
 	protected function getQueryCompilerClass(string $driver): string
 	{
@@ -133,9 +116,6 @@ class ConnectionManager extends BaseConnectionManager
 
 	/**
 	 * Retuns the query builder helper class.
-	 *
-	 * @param  string $driver Driver name
-	 * @return string
 	 */
 	protected function getQueryBuilderHelperClass(string $driver): string
 	{
@@ -144,9 +124,6 @@ class ConnectionManager extends BaseConnectionManager
 
 	/**
 	 * Sets a driver alias.
-	 *
-	 * @param string       $driver Driver name
-	 * @param array|string $alias  Alias or array of aliases
 	 */
 	public function setDriverAlias(string $driver, array|string $alias): void
 	{
@@ -155,9 +132,6 @@ class ConnectionManager extends BaseConnectionManager
 
 	/**
 	 * Sets a connection class.
-	 *
-	 * @param string $driver Driver name
-	 * @param string $class  Connection class
 	 */
 	public function setConnectionClass(string $driver, string $class): void
 	{
@@ -166,9 +140,6 @@ class ConnectionManager extends BaseConnectionManager
 
 	/**
 	 * Sets a query compiler class.
-	 *
-	 * @param string $driver Driver name
-	 * @param string $class  Query compiler class
 	 */
 	public function setQueryCompilerClass(string $driver, string $class): void
 	{
@@ -177,9 +148,6 @@ class ConnectionManager extends BaseConnectionManager
 
 	/**
 	 * Sets a query builder helper class.
-	 *
-	 * @param string $driver Driver name
-	 * @param string $class  Query builder helper class
 	 */
 	public function setQueryBuilderHelperClass(string $driver, string $class): void
 	{
@@ -188,9 +156,6 @@ class ConnectionManager extends BaseConnectionManager
 
 	/**
 	 * Connects to the chosen database and returns the connection.
-	 *
-	 * @param  string                                $connectionName Connection name
-	 * @return \mako\database\connections\Connection
 	 */
 	protected function connect(string $connectionName): Connection
 	{
@@ -212,9 +177,6 @@ class ConnectionManager extends BaseConnectionManager
 
 	/**
 	 * Adds a database connection to the connection manager.
-	 *
-	 * @param  \mako\database\connections\Connection $connection Database connection
-	 * @return \mako\database\ConnectionManager
 	 */
 	public function setConnection(Connection $connection): ConnectionManager
 	{
@@ -236,9 +198,6 @@ class ConnectionManager extends BaseConnectionManager
 
 	/**
 	 * Returns the query log for all connections.
-	 *
-	 * @param  bool  $groupedByConnection Group logs by connection?
-	 * @return array
 	 */
 	public function getLogs(bool $groupedByConnection = true): array
 	{

--- a/src/mako/database/connections/Connection.php
+++ b/src/mako/database/connections/Connection.php
@@ -45,95 +45,66 @@ class Connection
 {
 	/**
 	 * Connection DSN.
-	 *
-	 * @var string
 	 */
-	protected $dsn;
+	protected string $dsn;
 
 	/**
 	 * Database username.
-	 *
-	 * @var string
 	 */
-	protected $username;
+	protected string|null $username;
 
 	/**
 	 * Database password.
-	 *
-	 * @var string
 	 */
-	protected $password;
+	protected string|null $password;
 
 	/**
 	 * Enable the query log?
-	 *
-	 * @var bool
 	 */
-	protected $enableLog;
+	protected bool $enableLog;
 
 	/**
 	 * Should we reconnect?
-	 *
-	 * @var bool
 	 */
-	protected $reconnect;
+	protected bool $reconnect;
 
 	/**
 	 * Should we use a persistent connection?
-	 *
-	 * @var bool
 	 */
-	protected $usePersistentConnection;
+	protected bool $usePersistentConnection;
 
 	/**
 	 * PDO options.
-	 *
-	 * @var array
 	 */
-	protected $options;
+	protected array $options;
 
 	/**
 	 * Queries that should be executed upon connecting.
-	 *
-	 * @var array
 	 */
-	protected $onConnectQueries;
+	protected array $onConnectQueries;
 
 	/**
 	 * PDO object.
-	 *
-	 * @var \PDO|null
 	 */
-	protected $pdo;
+	protected PDO|null $pdo;
 
 	/**
 	 * Transaction nesting level.
-	 *
-	 * @var int
 	 */
-	protected $transactionNestingLevel = 0;
+	protected int $transactionNestingLevel = 0;
 
 	/**
 	 * Query log.
-	 *
-	 * @var array
 	 */
-	protected $log = [];
+	protected array $log = [];
 
 	/**
 	 * Does the connection support transactional DDL?
-	 *
-	 * @var bool
 	 */
-	protected $supportsTransactionalDDL = false;
+	protected bool $supportsTransactionalDDL = false;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string $name               Connection name
-	 * @param string $queryCompiler      Query compiler
-	 * @param string $queryBuilderHelper Query builder helper
-	 * @param array  $config             Connection configuration
 	 */
 	public function __construct(
 		protected string $name,
@@ -189,8 +160,6 @@ class Connection
 
 	/**
 	 * Does the connection support transactional DDL?
-	 *
-	 * @return bool
 	 */
 	public function supportsTransactionalDDL(): bool
 	{
@@ -199,8 +168,6 @@ class Connection
 
 	/**
 	 * Returns the connection name.
-	 *
-	 * @return string
 	 */
 	public function getName(): string
 	{
@@ -209,8 +176,6 @@ class Connection
 
 	/**
 	 * Returns a query builder helper instance.
-	 *
-	 * @return \mako\database\query\helpers\HelperInterface
 	 */
 	public function getQueryBuilderHelper(): HelperInterface
 	{
@@ -221,9 +186,6 @@ class Connection
 
 	/**
 	 * Returns a query compiler instance.
-	 *
-	 * @param  \mako\database\query\Query              $query Query
-	 * @return \mako\database\query\compilers\Compiler
 	 */
 	public function getQueryCompiler(Query $query): Compiler
 	{
@@ -232,8 +194,6 @@ class Connection
 
 	/**
 	 * Returns the PDO instance or NULL if the connection has been closed.
-	 *
-	 * @return \PDO|null
 	 */
 	public function getPDO(): ?PDO
 	{
@@ -258,8 +218,6 @@ class Connection
 
 	/**
 	 * Returns the connection options.
-	 *
-	 * @return array
 	 */
 	protected function getConnectionOptions(): array
 	{
@@ -275,8 +233,6 @@ class Connection
 
 	/**
 	 * Creates a PDO instance.
-	 *
-	 * @return \PDO
 	 */
 	protected function connect(): PDO
 	{
@@ -313,8 +269,6 @@ class Connection
 
 	/**
 	 * Checks if the connection is alive.
-	 *
-	 * @return bool
 	 */
 	public function isAlive(): bool
 	{
@@ -332,10 +286,6 @@ class Connection
 
 	/**
 	 * Prepares query for logging.
-	 *
-	 * @param  string $query  SQL query
-	 * @param  array  $params Query paramaters
-	 * @return string
 	 */
 	protected function prepareQueryForLog(string $query, array $params): string
 	{
@@ -368,10 +318,6 @@ class Connection
 
 	/**
 	 * Adds a query to the query log.
-	 *
-	 * @param string $query  SQL query
-	 * @param array  $params Query parameters
-	 * @param float  $start  Start time in microseconds
 	 */
 	protected function log(string $query, array $params, float $start): void
 	{
@@ -392,8 +338,6 @@ class Connection
 
 	/**
 	 * Returns the query log for the connection.
-	 *
-	 * @return array
 	 */
 	public function getLog(): array
 	{
@@ -402,10 +346,6 @@ class Connection
 
 	/**
 	 * Prepare query and params.
-	 *
-	 * @param  string $query  SQL Query
-	 * @param  array  $params Query parameters
-	 * @return array
 	 */
 	protected function prepareQueryAndParams(string $query, array $params): array
 	{
@@ -435,8 +375,6 @@ class Connection
 
 	/**
 	 * Should we try to reestablish the connection?
-	 *
-	 * @return bool
 	 */
 	protected function isConnectionLostAndShouldItBeReestablished(): bool
 	{
@@ -445,10 +383,6 @@ class Connection
 
 	/**
 	 * Binds parameter to the prepared statement.
-	 *
-	 * @param \PDOStatement $statement PDO statement
-	 * @param int           $key       Parameter key
-	 * @param mixed         $value     Parameter value
 	 */
 	protected function bindParameter(PDOStatement $statement, int $key, mixed $value): void
 	{
@@ -484,11 +418,6 @@ class Connection
 
 	/**
 	 * Prepares and executes a query.
-	 *
-	 * @param  string        $query    SQL query
-	 * @param  array         $params   Query parameters
-	 * @param  bool          &$success Was the query executed successfully?
-	 * @return \PDOStatement
 	 */
 	protected function prepareAndExecute(string $query, array $params, ?bool &$success = null): PDOStatement
 	{
@@ -558,10 +487,6 @@ class Connection
 
 	/**
 	 * Executes the query and returns TRUE on success or FALSE on failure.
-	 *
-	 * @param  string $query  SQL query
-	 * @param  array  $params Query parameters
-	 * @return bool
 	 */
 	public function query(string $query, array $params = []): bool
 	{
@@ -572,10 +497,6 @@ class Connection
 
 	/**
 	 * Executes the query and return number of affected rows.
-	 *
-	 * @param  string $query  SQL query
-	 * @param  array  $params Query parameters
-	 * @return int
 	 */
 	public function queryAndCount(string $query, array $params = []): int
 	{
@@ -584,11 +505,6 @@ class Connection
 
 	/**
 	 * Returns the first row of the result set or NULL if nothing is found.
-	 *
-	 * @param  string $query        SQL query
-	 * @param  array  $params       Query params
-	 * @param  mixed  ...$fetchMode Fetch mode
-	 * @return mixed
 	 */
 	public function first(string $query, array $params = [], mixed ...$fetchMode): mixed
 	{
@@ -604,12 +520,6 @@ class Connection
 
 	/**
 	 * Returns the first row of the result set or throw an exception if nothing is found.
-	 *
-	 * @param  string $query        SQL query
-	 * @param  array  $params       Query params
-	 * @param  string $exception    Exception class
-	 * @param  mixed  ...$fetchMode Fetch mode
-	 * @return mixed
 	 */
 	public function firstOrThrow(string $query, array $params = [], string $exception = NotFoundException::class, mixed ...$fetchMode): mixed
 	{
@@ -623,11 +533,6 @@ class Connection
 
 	/**
 	 * Returns an array containing all of the result set rows.
-	 *
-	 * @param  string $query        SQL query
-	 * @param  array  $params       Query parameters
-	 * @param  mixed  ...$fetchMode Fetch mode
-	 * @return array
 	 */
 	public function all(string $query, array $params = [], mixed ...$fetchMode): array
 	{
@@ -636,10 +541,6 @@ class Connection
 
 	/**
 	 * Returns the value of the first column of the first row of the result set or NULL if nothing is found.
-	 *
-	 * @param  string $query  SQL query
-	 * @param  array  $params Query parameters
-	 * @return mixed
 	 */
 	public function column(string $query, array $params = []): mixed
 	{
@@ -648,10 +549,6 @@ class Connection
 
 	/**
 	 * Returns an array containing the values of the indicated 0-indexed column.
-	 *
-	 * @param  string $query  SQL query
-	 * @param  array  $params Query parameters
-	 * @return array
 	 */
 	public function columns(string $query, array $params = []): array
 	{
@@ -660,10 +557,6 @@ class Connection
 
 	/**
 	 * Returns an array where the first column is used as keys and the second as values.
-	 *
-	 * @param  string $query  SQL query
-	 * @param  array  $params Query parameters
-	 * @return array
 	 */
 	public function pairs(string $query, array $params = []): array
 	{
@@ -672,11 +565,6 @@ class Connection
 
 	/**
 	 * Returns a generator that lets you iterate over the results.
-	 *
-	 * @param  string     $query        SQL query
-	 * @param  array      $params       Query params
-	 * @param  mixed      ...$fetchMode Fetch mode
-	 * @return \Generator
 	 */
 	public function yield(string $query, array $params = [], mixed ...$fetchMode): Generator
 	{
@@ -702,8 +590,6 @@ class Connection
 
 	/**
 	 * Returns a query builder instance.
-	 *
-	 * @return \mako\database\query\Query
 	 */
 	public function getQuery(): Query
 	{
@@ -712,8 +598,6 @@ class Connection
 
 	/**
 	 * Creates a new savepoint.
-	 *
-	 * @return bool
 	 */
 	protected function createSavepoint(): bool
 	{
@@ -722,8 +606,6 @@ class Connection
 
 	/**
 	 * Rolls back to the previously created savepoint.
-	 *
-	 * @return bool
 	 */
 	protected function rollBackSavepoint(): bool
 	{
@@ -732,8 +614,6 @@ class Connection
 
 	/**
 	 * Begin a transaction.
-	 *
-	 * @return bool
 	 */
 	public function beginTransaction(): bool
 	{
@@ -747,8 +627,6 @@ class Connection
 
 	/**
 	 * Commits a transaction.
-	 *
-	 * @return bool
 	 */
 	public function commitTransaction(): bool
 	{
@@ -762,8 +640,6 @@ class Connection
 
 	/**
 	 * Roll back a transaction.
-	 *
-	 * @return bool
 	 */
 	public function rollBackTransaction(): bool
 	{
@@ -788,8 +664,6 @@ class Connection
 
 	/**
 	 * Returns the transaction nesting level.
-	 *
-	 * @return int
 	 */
 	public function getTransactionNestingLevel(): int
 	{
@@ -798,8 +672,6 @@ class Connection
 
 	/**
 	 * Returns TRUE if we're in a transaction and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function inTransaction(): bool
 	{
@@ -808,9 +680,6 @@ class Connection
 
 	/**
 	 * Executes queries and rolls back the transaction if any of them fail.
-	 *
-	 * @param  \Closure $queries Queries
-	 * @return mixed
 	 */
 	public function transaction(Closure $queries): mixed
 	{

--- a/src/mako/database/connections/Postgres.php
+++ b/src/mako/database/connections/Postgres.php
@@ -15,5 +15,5 @@ class Postgres extends Connection
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $supportsTransactionalDDL = true;
+	protected bool $supportsTransactionalDDL = true;
 }

--- a/src/mako/database/connections/SQLite.php
+++ b/src/mako/database/connections/SQLite.php
@@ -15,5 +15,5 @@ class SQLite extends Connection
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $supportsTransactionalDDL = true;
+	protected bool $supportsTransactionalDDL = true;
 }

--- a/src/mako/database/midgard/ORM.php
+++ b/src/mako/database/midgard/ORM.php
@@ -107,12 +107,12 @@ abstract class ORM implements JsonSerializable, Stringable
 	/**
 	 * Table name.
 	 */
-	protected string $tableName = '';
+	protected string $tableName;
 
 	/**
 	 * Foreign key name.
 	 */
-	protected string $foreignKeyName = '';
+	protected string $foreignKeyName;
 
 	/**
 	 * Primary key.

--- a/src/mako/database/midgard/ORM.php
+++ b/src/mako/database/midgard/ORM.php
@@ -410,7 +410,7 @@ abstract class ORM implements JsonSerializable, Stringable
 	 *
 	 * @return $this
 	 */
-	public function include(array|string $includes)
+	public function include(array|string $includes): static
 	{
 		(function ($includes, $model): void
 		{
@@ -582,7 +582,7 @@ abstract class ORM implements JsonSerializable, Stringable
 	 *
 	 * @return $this
 	 */
-	public function assign(array $columns, bool $raw = false, bool $whitelist = true)
+	public function assign(array $columns, bool $raw = false, bool $whitelist = true): static
 	{
 		// Remove columns that are not in the whitelist
 
@@ -885,7 +885,7 @@ abstract class ORM implements JsonSerializable, Stringable
 	 * @param  array|false|string $column Column or relation to hide from the
 	 * @return $this
 	 */
-	public function protect($column)
+	public function protect($column): static
 	{
 		$this->protected = $column === false ? [] : array_unique([...$this->protected, ...(array) $column]);
 
@@ -899,7 +899,7 @@ abstract class ORM implements JsonSerializable, Stringable
 	 * @param  array|string|true $column Column or relation to hide from the
 	 * @return $this
 	 */
-	public function expose($column)
+	public function expose($column): static
 	{
 		$this->protected = $column === true ? [] : array_diff($this->protected, (array) $column);
 

--- a/src/mako/database/midgard/ORM.php
+++ b/src/mako/database/midgard/ORM.php
@@ -86,130 +86,91 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Connection name to use for the model.
-	 *
-	 * @var string
 	 */
-	protected $connectionName = null;
+	protected string|null $connectionName = null;
 
 	/**
 	 * Connection manager instance.
-	 *
-	 * @var \mako\database\ConnectionManager|null
 	 */
-	protected static $connectionManager = null;
+	protected static ConnectionManager|null $connectionManager = null;
 
 	/**
 	 * ORM query builder hooks.
-	 *
-	 * @var array
 	 */
-	protected static $traitHooks = [];
+	protected static array $traitHooks = [];
 
 	/**
 	 * Trait casts.
-	 *
-	 * @var array
 	 */
-	protected static $traitCasts = [];
+	protected static array $traitCasts = [];
 
 	/**
 	 * Table name.
-	 *
-	 * @var string
 	 */
-	protected $tableName = null;
+	protected string $tableName = '';
 
 	/**
 	 * Foreign key name.
-	 *
-	 * @var string
 	 */
-	protected $foreignKeyName = null;
+	protected string $foreignKeyName = '';
 
 	/**
 	 * Primary key.
-	 *
-	 * @var string
 	 */
-	protected $primaryKey = 'id';
+	protected string $primaryKey = 'id';
 
 	/**
 	 * Does this table have an auto increment primary index?
-	 *
-	 * @var int
 	 */
-	protected $primaryKeyType = ORM::PRIMARY_KEY_TYPE_INCREMENTING;
+	protected int $primaryKeyType = ORM::PRIMARY_KEY_TYPE_INCREMENTING;
 
 	/**
 	 * Has the record been loaded from/saved to a database?
-	 *
-	 * @var bool
 	 */
-	protected $isPersisted = false;
+	protected bool $isPersisted = false;
 
 	/**
 	 * Column values.
-	 *
-	 * @var array
 	 */
-	protected $columns = [];
+	protected array $columns = [];
 
 	/**
 	 * Original column values.
-	 *
-	 * @var array
 	 */
-	protected $original = [];
+	protected array $original = [];
 
 	/**
 	 * Relations to eager load.
-	 *
-	 * @var array
 	 */
-	protected $including = [];
+	protected array $including = [];
 
 	/**
 	 * Related records.
-	 *
-	 * @var array
 	 */
-	protected $related = [];
+	protected array $related = [];
 
 	/**
 	 * Columns that should be casted to a specific type.
-	 *
-	 * @var array
 	 */
-	protected $cast = [];
+	protected array $cast = [];
 
 	/**
 	 * Columns that can be set through mass assignment.
-	 *
-	 * @var array
 	 */
-	protected $assignable = [];
+	protected array $assignable = [];
 
 	/**
 	 * Columns and relations that are excluded from the array and json representations of the record.
-	 *
-	 * @var array
 	 */
-	protected $protected = [];
+	protected array $protected = [];
 
 	/**
 	 * Date format used when returning array and json representations of the record.
-	 *
-	 * @var string
 	 */
-	protected $dateOutputFormat = 'Y-m-d H:i:s';
+	protected string $dateOutputFormat = 'Y-m-d H:i:s';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array $columns     Column values
-	 * @param bool  $raw         Set raw values?
-	 * @param bool  $whitelist   Remove columns that are not in the whitelist?
-	 * @param bool  $isPersisted Does the record come from a database?
 	 */
 	final public function __construct(array $columns = [], bool $raw = false, bool $whitelist = true, bool $isPersisted = false)
 	{
@@ -242,8 +203,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Set the connection manager.
-	 *
-	 * @param \mako\database\ConnectionManager $connectionManager Connection manager instance
 	 */
 	public static function setConnectionManager(ConnectionManager $connectionManager): void
 	{
@@ -252,8 +211,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns the connection of the model.
-	 *
-	 * @return \mako\database\connections\Connection
 	 */
 	public function getConnection(): Connection
 	{
@@ -267,8 +224,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Has the record been loaded from/saved to a database?
-	 *
-	 * @return bool
 	 */
 	public function isPersisted(): bool
 	{
@@ -285,8 +240,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Gets the date format from the query builder compiler.
-	 *
-	 * @return string
 	 */
 	protected function getDateFormat(): string
 	{
@@ -324,9 +277,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Binds the hooks to the current instance of "$this".
-	 *
-	 * @param  array $hooks Array of hooks
-	 * @return array
 	 */
 	protected function bindHooks(array $hooks): array
 	{
@@ -342,9 +292,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns hooks for the chosen event.
-	 *
-	 * @param  string $event Event name
-	 * @return array
 	 */
 	public function getHooks(string $event): array
 	{
@@ -353,9 +300,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns the short name of a class.
-	 *
-	 * @param  string|null $className Class name
-	 * @return string
 	 */
 	protected function getClassShortName(?string $className = null): string
 	{
@@ -373,8 +317,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns the table name of the model.
-	 *
-	 * @return string
 	 */
 	public function getTable(): string
 	{
@@ -388,8 +330,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns the primary key of the table.
-	 *
-	 * @return string
 	 */
 	public function getPrimaryKey(): string
 	{
@@ -398,8 +338,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns the primary key type.
-	 *
-	 * @return int
 	 */
 	public function getPrimaryKeyType(): int
 	{
@@ -408,8 +346,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns the primary key value.
-	 *
-	 * @return mixed
 	 */
 	public function getPrimaryKeyValue(): mixed
 	{
@@ -418,8 +354,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns the foreign key of the table.
-	 *
-	 * @return string
 	 */
 	public function getForeignKey(): string
 	{
@@ -433,8 +367,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns the namespaced class name of the model.
-	 *
-	 * @return string
 	 */
 	public function getClass(): string
 	{
@@ -443,8 +375,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Sets the relations to eager load.
-	 *
-	 * @param array $includes Relations to eager load
 	 */
 	public function setIncludes(array $includes): void
 	{
@@ -453,8 +383,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns the relations to eager load.
-	 *
-	 * @return array
 	 */
 	public function getIncludes(): array
 	{
@@ -463,9 +391,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Sets eagerly loaded related records.
-	 *
-	 * @param string $relation Relation name
-	 * @param mixed  $related  Related record(s)
 	 */
 	public function setRelated(string $relation, mixed $related): void
 	{
@@ -474,9 +399,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns TRUE if the model has included the relationship and FALSE if not.
-	 *
-	 * @param  string $relation Relation name
-	 * @return bool
 	 */
 	public function includes(string $relation): bool
 	{
@@ -486,7 +408,6 @@ abstract class ORM implements JsonSerializable, Stringable
 	/**
 	 * Eager loads relations on the model.
 	 *
-	 * @param  array|string $includes Relation or array of relations to eager load
 	 * @return $this
 	 */
 	public function include(array|string $includes)
@@ -501,8 +422,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns the related records array.
-	 *
-	 * @return array
 	 */
 	public function getRelated(): array
 	{
@@ -511,10 +430,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Cast value to the appropriate type.
-	 *
-	 * @param  string $name  Column name
-	 * @param  mixed  $value Column value
-	 * @return mixed
 	 */
 	protected function cast(string $name, mixed $value): mixed
 	{
@@ -545,9 +460,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Sets a raw column value.
-	 *
-	 * @param string $name  Column name
-	 * @param mixed  $value Column value
 	 */
 	public function setRawColumnValue(string $name, mixed $value): void
 	{
@@ -556,9 +468,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Sets a column value.
-	 *
-	 * @param string $name  Column name
-	 * @param mixed  $value Column value
 	 */
 	public function setColumnValue(string $name, mixed $value): void
 	{
@@ -576,9 +485,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Gets a raw column value.
-	 *
-	 * @param  string $name Column name
-	 * @return mixed
 	 */
 	public function getRawColumnValue(string $name): mixed
 	{
@@ -587,9 +493,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a column value.
-	 *
-	 * @param  string $name Column name
-	 * @return mixed
 	 */
 	public function getColumnValue(string $name): mixed
 	{
@@ -603,9 +506,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns TRUE if it's probable that $name is a relation and FALSE if not.
-	 *
-	 * @param  string $name Relation name
-	 * @return bool
 	 */
 	protected function isRelation(string $name): bool
 	{
@@ -614,9 +514,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Gets a column value or relation.
-	 *
-	 * @param  string $name Column name
-	 * @return mixed
 	 */
 	public function getValue(string $name): mixed
 	{
@@ -646,8 +543,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns the columns array.
-	 *
-	 * @return array
 	 */
 	public function getRawColumnValues(): array
 	{
@@ -656,9 +551,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Sets column values.
-	 *
-	 * @param array $columns Column values
-	 * @param bool  $raw     Set raw values?
 	 */
 	protected function setColumValues(array $columns, bool $raw): void
 	{
@@ -688,9 +580,6 @@ abstract class ORM implements JsonSerializable, Stringable
 	/**
 	 * Assigns the column values to the model.
 	 *
-	 * @param  array $columns   Column values
-	 * @param  bool  $raw       Set raw values?
-	 * @param  bool  $whitelist Remove columns that are not in the whitelist?
 	 * @return $this
 	 */
 	public function assign(array $columns, bool $raw = false, bool $whitelist = true)
@@ -718,9 +607,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Set column value using overloading.
-	 *
-	 * @param string $name  Column name
-	 * @param mixed  $value Column value
 	 */
 	public function __set(string $name, mixed $value): void
 	{
@@ -729,9 +615,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Get column value or relation using overloading.
-	 *
-	 * @param  string $name Column name
-	 * @return mixed
 	 */
 	public function __get(string $name): mixed
 	{
@@ -740,9 +623,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Checks if a column or relation is set using overloading.
-	 *
-	 * @param  string $name Column or relation name
-	 * @return bool
 	 */
 	public function __isset(string $name): bool
 	{
@@ -756,8 +636,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Unset column value or relation using overloading.
-	 *
-	 * @param string $name Column name
 	 */
 	public function __unset(string $name): void
 	{
@@ -766,8 +644,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a query builder instance.
-	 *
-	 * @return \mako\database\midgard\Query
 	 */
 	public function getQuery(): Query
 	{
@@ -776,10 +652,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a record using the value of its primary key.
-	 *
-	 * @param  mixed       $id      Primary key
-	 * @param  array       $columns Columns to select
-	 * @return static|null
 	 */
 	public static function get(mixed $id, array $columns = []): ?static
 	{
@@ -788,11 +660,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a record using the value of its primary key.
-	 *
-	 * @param  mixed  $id        Primary key
-	 * @param  array  $columns   Columns to select
-	 * @param  string $exception Exception class
-	 * @return static
 	 */
 	public static function getOrThrow(mixed $id, array $columns = [], string $exception = NotFoundException::class): static
 	{
@@ -801,11 +668,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Creates a new record and returns the model.
-	 *
-	 * @param  array  $columns   Column values
-	 * @param  bool   $raw       Set raw values?
-	 * @param  bool   $whitelist Remove columns that are not in the whitelist?
-	 * @return static
 	 */
 	public static function create(array $columns = [], bool $raw = false, bool $whitelist = true): static
 	{
@@ -818,10 +680,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a HasOne relation.
-	 *
-	 * @param  string                                  $model      Related model
-	 * @param  string|null                             $foreignKey Foreign key name
-	 * @return \mako\database\midgard\relations\HasOne
 	 */
 	protected function hasOne(string $model, ?string $foreignKey = null): HasOne
 	{
@@ -832,10 +690,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a HasOnePolymorphic relation.
-	 *
-	 * @param  string                                             $model           Related model
-	 * @param  string                                             $polymorphicType Polymorphic type
-	 * @return \mako\database\midgard\relations\HasOnePolymorphic
 	 */
 	protected function hasOnePolymorphic(string $model, string $polymorphicType): HasOnePolymorphic
 	{
@@ -846,10 +700,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a HasMany relation.
-	 *
-	 * @param  string                                   $model      Related model
-	 * @param  string|null                              $foreignKey Foreign key name
-	 * @return \mako\database\midgard\relations\HasMany
 	 */
 	protected function hasMany(string $model, ?string $foreignKey = null): HasMany
 	{
@@ -860,10 +710,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a HasManyPolymorphic relation.
-	 *
-	 * @param  string                                              $model           Related model
-	 * @param  string                                              $polymorphicType Polymorphic type
-	 * @return \mako\database\midgard\relations\HasManyPolymorphic
 	 */
 	protected function hasManyPolymorphic(string $model, string $polymorphicType): HasManyPolymorphic
 	{
@@ -874,12 +720,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a ManyToMany relation.
-	 *
-	 * @param  string                                      $model         Related model
-	 * @param  string|null                                 $foreignKey    Foreign key name
-	 * @param  string|null                                 $junctionTable Junction table name
-	 * @param  string|null                                 $junctionKey   Junction key name
-	 * @return \mako\database\midgard\relations\ManyToMany
 	 */
 	protected function manyToMany(string $model, ?string $foreignKey = null, ?string $junctionTable = null, ?string $junctionKey = null): ManyToMany
 	{
@@ -890,10 +730,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a BelongsTo relation.
-	 *
-	 * @param  string                                     $model      Related model
-	 * @param  string|null                                $foreignKey Foreign key name
-	 * @return \mako\database\midgard\relations\BelongsTo
 	 */
 	protected function belongsTo(string $model, ?string $foreignKey = null): BelongsTo
 	{
@@ -904,10 +740,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a BelongsToPolymorphic relation.
-	 *
-	 * @param  string                                                $model           Related model
-	 * @param  string                                                $polymorphicType Polymorphic type
-	 * @return \mako\database\midgard\relations\BelongsToPolymorphic
 	 */
 	protected function belongsToPolymorphic(string $model, string $polymorphicType): BelongsToPolymorphic
 	{
@@ -918,8 +750,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Has the record been modified?
-	 *
-	 * @return bool
 	 */
 	public function isModified(): bool
 	{
@@ -928,8 +758,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns the modified column values of the record.
-	 *
-	 * @return array
 	 */
 	public function getModified(): array
 	{
@@ -948,8 +776,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Generates a primary key.
-	 *
-	 * @return mixed
 	 */
 	protected function generatePrimaryKey(): mixed
 	{
@@ -958,8 +784,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Inserts a new record into the database.
-	 *
-	 * @param \mako\database\midgard\Query $query Query builder
 	 */
 	protected function insertRecord(Query $query): void
 	{
@@ -984,9 +808,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Updates an existing record.
-	 *
-	 * @param  \mako\database\midgard\Query $query Query builder
-	 * @return bool
 	 */
 	protected function updateRecord(Query $query): bool
 	{
@@ -997,8 +818,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Saves the record to the database.
-	 *
-	 * @return bool
 	 */
 	public function save(): bool
 	{
@@ -1031,9 +850,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Deletes a record from the database.
-	 *
-	 * @param  \mako\database\midgard\Query $query Query builder
-	 * @return bool
 	 */
 	protected function deleteRecord(Query $query): bool
 	{
@@ -1042,8 +858,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Deletes a record from the database.
-	 *
-	 * @return bool
 	 */
 	public function delete(): bool
 	{
@@ -1094,8 +908,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns an array representation of the record.
-	 *
-	 * @return array
 	 */
 	public function toArray(): array
 	{
@@ -1160,8 +972,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns data which can be serialized by json_encode().
-	 *
-	 * @return mixed
 	 */
 	public function jsonSerialize(): mixed
 	{
@@ -1170,9 +980,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a json representation of the record.
-	 *
-	 * @param  int    $options JSON encode options
-	 * @return string
 	 */
 	public function toJson(int $options = 0): string
 	{
@@ -1181,8 +988,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a json representation of the record.
-	 *
-	 * @return string
 	 */
 	public function __toString(): string
 	{
@@ -1191,10 +996,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Forwards method calls to the query builder.
-	 *
-	 * @param  string $name      Method name
-	 * @param  array  $arguments Method arguments
-	 * @return mixed
 	 */
 	public function __call(string $name, array $arguments): mixed
 	{
@@ -1203,10 +1004,6 @@ abstract class ORM implements JsonSerializable, Stringable
 
 	/**
 	 * Forwards static method calls to the query builder.
-	 *
-	 * @param  string $name      Method name
-	 * @param  array  $arguments Method arguments
-	 * @return mixed
 	 */
 	public static function __callStatic(string $name, array $arguments): mixed
 	{

--- a/src/mako/database/midgard/Query.php
+++ b/src/mako/database/midgard/Query.php
@@ -38,23 +38,16 @@ class Query extends QueryBuilder
 {
 	/**
 	 * Class name of the model we're hydrating.
-	 *
-	 * @var string
 	 */
-	protected $modelClass;
+	protected string $modelClass;
 
 	/**
 	 * Relation count subqueries.
-	 *
-	 * @var array
 	 */
-	protected $relationCounters = [];
+	protected array $relationCounters = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\database\connections\Connection $connection Database connection
-	 * @param \mako\database\midgard\ORM            $model      Model to hydrate
 	 */
 	public function __construct(
 		Connection $connection,
@@ -83,10 +76,8 @@ class Query extends QueryBuilder
 
 	/**
 	 * Returns the model.
-	 *
-	 * @return \mako\database\midgard\ORM
 	 */
-	public function getModel()
+	public function getModel(): ORM
 	{
 		return $this->model;
 	}
@@ -261,12 +252,8 @@ class Query extends QueryBuilder
 
 	/**
 	 * Returns a record using the value of its primary key.
-	 *
-	 * @param  int|string                      $id      Primary key
-	 * @param  array                           $columns Columns to select
-	 * @return \mako\database\midgard\ORM|null
 	 */
-	public function get(int|string $id, array $columns = [])
+	public function get(int|string $id, array $columns = []): ?ORM
 	{
 		if(!empty($columns))
 		{
@@ -278,13 +265,8 @@ class Query extends QueryBuilder
 
 	/**
 	 * Returns a record using the value of its primary key.
-	 *
-	 * @param  int|string                 $id        Primary key
-	 * @param  array                      $columns   Columns to select
-	 * @param  string                     $exception Exception class
-	 * @return \mako\database\midgard\ORM
 	 */
-	public function getOrThrow(int|string $id, array $columns = [], string $exception = NotFoundException::class)
+	public function getOrThrow(int|string $id, array $columns = [], string $exception = NotFoundException::class): ORM
 	{
 		if(!empty($columns))
 		{
@@ -370,9 +352,6 @@ class Query extends QueryBuilder
 
 	/**
 	 * Parses the count relation name and returns an array consisting of the relation name and the chosen alias.
-	 *
-	 * @param  string $relation Relation name
-	 * @return array
 	 */
 	protected function parseRelationCountName(string $relation): array
 	{
@@ -389,7 +368,6 @@ class Query extends QueryBuilder
 	/**
 	 * Adds subqueries that count the number of related records for the chosen relations.
 	 *
-	 * @param  array|string $relations Relation or array of relations to count
 	 * @return $this
 	 */
 	public function withCountOf(array|string $relations)
@@ -425,19 +403,14 @@ class Query extends QueryBuilder
 
 	/**
 	 * Returns a hydrated model.
-	 *
-	 * @param  array                      $result Database result
-	 * @return \mako\database\midgard\ORM
 	 */
-	protected function hydrateModel(array $result)
+	protected function hydrateModel(array $result): ORM
 	{
 		return new ($this->modelClass)($result, true, false, true);
 	}
 
 	/**
 	 * Parses includes.
-	 *
-	 * @return array
 	 */
 	protected function parseIncludes(): array
 	{
@@ -473,9 +446,6 @@ class Query extends QueryBuilder
 
 	/**
 	 * Parses include names.
-	 *
-	 * @param  string $name Include name
-	 * @return array
 	 */
 	protected function parseIncludeName(string $name): array
 	{
@@ -491,8 +461,6 @@ class Query extends QueryBuilder
 
 	/**
 	 * Load includes.
-	 *
-	 * @param array $results Loaded records
 	 */
 	protected function loadIncludes(array $results): void
 	{
@@ -510,9 +478,6 @@ class Query extends QueryBuilder
 
 	/**
 	 * Returns hydrated models.
-	 *
-	 * @param  mixed $results Database results
-	 * @return array
 	 */
 	protected function hydrateModelsAndLoadIncludes(mixed $results): array
 	{
@@ -530,10 +495,8 @@ class Query extends QueryBuilder
 
 	/**
 	 * Returns a single record from the database.
-	 *
-	 * @return \mako\database\midgard\ORM|null
 	 */
-	public function first(): mixed
+	public function first(): ?ORM
 	{
 		$result = $this->fetchFirst(PDO::FETCH_ASSOC);
 
@@ -547,20 +510,14 @@ class Query extends QueryBuilder
 
 	/**
 	 * Returns a single record from the database.
-	 *
-	 * @param  string                     $exception Exception class
-	 * @return \mako\database\midgard\ORM
 	 */
-	public function firstOrThrow(string $exception = NotFoundException::class): mixed
+	public function firstOrThrow(string $exception = NotFoundException::class): ORM
 	{
 		return $this->hydrateModelsAndLoadIncludes([$this->fetchFirstOrThrow($exception, PDO::FETCH_ASSOC)])[0];
 	}
 
 	/**
 	 * Creates a result set.
-	 *
-	 * @param  array                            $results Results
-	 * @return \mako\database\midgard\ResultSet
 	 */
 	protected function createResultSet(array $results): ResultSet
 	{
@@ -569,8 +526,6 @@ class Query extends QueryBuilder
 
 	/**
 	 * Returns a result set from the database.
-	 *
-	 * @return \mako\database\midgard\ResultSet
 	 */
 	public function all(): ResultSet
 	{
@@ -586,8 +541,6 @@ class Query extends QueryBuilder
 
 	/**
 	 * Returns a generator that lets you iterate over the results.
-	 *
-	 * @return \Generator
 	 */
 	public function yield(): Generator
 	{
@@ -628,8 +581,6 @@ class Query extends QueryBuilder
 	/**
 	 * Calls a scope method on the model.
 	 *
-	 * @param  string $scope        Scope
-	 * @param  mixed  ...$arguments Arguments
 	 * @return $this
 	 */
 	public function scope(string $scope, mixed ...$arguments)

--- a/src/mako/database/midgard/Query.php
+++ b/src/mako/database/midgard/Query.php
@@ -85,7 +85,7 @@ class Query extends QueryBuilder
 	/**
 	 * {@inheritDoc}
 	 */
-	public function join(Raw|Subquery|string $table, Closure|Raw|string|null $column1 = null, ?string $operator = null, Raw|string|null $column2 = null, string $type = 'INNER JOIN')
+	public function join(Raw|Subquery|string $table, Closure|Raw|string|null $column1 = null, ?string $operator = null, Raw|string|null $column2 = null, string $type = 'INNER JOIN'): static
 	{
 		if(empty($this->joins) && $this->columns === ['*'])
 		{
@@ -282,7 +282,7 @@ class Query extends QueryBuilder
 	 * @param  array|false|string $includes Relation or array of relations to eager load
 	 * @return $this
 	 */
-	public function including($includes)
+	public function including($includes): static
 	{
 		if($includes === false)
 		{
@@ -324,7 +324,7 @@ class Query extends QueryBuilder
 	 * @param  array|string|true $excludes Relation or array of relations to exclude from eager loading
 	 * @return $this
 	 */
-	public function excluding($excludes)
+	public function excluding($excludes): static
 	{
 		if($excludes === true)
 		{
@@ -370,7 +370,7 @@ class Query extends QueryBuilder
 	 *
 	 * @return $this
 	 */
-	public function withCountOf(array|string $relations)
+	public function withCountOf(array|string $relations): static
 	{
 		foreach((array) $relations as $relation => $criteria)
 		{
@@ -583,7 +583,7 @@ class Query extends QueryBuilder
 	 *
 	 * @return $this
 	 */
-	public function scope(string $scope, mixed ...$arguments)
+	public function scope(string $scope, mixed ...$arguments): static
 	{
 		$this->model->{Str::snakeToCamel($scope) . 'Scope'}(...[$this, ...$arguments]);
 

--- a/src/mako/database/midgard/ResultSet.php
+++ b/src/mako/database/midgard/ResultSet.php
@@ -60,7 +60,6 @@ class ResultSet extends BaseResultSet
 	/**
 	 * Eager loads relations on the collection.
 	 *
-	 * @param  array|string $includes Relation or array of relations to eager load
 	 * @return $this
 	 */
 	public function include(array|string $includes)

--- a/src/mako/database/midgard/ResultSet.php
+++ b/src/mako/database/midgard/ResultSet.php
@@ -31,7 +31,7 @@ class ResultSet extends BaseResultSet
 	 * @param  array|false|string $column Column or relation to hide from the
 	 * @return $this
 	 */
-	public function protect($column)
+	public function protect($column): static
 	{
 		foreach($this->items as $item)
 		{
@@ -47,7 +47,7 @@ class ResultSet extends BaseResultSet
 	 * @param  array|string|true $column Column or relation to hide from the
 	 * @return $this
 	 */
-	public function expose($column)
+	public function expose($column): static
 	{
 		foreach($this->items as $item)
 		{
@@ -62,7 +62,7 @@ class ResultSet extends BaseResultSet
 	 *
 	 * @return $this
 	 */
-	public function include(array|string $includes)
+	public function include(array|string $includes): static
 	{
 		(function ($includes, $items): void
 		{

--- a/src/mako/database/midgard/relations/BelongsTo.php
+++ b/src/mako/database/midgard/relations/BelongsTo.php
@@ -8,6 +8,7 @@
 namespace mako\database\midgard\relations;
 
 use Closure;
+use mako\database\midgard\ORM;
 
 use function array_filter;
 use function array_unique;
@@ -77,11 +78,6 @@ class BelongsTo extends Relation
 
 	/**
 	 * Eager loads related records and matches them with their originating records.
-	 *
-	 * @param array         &$results Originating records
-	 * @param string        $relation Relation name
-	 * @param \Closure|null $criteria Relation criteria
-	 * @param array         $includes Includes passed from the originating record
 	 */
 	public function eagerLoad(array &$results, string $relation, ?Closure $criteria, array $includes): void
 	{
@@ -112,10 +108,8 @@ class BelongsTo extends Relation
 
 	/**
 	 * Fetches a related record from the database.
-	 *
-	 * @return \mako\database\midgard\ORM|null
 	 */
-	protected function fetchRelated()
+	protected function fetchRelated(): ?ORM
 	{
 		if($this->origin->getRawColumnValue($this->getForeignKey()) === null)
 		{

--- a/src/mako/database/midgard/relations/BelongsTo.php
+++ b/src/mako/database/midgard/relations/BelongsTo.php
@@ -59,7 +59,7 @@ class BelongsTo extends Relation
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function eagerCriterion(array $keys)
+	protected function eagerCriterion(array $keys): static
 	{
 		$this->in("{$this->table}.{$this->model->getPrimaryKey()}", $keys);
 
@@ -69,7 +69,7 @@ class BelongsTo extends Relation
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function getRelationCountQuery()
+	protected function getRelationCountQuery(): static
 	{
 		$this->whereColumn("{$this->table}.{$this->model->getPrimaryKey()}", '=', "{$this->origin->getTable()}.{$this->getForeignKey()}");
 

--- a/src/mako/database/midgard/relations/BelongsToPolymorphic.php
+++ b/src/mako/database/midgard/relations/BelongsToPolymorphic.php
@@ -17,11 +17,6 @@ class BelongsToPolymorphic extends BelongsTo
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\database\connections\Connection $connection      Database connection
-	 * @param \mako\database\midgard\ORM            $origin          Originating model
-	 * @param \mako\database\midgard\ORM            $model           Related model
-	 * @param string                                $polymorphicType Polymorphic type
 	 */
 	public function __construct(Connection $connection, ORM $origin, ORM $model, string $polymorphicType)
 	{

--- a/src/mako/database/midgard/relations/HasMany.php
+++ b/src/mako/database/midgard/relations/HasMany.php
@@ -8,6 +8,7 @@
 namespace mako\database\midgard\relations;
 
 use Closure;
+use mako\database\midgard\ResultSet;
 
 /**
  * Has many relation.
@@ -16,11 +17,6 @@ class HasMany extends HasOneOrMany
 {
 	/**
 	 * Eager loads related records and matches them with their originating records.
-	 *
-	 * @param array         &$results Originating records
-	 * @param string        $relation Relation name
-	 * @param \Closure|null $criteria Relation criteria
-	 * @param array         $includes Includes passed from the originating record
 	 */
 	public function eagerLoad(array &$results, string $relation, ?Closure $criteria, array $includes): void
 	{
@@ -48,10 +44,8 @@ class HasMany extends HasOneOrMany
 
 	/**
 	 * Fetches a related result set from the database.
-	 *
-	 * @return \mako\database\midgard\ResultSet
 	 */
-	protected function fetchRelated()
+	protected function fetchRelated(): ResultSet
 	{
 		return $this->all();
 	}

--- a/src/mako/database/midgard/relations/HasOne.php
+++ b/src/mako/database/midgard/relations/HasOne.php
@@ -8,6 +8,7 @@
 namespace mako\database\midgard\relations;
 
 use Closure;
+use mako\database\midgard\ORM;
 
 /**
  * Has one relation.
@@ -16,11 +17,6 @@ class HasOne extends HasOneOrMany
 {
 	/**
 	 * Eager loads related records and matches them with their originating records.
-	 *
-	 * @param array         &$results Originating records
-	 * @param string        $relation Relation name
-	 * @param \Closure|null $criteria Relation criteria
-	 * @param array         $includes Includes passed from the originating record
 	 */
 	public function eagerLoad(array &$results, string $relation, ?Closure $criteria, array $includes): void
 	{
@@ -48,10 +44,8 @@ class HasOne extends HasOneOrMany
 
 	/**
 	 * Fetches a related record from the database.
-	 *
-	 * @return \mako\database\midgard\ORM|null
 	 */
-	protected function fetchRelated()
+	protected function fetchRelated(): ?ORM
 	{
 		return $this->first();
 	}

--- a/src/mako/database/midgard/relations/HasOneOrMany.php
+++ b/src/mako/database/midgard/relations/HasOneOrMany.php
@@ -7,6 +7,8 @@
 
 namespace mako\database\midgard\relations;
 
+use mako\database\midgard\ORM;
+
 /**
  * Has one or has many relation.
  */
@@ -14,11 +16,8 @@ abstract class HasOneOrMany extends Relation
 {
 	/**
 	 * Creates a related record.
-	 *
-	 * @param  array|\mako\database\midgard\ORM $related Related record
-	 * @return \mako\database\midgard\ORM
 	 */
-	public function create($related)
+	public function create(array|ORM $related): ORM
 	{
 		if($related instanceof $this->model)
 		{

--- a/src/mako/database/midgard/relations/ManyToMany.php
+++ b/src/mako/database/midgard/relations/ManyToMany.php
@@ -84,7 +84,7 @@ class ManyToMany extends Relation
 	 *
 	 * @return $this
 	 */
-	public function alongWith(array $columns)
+	public function alongWith(array $columns): static
 	{
 		foreach($columns as $key => $value)
 		{
@@ -155,7 +155,7 @@ class ManyToMany extends Relation
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function eagerCriterion(array $keys)
+	protected function eagerCriterion(array $keys): static
 	{
 		$this->in("{$this->getJunctionTable()}.{$this->getForeignKey()}", $keys);
 
@@ -165,7 +165,7 @@ class ManyToMany extends Relation
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function getRelationCountQuery()
+	protected function getRelationCountQuery(): static
 	{
 		$this->whereColumn("{$this->getJunctionTable()}.{$this->getForeignKey()}", '=', "{$this->origin->getTable()}.{$this->origin->getPrimaryKey()}");
 

--- a/src/mako/database/midgard/relations/ManyToMany.php
+++ b/src/mako/database/midgard/relations/ManyToMany.php
@@ -10,6 +10,8 @@ namespace mako\database\midgard\relations;
 use Closure;
 use mako\database\connections\Connection;
 use mako\database\midgard\ORM;
+use mako\database\midgard\ResultSet;
+use mako\database\query\Query;
 use mako\database\query\Raw;
 
 use function array_diff;
@@ -28,20 +30,11 @@ class ManyToMany extends Relation
 {
 	/**
 	 * Junction columns to include in the result.
-	 *
-	 * @var array
 	 */
-	protected $alongWith = [];
+	protected array $alongWith = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\database\connections\Connection $connection    Database connection
-	 * @param \mako\database\midgard\ORM            $origin        Originating model
-	 * @param \mako\database\midgard\ORM            $model         Related model
-	 * @param string|null                           $foreignKey    Foreign key name
-	 * @param string|null                           $junctionTable Junction table name
-	 * @param string|null                           $junctionKey   Junction key name
 	 */
 	public function __construct(
 		Connection $connection,
@@ -89,7 +82,6 @@ class ManyToMany extends Relation
 	/**
 	 * Columns to include with the result.
 	 *
-	 * @param  array $columns Columns
 	 * @return $this
 	 */
 	public function alongWith(array $columns)
@@ -109,8 +101,6 @@ class ManyToMany extends Relation
 
 	/**
 	 * Returns the the junction table.
-	 *
-	 * @return string
 	 */
 	protected function getJunctionTable(): string
 	{
@@ -135,8 +125,6 @@ class ManyToMany extends Relation
 
 	/**
 	 * Returns the the junction key.
-	 *
-	 * @return string
 	 */
 	protected function getJunctionKey(): string
 	{
@@ -186,11 +174,6 @@ class ManyToMany extends Relation
 
 	/**
 	 * Eager loads related records and matches them with their originating records.
-	 *
-	 * @param array         &$results Originating records
-	 * @param string        $relation Relation name
-	 * @param \Closure|null $criteria Relation criteria
-	 * @param array         $includes Includes passed from the originating record
 	 */
 	public function eagerLoad(array &$results, string $relation, ?Closure $criteria, array $includes): void
 	{
@@ -220,21 +203,16 @@ class ManyToMany extends Relation
 
 	/**
 	 * Fetches a related result set from the database.
-	 *
-	 * @return \mako\database\midgard\ResultSet
 	 */
-	protected function fetchRelated()
+	protected function fetchRelated(): ResultSet
 	{
 		return $this->all();
 	}
 
 	/**
 	 * Returns a query builder instance to the junction table.
-	 *
-	 * @param  bool                       $includeWheres Should the wheres be included?
-	 * @return \mako\database\query\Query
 	 */
-	protected function junction(bool $includeWheres = false)
+	protected function junction(bool $includeWheres = false): Query
 	{
 		$query = $this->connection->getQuery()->table($this->getJunctionTable());
 
@@ -250,9 +228,6 @@ class ManyToMany extends Relation
 
 	/**
 	 * Returns an array of ids.
-	 *
-	 * @param  mixed $id Id, model or an array of ids and/or models
-	 * @return array
 	 */
 	protected function getJunctionKeys(mixed $id): array
 	{
@@ -273,10 +248,6 @@ class ManyToMany extends Relation
 
 	/**
 	 * Get junction attributes.
-	 *
-	 * @param  mixed $key        Key
-	 * @param  array $attributes Attributes
-	 * @return array
 	 */
 	protected function getJunctionAttributes(mixed $key, array $attributes): array
 	{
@@ -290,10 +261,6 @@ class ManyToMany extends Relation
 
 	/**
 	 * Links related records.
-	 *
-	 * @param  mixed $id         Id, model or an array of ids and/or models
-	 * @param  array $attributes Junction attributes
-	 * @return bool
 	 */
 	public function link(mixed $id, array $attributes = []): bool
 	{
@@ -317,10 +284,6 @@ class ManyToMany extends Relation
 
 	/**
 	 * Updates junction attributes.
-	 *
-	 * @param  mixed $id         Id, model or an array of ids and/or models
-	 * @param  array $attributes Junction attributes
-	 * @return bool
 	 */
 	public function updateLink(mixed $id, array $attributes): bool
 	{
@@ -342,9 +305,6 @@ class ManyToMany extends Relation
 
 	/**
 	 * Unlinks related records.
-	 *
-	 * @param  mixed $id Id, model or an array of ids and/or models
-	 * @return bool
 	 */
 	public function unlink(mixed $id = null): bool
 	{
@@ -360,9 +320,6 @@ class ManyToMany extends Relation
 
 	/**
 	 * Synchronize related records.
-	 *
-	 * @param  array $ids An array of ids and/or models
-	 * @return bool
 	 */
 	public function synchronize(array $ids): bool
 	{

--- a/src/mako/database/midgard/relations/Relation.php
+++ b/src/mako/database/midgard/relations/Relation.php
@@ -32,18 +32,11 @@ abstract class Relation extends Query
 
 	/**
 	 * Are we lazy load related records?
-	 *
-	 * @var bool
 	 */
-	protected $lazy = true;
+	protected bool $lazy = true;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\database\connections\Connection $connection Database connection
-	 * @param \mako\database\midgard\ORM            $origin     Originating model
-	 * @param \mako\database\midgard\ORM            $model      Related model
-	 * @param string|null                           $foreignKey Foreign key name
 	 */
 	public function __construct(
 		Connection $connection,
@@ -62,8 +55,6 @@ abstract class Relation extends Query
 
 	/**
 	 * Returns the foreign key name.
-	 *
-	 * @return string
 	 */
 	protected function getForeignKey(): string
 	{
@@ -77,9 +68,6 @@ abstract class Relation extends Query
 
 	/**
 	 * Returns the keys used to eagerly load records.
-	 *
-	 * @param  array $results Result set
-	 * @return array
 	 */
 	protected function keys(array $results): array
 	{
@@ -104,7 +92,6 @@ abstract class Relation extends Query
 	/**
 	 * Sets the criterion used when eager loading related records.
 	 *
-	 * @param  array $keys Keys
 	 * @return $this
 	 */
 	protected function eagerCriterion(array $keys)
@@ -116,9 +103,6 @@ abstract class Relation extends Query
 
 	/**
 	 * Eager loads records in chunks.
-	 *
-	 * @param  array                            $keys Keys
-	 * @return \mako\database\midgard\ResultSet
 	 */
 	protected function eagerLoadChunked(array $keys): ResultSet
 	{
@@ -173,10 +157,8 @@ abstract class Relation extends Query
 
 	/**
 	 * Returns a single record from the database.
-	 *
-	 * @return \mako\database\midgard\ORM|null
 	 */
-	public function first(): mixed
+	public function first(): ?ORM
 	{
 		$this->adjustQuery();
 
@@ -185,8 +167,6 @@ abstract class Relation extends Query
 
 	/**
 	 * Returns a result set from the database.
-	 *
-	 * @return \mako\database\midgard\ResultSet
 	 */
 	public function all(): ResultSet
 	{
@@ -197,17 +177,13 @@ abstract class Relation extends Query
 
 	/**
 	 * Fetches the related record(s) from the database.
-	 *
-	 * @return \mako\database\midgard\ORM|\mako\database\midgard\ResultSet|null
 	 */
-	abstract protected function fetchRelated();
+	abstract protected function fetchRelated(): mixed;
 
 	/**
 	 * Returns the related record(s) from the database.
-	 *
-	 * @return \mako\database\midgard\ORM|\mako\database\midgard\ResultSet|null
 	 */
-	public function getRelated()
+	public function getRelated(): mixed
 	{
 		if(!$this->origin->isPersisted())
 		{

--- a/src/mako/database/midgard/relations/Relation.php
+++ b/src/mako/database/midgard/relations/Relation.php
@@ -94,7 +94,7 @@ abstract class Relation extends Query
 	 *
 	 * @return $this
 	 */
-	protected function eagerCriterion(array $keys)
+	protected function eagerCriterion(array $keys): static
 	{
 		$this->in("{$this->table}.{$this->getForeignKey()}", $keys);
 
@@ -137,7 +137,7 @@ abstract class Relation extends Query
 	 *
 	 * @return $this
 	 */
-	protected function getRelationCountQuery()
+	protected function getRelationCountQuery(): static
 	{
 		$this->whereColumn("{$this->table}.{$this->getForeignKey()}", '=', "{$this->origin->getTable()}.{$this->origin->getPrimaryKey()}");
 

--- a/src/mako/database/midgard/relations/traits/HasOneOrManyPolymorphicTrait.php
+++ b/src/mako/database/midgard/relations/traits/HasOneOrManyPolymorphicTrait.php
@@ -17,18 +17,11 @@ trait HasOneOrManyPolymorphicTrait
 {
 	/**
 	 * Polymorphic type.
-	 *
-	 * @var string
 	 */
-	protected $polymorphicType;
+	protected string $polymorphicType;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\database\connections\Connection $connection      Database connection
-	 * @param \mako\database\midgard\ORM            $origin          Originating model
-	 * @param \mako\database\midgard\ORM            $model           Related model
-	 * @param string                                $polymorphicType Polymorphic type
 	 */
 	public function __construct(Connection $connection, ORM $origin, ORM $model, string $polymorphicType)
 	{
@@ -41,11 +34,8 @@ trait HasOneOrManyPolymorphicTrait
 
 	/**
 	 * Creates a related record.
-	 *
-	 * @param  array|\mako\database\midgard\ORM $related Related record
-	 * @return \mako\database\midgard\ORM
 	 */
-	public function create($related)
+	public function create(array|ORM $related): ORM
 	{
 		if($related instanceof $this->model)
 		{

--- a/src/mako/database/midgard/traits/CamelCasedDataExportTrait.php
+++ b/src/mako/database/midgard/traits/CamelCasedDataExportTrait.php
@@ -16,8 +16,6 @@ trait CamelCasedDataExportTrait
 {
 	/**
 	 * Returns an array representation of the record.
-	 *
-	 * @return array
 	 */
 	public function toArray(): array
 	{

--- a/src/mako/database/midgard/traits/CamelCasedDataInteractionTrait.php
+++ b/src/mako/database/midgard/traits/CamelCasedDataInteractionTrait.php
@@ -53,7 +53,7 @@ trait CamelCasedDataInteractionTrait
 	 *
 	 * @return $this
 	 */
-	public function assign(array $columns, bool $raw = false, bool $whitelist = true)
+	public function assign(array $columns, bool $raw = false, bool $whitelist = true): static
 	{
 		$snakeCased = [];
 

--- a/src/mako/database/midgard/traits/CamelCasedDataInteractionTrait.php
+++ b/src/mako/database/midgard/traits/CamelCasedDataInteractionTrait.php
@@ -21,9 +21,6 @@ trait CamelCasedDataInteractionTrait
 {
 	/**
 	 * Sets a raw column value.
-	 *
-	 * @param string $name  Column name
-	 * @param mixed  $value Column value
 	 */
 	public function setRawColumnValue(string $name, mixed $value): void
 	{
@@ -32,9 +29,6 @@ trait CamelCasedDataInteractionTrait
 
 	/**
 	 * Sets a column value.
-	 *
-	 * @param string $name  Column name
-	 * @param mixed  $value Column value
 	 */
 	public function setColumnValue(string $name, mixed $value): void
 	{
@@ -57,9 +51,6 @@ trait CamelCasedDataInteractionTrait
 	/**
 	 * Assigns the column values to the model.
 	 *
-	 * @param  array $columns   Column values
-	 * @param  bool  $raw       Set raw values?
-	 * @param  bool  $whitelist Remove columns that are not in the whitelist?
 	 * @return $this
 	 */
 	public function assign(array $columns, bool $raw = false, bool $whitelist = true)
@@ -76,9 +67,6 @@ trait CamelCasedDataInteractionTrait
 
 	/**
 	 * Gets a raw column value.
-	 *
-	 * @param  string $name Column name
-	 * @return mixed
 	 */
 	public function getRawColumnValue(string $name): mixed
 	{
@@ -87,9 +75,6 @@ trait CamelCasedDataInteractionTrait
 
 	/**
 	 * Returns a column value.
-	 *
-	 * @param  string $name Column name
-	 * @return mixed
 	 */
 	public function getColumnValue(string $name): mixed
 	{
@@ -105,9 +90,6 @@ trait CamelCasedDataInteractionTrait
 
 	/**
 	 * Gets a column value or relation.
-	 *
-	 * @param  string $name Column name
-	 * @return mixed
 	 */
 	public function getValue(string $name): mixed
 	{
@@ -137,9 +119,6 @@ trait CamelCasedDataInteractionTrait
 
 	/**
 	 * Checks if a column or relation is set using overloading.
-	 *
-	 * @param  string $name Column or relation name
-	 * @return bool
 	 */
 	public function __isset(string $name): bool
 	{
@@ -153,8 +132,6 @@ trait CamelCasedDataInteractionTrait
 
 	/**
 	 * Unset column value or relation using overloading.
-	 *
-	 * @param string $name Column name
 	 */
 	public function __unset(string $name): void
 	{

--- a/src/mako/database/midgard/traits/NullableTrait.php
+++ b/src/mako/database/midgard/traits/NullableTrait.php
@@ -17,8 +17,6 @@ trait NullableTrait
 {
 	/**
 	 * Returns array of nullable columns.
-	 *
-	 * @return array
 	 */
 	protected function getNullableColumns(): array
 	{
@@ -27,9 +25,6 @@ trait NullableTrait
 
 	/**
 	 * Will replace empty strings with null if the column is nullable.
-	 *
-	 * @param  array $values Values
-	 * @return array
 	 */
 	protected function setEmptyNullablesToNull(array $values): array
 	{
@@ -48,8 +43,6 @@ trait NullableTrait
 
 	/**
 	 * Returns trait hooks.
-	 *
-	 * @return array
 	 */
 	protected function getNullableTraitHooks(): array
 	{

--- a/src/mako/database/midgard/traits/OptimisticLockingTrait.php
+++ b/src/mako/database/midgard/traits/OptimisticLockingTrait.php
@@ -20,8 +20,6 @@ trait OptimisticLockingTrait
 {
 	/**
 	 * Returns trait hooks.
-	 *
-	 * @return array
 	 */
 	protected function getOptimisticLockingTraitHooks(): array
 	{
@@ -65,8 +63,6 @@ trait OptimisticLockingTrait
 
 	/**
 	 * Returns the optimistic locking column.
-	 *
-	 * @return string
 	 */
 	protected function getLockingColumn(): string
 	{
@@ -75,8 +71,6 @@ trait OptimisticLockingTrait
 
 	/**
 	 * Reloads the record from the database.
-	 *
-	 * @return bool
 	 */
 	public function reload(): bool
 	{
@@ -99,8 +93,6 @@ trait OptimisticLockingTrait
 
 	/**
 	 * Sets the optimistic locking version.
-	 *
-	 * @param int $version Locking version
 	 */
 	public function setLockVersion(int $version): void
 	{
@@ -109,8 +101,6 @@ trait OptimisticLockingTrait
 
 	/**
 	 * Returns the optimistic locking version.
-	 *
-	 * @return int
 	 */
 	public function getLockVersion(): int
 	{
@@ -119,9 +109,6 @@ trait OptimisticLockingTrait
 
 	/**
 	 * Updates an existing record.
-	 *
-	 * @param  \mako\database\midgard\Query $query Query builder
-	 * @return bool
 	 */
 	protected function updateRecord(Query $query): bool
 	{
@@ -145,9 +132,6 @@ trait OptimisticLockingTrait
 
 	/**
 	 * Deletes a record from the database.
-	 *
-	 * @param  \mako\database\midgard\Query $query Query builder
-	 * @return bool
 	 */
 	protected function deleteRecord(Query $query): bool
 	{

--- a/src/mako/database/midgard/traits/ReadOnlyTrait.php
+++ b/src/mako/database/midgard/traits/ReadOnlyTrait.php
@@ -16,8 +16,6 @@ trait ReadOnlyTrait
 {
 	/**
 	 * Returns trait hooks.
-	 *
-	 * @return array
 	 */
 	protected function getReadOnlyTraitHooks(): array
 	{

--- a/src/mako/database/midgard/traits/TimestampedTrait.php
+++ b/src/mako/database/midgard/traits/TimestampedTrait.php
@@ -20,8 +20,6 @@ trait TimestampedTrait
 {
 	/**
 	 * Returns trait hooks.
-	 *
-	 * @return array
 	 */
 	protected function getTimestampedTraitHooks(): array
 	{
@@ -92,8 +90,6 @@ trait TimestampedTrait
 
 	/**
 	 * Returns trait casts.
-	 *
-	 * @return array
 	 */
 	protected function getTimestampedTraitCasts(): array
 	{
@@ -102,8 +98,6 @@ trait TimestampedTrait
 
 	/**
 	 * Should we touch relations on insert?
-	 *
-	 * @return bool
 	 */
 	protected function shouldTouchOnInsert(): bool
 	{
@@ -112,8 +106,6 @@ trait TimestampedTrait
 
 	/**
 	 * Should we touch relations on update?
-	 *
-	 * @return bool
 	 */
 	protected function shouldTouchOnUpdate(): bool
 	{
@@ -122,8 +114,6 @@ trait TimestampedTrait
 
 	/**
 	 * Should we touch relations on delete?
-	 *
-	 * @return bool
 	 */
 	protected function shouldTouchOnDelete(): bool
 	{
@@ -132,8 +122,6 @@ trait TimestampedTrait
 
 	/**
 	 * Returns the column that holds the "created at" timestamp.
-	 *
-	 * @return string
 	 */
 	public function getCreatedAtColumn(): string
 	{
@@ -142,8 +130,6 @@ trait TimestampedTrait
 
 	/**
 	 * Returns the column that holds the "updated at" timestamp.
-	 *
-	 * @return string
 	 */
 	public function getUpdatedAtColumn(): string
 	{
@@ -152,8 +138,6 @@ trait TimestampedTrait
 
 	/**
 	 * Returns the relations that we should touch.
-	 *
-	 * @return array
 	 */
 	protected function getRelationsToTouch(): array
 	{
@@ -162,8 +146,6 @@ trait TimestampedTrait
 
 	/**
 	 * Allows you to update the "updated at" timestamp without modifying any data.
-	 *
-	 * @return bool
 	 */
 	public function touch(): bool
 	{

--- a/src/mako/database/migrations/Migration.php
+++ b/src/mako/database/migrations/Migration.php
@@ -20,29 +20,21 @@ abstract class Migration
 
 	/**
 	 * Should a transaction be used if possible?
-	 *
-	 * @var bool
 	 */
-	protected $useTransaction = true;
+	protected bool $useTransaction = true;
 
 	/**
 	 * Connection name.
-	 *
-	 * @var string|null
 	 */
-	protected $connectionName;
+	protected string|null $connectionName;
 
 	/**
 	 * Migration description.
-	 *
-	 * @var string|null
 	 */
-	protected $description;
+	protected string $description = '';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\database\ConnectionManager $database Connection manager instance
 	 */
 	public function __construct(
 		protected ConnectionManager $database
@@ -51,8 +43,6 @@ abstract class Migration
 
 	/**
 	 * Returns the connection name.
-	 *
-	 * @return string|null
 	 */
 	public function getConnectionName(): ?string
 	{
@@ -61,8 +51,6 @@ abstract class Migration
 
 	/**
 	 * Returns the chosen connection.
-	 *
-	 * @return \mako\database\connections\Connection
 	 */
 	public function getConnection(): Connection
 	{
@@ -71,8 +59,6 @@ abstract class Migration
 
 	/**
 	 * Should we execute this migration in a transaction?
-	 *
-	 * @return bool
 	 */
 	public function useTransaction(): bool
 	{
@@ -81,8 +67,6 @@ abstract class Migration
 
 	/**
 	 * Returns the migration description.
-	 *
-	 * @return string
 	 */
 	public function getDescription(): string
 	{

--- a/src/mako/database/query/Join.php
+++ b/src/mako/database/query/Join.php
@@ -16,16 +16,11 @@ class Join
 {
 	/**
 	 * ON conditions.
-	 *
-	 * @var array
 	 */
-	protected $conditions = [];
+	protected array $conditions = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string|null                                                        $type  Join type
-	 * @param \mako\database\query\Raw|\mako\database\query\Subquery|string|null $table Table we are joining
 	 */
 	public function __construct(
 		protected ?string $type = null,
@@ -35,8 +30,6 @@ class Join
 
 	/**
 	 * Returns the join type.
-	 *
-	 * @return string
 	 */
 	public function getType(): string
 	{
@@ -45,8 +38,6 @@ class Join
 
 	/**
 	 * Returns the table name.
-	 *
-	 * @return mixed
 	 */
 	public function getTable(): mixed
 	{
@@ -55,8 +46,6 @@ class Join
 
 	/**
 	 * Does this join have conditions?
-	 *
-	 * @return bool
 	 */
 	public function hasConditions(): bool
 	{
@@ -65,8 +54,6 @@ class Join
 
 	/**
 	 * Returns ON conditions.
-	 *
-	 * @return array
 	 */
 	public function getConditions(): array
 	{
@@ -75,12 +62,6 @@ class Join
 
 	/**
 	 * Adds a ON condition to the join.
-	 *
-	 * @param  \Closure|\mako\database\query\Raw|string $column1   Column name
-	 * @param  string|null                              $operator  Operator
-	 * @param  \mako\database\query\Raw|string|null     $column2   Column name
-	 * @param  string                                   $separator Condition separator
-	 * @return \mako\database\query\Join
 	 */
 	public function on(Closure|Raw|string $column1, ?string $operator = null, Raw|string|null $column2 = null, string $separator = 'AND'): Join
 	{
@@ -114,13 +95,6 @@ class Join
 
 	/**
 	 * Adds a raw ON condition to the join.
-	 *
-	 * @param  \mako\database\query\Raw|string $column1    Column name
-	 * @param  string                          $operator   Operator
-	 * @param  string                          $raw        Raw SQL
-	 * @param  array                           $parameters Parameters
-	 * @param  string                          $separator  Condition separator
-	 * @return \mako\database\query\Join
 	 */
 	public function onRaw(Raw|string $column1, string $operator, string $raw, array $parameters = [], string $separator = 'AND'): Join
 	{
@@ -129,11 +103,6 @@ class Join
 
 	/**
 	 * Adds a OR ON condition to the join.
-	 *
-	 * @param  \Closure|\mako\database\query\Raw|string $column1  Column name
-	 * @param  string|null                              $operator Operator
-	 * @param  \mako\database\query\Raw|string|null     $column2  Column name
-	 * @return \mako\database\query\Join
 	 */
 	public function orOn(Closure|Raw|string $column1, ?string $operator = null, Raw|string|null $column2 = null): Join
 	{
@@ -142,12 +111,6 @@ class Join
 
 	/**
 	 * Adds a raw OR ON condition to the join.
-	 *
-	 * @param  \mako\database\query\Raw|string $column1    Column name
-	 * @param  string                          $operator   Operator
-	 * @param  string                          $raw        Raw SQL
-	 * @param  array                           $parameters Parameters
-	 * @return \mako\database\query\Join
 	 */
 	public function orOnRaw(Raw|string $column1, string $operator, string $raw, array $parameters = []): Join
 	{

--- a/src/mako/database/query/Query.php
+++ b/src/mako/database/query/Query.php
@@ -12,6 +12,8 @@ use DateTimeInterface;
 use Generator;
 use mako\database\connections\Connection;
 use mako\database\exceptions\NotFoundException;
+use mako\database\query\compilers\Compiler;
+use mako\database\query\helpers\HelperInterface;
 use mako\pagination\PaginationFactoryInterface;
 use PDO;
 
@@ -29,134 +31,96 @@ class Query
 {
 	/**
 	 * Query helper.
-	 *
-	 * @var \mako\database\query\helpers\HelperInterface
 	 */
-	protected $helper;
+	protected HelperInterface $helper;
 
 	/**
 	 * Query compiler.
-	 *
-	 * @var \mako\database\query\compilers\Compiler
 	 */
-	protected $compiler;
+	protected Compiler $compiler;
 
 	/**
 	 * Database table.
-	 *
-	 * @var array|\mako\database\query\Raw|\mako\database\query\Subquery|string|null
 	 */
-	protected $table;
+	protected array|Raw|Subquery|string|null $table = null;
 
 	/**
 	 * Select distinct?
-	 *
-	 * @var bool
 	 */
-	protected $distinct = false;
+	protected bool $distinct = false;
 
 	/**
 	 * Common table expressions.
-	 *
-	 * @var array
 	 */
-	protected $commonTableExpressions = ['recursive' => false, 'ctes' => []];
+	protected array $commonTableExpressions = ['recursive' => false, 'ctes' => []];
 
 	/**
 	 * Set operations.
-	 *
-	 * @var array
 	 */
-	protected $setOperations = [];
+	protected array $setOperations = [];
 
 	/**
 	 * Columns from which we are fetching data.
-	 *
-	 * @var array
 	 */
-	protected $columns = ['*'];
+	protected array $columns = ['*'];
 
 	/**
 	 * WHERE clauses.
-	 *
-	 * @var array
 	 */
-	protected $wheres = [];
+	protected array $wheres = [];
 
 	/**
 	 * JOIN clauses.
-	 *
-	 * @var array
 	 */
-	protected $joins = [];
+	protected array $joins = [];
 
 	/**
 	 * GROUP BY clauses.
-	 *
-	 * @var array
 	 */
-	protected $groupings = [];
+	protected array $groupings = [];
 
 	/**
 	 * HAVING clauses.
-	 *
-	 * @var array
 	 */
-	protected $havings = [];
+	protected array $havings = [];
 
 	/**
 	 * ORDER BY clauses.
-	 *
-	 * @var array
 	 */
-	protected $orderings = [];
+	protected array $orderings = [];
 
 	/**
 	 * Limit.
-	 *
-	 * @var int|null
 	 */
-	protected $limit = null;
+	protected int|null $limit = null;
 
 	/**
 	 * Offset.
-	 *
-	 * @var int|null
 	 */
-	protected $offset = null;
+	protected int|null $offset = null;
 
 	/**
 	 * Lock.
-	 *
-	 * @var bool|string|null
 	 */
-	protected $lock = null;
+	protected bool|string|null $lock = null;
 
 	/**
 	 * Prefix.
-	 *
-	 * @var string|null
 	 */
-	protected $prefix = null;
+	protected string|null $prefix = null;
 
 	/**
 	 * Is the query in subquery context?
-	 *
-	 * @var bool
 	 */
-	protected $inSubqueryContext = false;
+	protected bool $inSubqueryContext = false;
 
 	/**
 	 * Pagination factory.
-	 *
-	 * @var \Closure|\mako\pagination\PaginationFactoryInterface
 	 */
-	protected static $paginationFactory;
+	protected static Closure|PaginationFactoryInterface $paginationFactory;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\database\connections\Connection $connection Database connection
 	 */
 	public function __construct(
 		protected Connection $connection
@@ -195,8 +159,6 @@ class Query
 
 	/**
 	 * Returns a new query builder instance.
-	 *
-	 * @return self
 	 */
 	public function newInstance(): self
 	{
@@ -217,8 +179,6 @@ class Query
 
 	/**
 	 * Sets the pagination factory.
-	 *
-	 * @param \Closure|\mako\pagination\PaginationFactoryInterface $factory Pagination factory
 	 */
 	public static function setPaginationFactory(Closure|PaginationFactoryInterface $factory): void
 	{
@@ -227,8 +187,6 @@ class Query
 
 	/**
 	 * Gets the pagination factory.
-	 *
-	 * @return \mako\pagination\PaginationFactoryInterface
 	 */
 	public static function getPaginationFactory(): PaginationFactoryInterface
 	{
@@ -244,28 +202,22 @@ class Query
 
 	/**
 	 * Returns the connection instance.
-	 *
-	 * @return \mako\database\connections\Connection
 	 */
-	public function getConnection()
+	public function getConnection(): Connection
 	{
 		return $this->connection;
 	}
 
 	/**
 	 * Returns query compiler instance.
-	 *
-	 * @return \mako\database\query\compilers\Compiler
 	 */
-	public function getCompiler()
+	public function getCompiler(): Compiler
 	{
 		return $this->compiler;
 	}
 
 	/**
 	 * Returns the common set operations.
-	 *
-	 * @return array
 	 */
 	public function getCommonTableExpressions(): array
 	{
@@ -274,8 +226,6 @@ class Query
 
 	/**
 	 * Returns the set operations.
-	 *
-	 * @return array
 	 */
 	public function getSetOperations(): array
 	{
@@ -284,8 +234,6 @@ class Query
 
 	/**
 	 * Returns the database table.
-	 *
-	 * @return array|\mako\database\query\Raw|\mako\database\query\Subquery|string|null
 	 */
 	public function getTable(): array|Raw|Subquery|string|null
 	{
@@ -294,8 +242,6 @@ class Query
 
 	/**
 	 * Is it a distict select?
-	 *
-	 * @return bool
 	 */
 	public function isDistinct(): bool
 	{
@@ -304,8 +250,6 @@ class Query
 
 	/**
 	 * Returns the columns from which we are fetching data.
-	 *
-	 * @return array
 	 */
 	public function getColumns(): array
 	{
@@ -314,8 +258,6 @@ class Query
 
 	/**
 	 * Returns WHERE clauses.
-	 *
-	 * @return array
 	 */
 	public function getWheres(): array
 	{
@@ -324,8 +266,6 @@ class Query
 
 	/**
 	 * Returns JOIN clauses.
-	 *
-	 * @return array
 	 */
 	public function getJoins(): array
 	{
@@ -334,8 +274,6 @@ class Query
 
 	/**
 	 * Returns GROUP BY clauses.
-	 *
-	 * @return array
 	 */
 	public function getGroupings(): array
 	{
@@ -344,8 +282,6 @@ class Query
 
 	/**
 	 * Returns HAVING clauses.
-	 *
-	 * @return array
 	 */
 	public function getHavings(): array
 	{
@@ -354,8 +290,6 @@ class Query
 
 	/**
 	 * Returns ORDER BY clauses.
-	 *
-	 * @return array
 	 */
 	public function getOrderings(): array
 	{
@@ -364,8 +298,6 @@ class Query
 
 	/**
 	 * Returns the limit.
-	 *
-	 * @return int|null
 	 */
 	public function getLimit(): ?int
 	{
@@ -374,8 +306,6 @@ class Query
 
 	/**
 	 * Returns the offset.
-	 *
-	 * @return int|null
 	 */
 	public function getOffset(): ?int
 	{
@@ -384,8 +314,6 @@ class Query
 
 	/**
 	 * Returns the lock.
-	 *
-	 * @return bool|string|null
 	 */
 	public function getLock(): bool|string|null
 	{
@@ -394,8 +322,6 @@ class Query
 
 	/**
 	 * Returns the prefix.
-	 *
-	 * @return string|null
 	 */
 	public function getPrefix(): ?string
 	{
@@ -405,8 +331,6 @@ class Query
 	/**
 	 * Executes the closure if the compiler is of the correct class.
 	 *
-	 * @param  string   $compilerClass Compiler class name
-	 * @param  \Closure $query         Closure
 	 * @return $this
 	 */
 	public function forCompiler(string $compilerClass, Closure $query)
@@ -422,9 +346,6 @@ class Query
 	/**
 	 * Adds a common table expression.
 	 *
-	 * @param  string                        $name    Table name
-	 * @param  array                         $columns Column names
-	 * @param  \mako\database\query\Subquery $query   Query
 	 * @return $this
 	 */
 	public function with(string $name, array $columns, Subquery $query)
@@ -442,9 +363,6 @@ class Query
 	/**
 	 * Adds a recursive common table expression.
 	 *
-	 * @param  string                        $name    Table name
-	 * @param  array                         $columns Column names
-	 * @param  \mako\database\query\Subquery $query   Query
 	 * @return $this
 	 */
 	public function withRecursive(string $name, array $columns, Subquery $query)
@@ -457,7 +375,6 @@ class Query
 	/**
 	 * Adds a set operation.
 	 *
-	 * @param  string $operation Operation
 	 * @return $this
 	 */
 	protected function setOperation(string $operation)
@@ -538,7 +455,6 @@ class Query
 	/**
 	 * Sets table we want to query.
 	 *
-	 * @param  array|\mako\database\query\Raw|\mako\database\query\Subquery|string|null $table Database table or subquery
 	 * @return $this
 	 */
 	public function table(array|Raw|Subquery|string|null $table)
@@ -551,7 +467,6 @@ class Query
 	/**
 	 * Alias of Query::table().
 	 *
-	 * @param  array|\mako\database\query\Raw|\mako\database\query\Subquery|string|null $table Database table or subquery
 	 * @return $this
 	 */
 	public function from(array|Raw|Subquery|string|null $table)
@@ -562,7 +477,6 @@ class Query
 	/**
 	 * Alias of Query::table().
 	 *
-	 * @param  array|\mako\database\query\Raw|\mako\database\query\Subquery|string|null $table Database table or subquery
 	 * @return $this
 	 */
 	public function into(array|Raw|Subquery|string|null $table)
@@ -573,7 +487,6 @@ class Query
 	/**
 	 * Sets the columns we want to select.
 	 *
-	 * @param  array $columns Array of columns we want to select from
 	 * @return $this
 	 */
 	public function select(array $columns)
@@ -586,8 +499,6 @@ class Query
 	/**
 	 * Sets the columns we want to select using raw SQL.
 	 *
-	 * @param  string $sql        Raw sql
-	 * @param  array  $parameters Parameters
 	 * @return $this
 	 */
 	public function selectRaw(string $sql, array $parameters = [])
@@ -612,10 +523,6 @@ class Query
 	/**
 	 * Adds a WHERE clause.
 	 *
-	 * @param  array|\Closure|\mako\database\query\Raw|string $column    Column name or an array of column names
-	 * @param  string|null                                    $operator  Operator
-	 * @param  mixed                                          $value     Value
-	 * @param  string                                         $separator Clause separator
 	 * @return $this
 	 */
 	public function where(array|Closure|Raw|string $column, ?string $operator = null, mixed $value = null, string $separator = 'AND')
@@ -651,10 +558,6 @@ class Query
 	/**
 	 * Adds a raw WHERE clause.
 	 *
-	 * @param  array|\mako\database\query\Raw|string $column    Column name, an array of column names or raw SQL
-	 * @param  array|string|null                     $operator  Operator or parameters
-	 * @param  string|null                           $raw       Raw SQL
-	 * @param  string                                $separator Clause separator
 	 * @return $this
 	 */
 	public function whereRaw(array|Raw|string $column, array|string|null $operator = null, ?string $raw = null, string $separator = 'AND')
@@ -677,9 +580,6 @@ class Query
 	/**
 	 * Adds a OR WHERE clause.
 	 *
-	 * @param  array|\Closure|\mako\database\query\Raw|string $column   Column name or an array of column names
-	 * @param  string|null                                    $operator Operator
-	 * @param  mixed                                          $value    Value
 	 * @return $this
 	 */
 	public function orWhere(array|Closure|Raw|string $column, ?string $operator = null, mixed $value = null)
@@ -690,9 +590,6 @@ class Query
 	/**
 	 * Adds a raw OR WHERE clause.
 	 *
-	 * @param  array|\mako\database\query\Raw|string $column   Column name, and array of column names or raw SQL
-	 * @param  array|string|null                     $operator Operator or parameters
-	 * @param  string|null                           $raw      Raw SQL
 	 * @return $this
 	 */
 	public function orWhereRaw(array|Raw|string $column, array|string|null $operator = null, ?string $raw = null)
@@ -703,10 +600,6 @@ class Query
 	/**
 	 * Adds a date comparison clause.
 	 *
-	 * @param  string                    $column    Column name
-	 * @param  string                    $operator  Operator
-	 * @param  \DateTimeInterface|string $date      Date
-	 * @param  string                    $separator Separator
 	 * @return $this
 	 */
 	public function whereDate(string $column, string $operator, DateTimeInterface|string $date, string $separator = 'AND')
@@ -727,9 +620,6 @@ class Query
 	/**
 	 * Adds a date comparison clause.
 	 *
-	 * @param  string                    $column   Column name
-	 * @param  string                    $operator Operator
-	 * @param  \DateTimeInterface|string $date     Date
 	 * @return $this
 	 */
 	public function orWhereDate(string $column, string $operator, DateTimeInterface|string $date)
@@ -740,10 +630,6 @@ class Query
 	/**
 	 * Adds a column comparison clause.
 	 *
-	 * @param  array|string $column1   Column name of array of column names
-	 * @param  string       $operator  Operator
-	 * @param  array|string $column2   Column name of array of column names
-	 * @param  string       $separator Separator
 	 * @return $this
 	 */
 	public function whereColumn(array|string $column1, string $operator, array|string $column2, string $separator = 'AND')
@@ -763,9 +649,6 @@ class Query
 	/**
 	 * Adds a column comparison clause.
 	 *
-	 * @param  array|string $column1  Column name of array of column names
-	 * @param  string       $operator Operator
-	 * @param  array|string $column2  Column name of array of column names
 	 * @return $this
 	 */
 	public function orWhereColumn(array|string $column1, string $operator, array|string $column2)
@@ -776,11 +659,6 @@ class Query
 	/**
 	 * Adds a BETWEEN clause.
 	 *
-	 * @param  mixed  $column    Column name
-	 * @param  mixed  $value1    First value
-	 * @param  mixed  $value2    Second value
-	 * @param  string $separator Clause separator
-	 * @param  bool   $not       Not between?
 	 * @return $this
 	 */
 	public function between(mixed $column, mixed $value1, mixed $value2, string $separator = 'AND', bool $not = false)
@@ -801,9 +679,6 @@ class Query
 	/**
 	 * Adds a OR BETWEEN clause.
 	 *
-	 * @param  mixed $column Column name
-	 * @param  mixed $value1 First value
-	 * @param  mixed $value2 Second value
 	 * @return $this
 	 */
 	public function orBetween(mixed $column, mixed $value1, mixed $value2)
@@ -814,9 +689,6 @@ class Query
 	/**
 	 * Adds a NOT BETWEEN clause.
 	 *
-	 * @param  mixed $column Column name
-	 * @param  mixed $value1 First value
-	 * @param  mixed $value2 Second value
 	 * @return $this
 	 */
 	public function notBetween(mixed $column, mixed $value1, mixed $value2)
@@ -827,9 +699,6 @@ class Query
 	/**
 	 * Adds a OR NOT BETWEEN clause.
 	 *
-	 * @param  mixed $column Column name
-	 * @param  mixed $value1 First value
-	 * @param  mixed $value2 Second value
 	 * @return $this
 	 */
 	public function orNotBetween(mixed $column, mixed $value1, mixed $value2)
@@ -840,11 +709,6 @@ class Query
 	/**
 	 * Adds a date range clause.
 	 *
-	 * @param  string                    $column    Column name
-	 * @param  \DateTimeInterface|string $date1     First date
-	 * @param  \DateTimeInterface|string $date2     Second date
-	 * @param  string                    $separator Separator
-	 * @param  bool                      $not       Not between?
 	 * @return $this
 	 */
 	public function betweenDate(string $column, DateTimeInterface|string $date1, DateTimeInterface|string $date2, string $separator = 'AND', bool $not = false)
@@ -865,9 +729,6 @@ class Query
 	/**
 	 * Adds a date range clause.
 	 *
-	 * @param  string                    $column Column name
-	 * @param  \DateTimeInterface|string $date1  First date
-	 * @param  \DateTimeInterface|string $date2  Second date
 	 * @return $this
 	 */
 	public function orBetweenDate(string $column, DateTimeInterface|string $date1, DateTimeInterface|string $date2)
@@ -878,9 +739,6 @@ class Query
 	/**
 	 * Adds a date range clause.
 	 *
-	 * @param  string                    $column Column name
-	 * @param  \DateTimeInterface|string $date1  First date
-	 * @param  \DateTimeInterface|string $date2  Second date
 	 * @return $this
 	 */
 	public function notBetweenDate(string $column, DateTimeInterface|string $date1, DateTimeInterface|string $date2)
@@ -891,9 +749,6 @@ class Query
 	/**
 	 * Adds a date range clause.
 	 *
-	 * @param  string                    $column Column name
-	 * @param  \DateTimeInterface|string $date1  First date
-	 * @param  \DateTimeInterface|string $date2  Second date
 	 * @return $this
 	 */
 	public function orNotBetweenDate(string $column, DateTimeInterface|string $date1, DateTimeInterface|string $date2)
@@ -904,10 +759,6 @@ class Query
 	/**
 	 * Adds a IN clause.
 	 *
-	 * @param  mixed                                                        $column    Column name
-	 * @param  array|\mako\database\query\Raw|\mako\database\query\Subquery $values    Array of values or Subquery
-	 * @param  string                                                       $separator Clause separator
-	 * @param  bool                                                         $not       Not in?
 	 * @return $this
 	 */
 	public function in(mixed $column, array|Raw|Subquery $values, string $separator = 'AND', bool $not = false)
@@ -927,8 +778,6 @@ class Query
 	/**
 	 * Adds a OR IN clause.
 	 *
-	 * @param  mixed                                                        $column Column name
-	 * @param  array|\mako\database\query\Raw|\mako\database\query\Subquery $values Array of values or Subquery
 	 * @return $this
 	 */
 	public function orIn(mixed $column, array|Raw|Subquery $values)
@@ -939,8 +788,6 @@ class Query
 	/**
 	 * Adds a NOT IN clause.
 	 *
-	 * @param  mixed                                                        $column Column name
-	 * @param  array|\mako\database\query\Raw|\mako\database\query\Subquery $values Array of values or Subquery
 	 * @return $this
 	 */
 	public function notIn(mixed $column, array|Raw|Subquery $values)
@@ -951,8 +798,6 @@ class Query
 	/**
 	 * Adds a OR NOT IN clause.
 	 *
-	 * @param  mixed                                                        $column Column name
-	 * @param  array|\mako\database\query\Raw|\mako\database\query\Subquery $values Array of values or Subquery
 	 * @return $this
 	 */
 	public function orNotIn(mixed $column, array|Raw|Subquery $values)
@@ -963,9 +808,6 @@ class Query
 	/**
 	 * Adds a IS NULL clause.
 	 *
-	 * @param  mixed  $column    Column name
-	 * @param  string $separator Clause separator
-	 * @param  bool   $not       Not in?
 	 * @return $this
 	 */
 	public function isNull(mixed $column, string $separator = 'AND', bool $not = false)
@@ -984,7 +826,6 @@ class Query
 	/**
 	 * Adds a OR IS NULL clause.
 	 *
-	 * @param  mixed $column Column name
 	 * @return $this
 	 */
 	public function orIsNull(mixed $column)
@@ -995,7 +836,6 @@ class Query
 	/**
 	 * Adds a IS NOT NULL clause.
 	 *
-	 * @param  mixed $column Column name
 	 * @return $this
 	 */
 	public function isNotNull(mixed $column)
@@ -1006,7 +846,6 @@ class Query
 	/**
 	 * Adds a OR IS NOT NULL clause.
 	 *
-	 * @param  mixed $column Column name
 	 * @return $this
 	 */
 	public function orIsNotNull(mixed $column)
@@ -1017,9 +856,6 @@ class Query
 	/**
 	 * Adds a EXISTS clause.
 	 *
-	 * @param  \mako\database\query\Subquery $query     Subquery
-	 * @param  string                        $separator Clause separator
-	 * @param  bool                          $not       Not exists?
 	 * @return $this
 	 */
 	public function exists(Subquery $query, string $separator = 'AND', bool $not = false)
@@ -1038,7 +874,6 @@ class Query
 	/**
 	 * Adds a OR EXISTS clause.
 	 *
-	 * @param  \mako\database\query\Subquery $query Subquery
 	 * @return $this
 	 */
 	public function orExists(Subquery $query)
@@ -1049,7 +884,6 @@ class Query
 	/**
 	 * Adds a NOT EXISTS clause.
 	 *
-	 * @param  \mako\database\query\Subquery $query Subquery
 	 * @return $this
 	 */
 	public function notExists(Subquery $query)
@@ -1060,7 +894,6 @@ class Query
 	/**
 	 * Adds a OR NOT EXISTS clause.
 	 *
-	 * @param  \mako\database\query\Subquery $query Subquery
 	 * @return $this
 	 */
 	public function orNotExists(Subquery $query)
@@ -1071,11 +904,6 @@ class Query
 	/**
 	 * Adds a JOIN clause.
 	 *
-	 * @param  \mako\database\query\Raw|\mako\database\query\Subquery|string $table    Table name
-	 * @param  \Closure|\mako\database\query\Raw|string|null                 $column1  Column name
-	 * @param  string|null                                                   $operator Operator
-	 * @param  \mako\database\query\Raw|string|null                          $column2  Column name
-	 * @param  string                                                        $type     Join type
 	 * @return $this
 	 */
 	public function join(Raw|Subquery|string $table, Closure|Raw|string|null $column1 = null, ?string $operator = null, Raw|string|null $column2 = null, string $type = 'INNER JOIN')
@@ -1099,11 +927,6 @@ class Query
 	/**
 	 * Adds a raw JOIN clause.
 	 *
-	 * @param  \mako\database\query\Raw|\mako\database\query\Subquery|string $table    Table name
-	 * @param  \mako\database\query\Raw|string                               $column1  Column name
-	 * @param  string                                                        $operator Operator
-	 * @param  string                                                        $raw      Raw SQL
-	 * @param  string                                                        $type     Join type
 	 * @return $this
 	 */
 	public function joinRaw(Raw|Subquery|string $table, Raw|string $column1, string $operator, string $raw, string $type = 'INNER JOIN')
@@ -1114,10 +937,6 @@ class Query
 	/**
 	 * Adds a LEFT OUTER JOIN clause.
 	 *
-	 * @param  \mako\database\query\Raw|\mako\database\query\Subquery|string $table    Table name
-	 * @param  \Closure|\mako\database\query\Raw|string|null                 $column1  Column name
-	 * @param  string|null                                                   $operator Operator
-	 * @param  \mako\database\query\Raw|string|null                          $column2  Column name
 	 * @return $this
 	 */
 	public function leftJoin(Raw|Subquery|string $table, Closure|Raw|string|null $column1 = null, ?string $operator = null, Raw|string|null $column2 = null)
@@ -1128,10 +947,6 @@ class Query
 	/**
 	 * Adds a raw LEFT OUTER JOIN clause.
 	 *
-	 * @param  \mako\database\query\Raw|\mako\database\query\Subquery|string $table    Table name
-	 * @param  \mako\database\query\Raw|string                               $column1  Column name
-	 * @param  string                                                        $operator Operator
-	 * @param  string                                                        $raw      Raw SQL
 	 * @return $this
 	 */
 	public function leftJoinRaw(Raw|Subquery|string $table, Raw|string $column1, string $operator, string $raw)
@@ -1142,10 +957,6 @@ class Query
 	/**
 	 * Adds a RIGHT OUTER JOIN clause.
 	 *
-	 * @param  \mako\database\query\Raw|\mako\database\query\Subquery|string $table    Table name
-	 * @param  \Closure|\mako\database\query\Raw|string|null                 $column1  Column name
-	 * @param  string|null                                                   $operator Operator
-	 * @param  \mako\database\query\Raw|string|null                          $column2  Column name
 	 * @return $this
 	 */
 	public function rightJoin(Raw|Subquery|string $table, Closure|Raw|string|null $column1 = null, ?string $operator = null, Raw|string|null $column2 = null)
@@ -1156,10 +967,6 @@ class Query
 	/**
 	 * Adds a raw RIGHT OUTER JOIN clause.
 	 *
-	 * @param  \mako\database\query\Raw|\mako\database\query\Subquery|string $table    Table name
-	 * @param  \mako\database\query\Raw|string                               $column1  Column name
-	 * @param  string                                                        $operator Operator
-	 * @param  string                                                        $raw      Raw SQL
 	 * @return $this
 	 */
 	public function rightJoinRaw(Raw|Subquery|string $table, Raw|string $column1, string $operator, string $raw)
@@ -1170,7 +977,6 @@ class Query
 	/**
 	 * Adds a CROSS JOIN clause.
 	 *
-	 * @param  \mako\database\query\Subquery|string $table Table name or subquery
 	 * @return $this
 	 */
 	public function crossJoin(Raw|Subquery|string $table)
@@ -1181,8 +987,6 @@ class Query
 	/**
 	 * Adds a LATERAL JOIN clause.
 	 *
-	 * @param  \mako\database\query\Subquery $subquery Subquery
-	 * @param  string                        $type     Join type
 	 * @return $this
 	 */
 	public function lateralJoin(Subquery $subquery, string $type = 'LEFT OUTER JOIN')
@@ -1193,7 +997,6 @@ class Query
 	/**
 	 * Adds a GROUP BY clause.
 	 *
-	 * @param  array|string $columns Column name or array of column names
 	 * @return $this
 	 */
 	public function groupBy(array|string $columns)
@@ -1206,10 +1009,6 @@ class Query
 	/**
 	 * Adds a HAVING clause.
 	 *
-	 * @param  \mako\database\query\Raw|string $column    Column name
-	 * @param  string                          $operator  Operator
-	 * @param  mixed                           $value     Value
-	 * @param  string                          $separator Clause separator
 	 * @return $this
 	 */
 	public function having(Raw|string $column, string $operator, mixed $value, string $separator = 'AND')
@@ -1228,10 +1027,6 @@ class Query
 	/**
 	 * Adds a raw HAVING clause.
 	 *
-	 * @param  string $raw       Raw SQL
-	 * @param  string $operator  Operator
-	 * @param  mixed  $value     Value
-	 * @param  string $separator Clause separator
 	 * @return $this
 	 */
 	public function havingRaw(string $raw, string $operator, mixed $value, string $separator = 'AND')
@@ -1242,9 +1037,6 @@ class Query
 	/**
 	 * Adds a OR HAVING clause.
 	 *
-	 * @param  \mako\database\query\Raw|string $column   Column name
-	 * @param  string                          $operator Operator
-	 * @param  mixed                           $value    Value
 	 * @return $this
 	 */
 	public function orHaving(Raw|string $column, string $operator, mixed $value)
@@ -1255,9 +1047,6 @@ class Query
 	/**
 	 * Adds a raw OR HAVING clause.
 	 *
-	 * @param  string $raw      Raw SQL
-	 * @param  string $operator Operator
-	 * @param  mixed  $value    Value
 	 * @return $this
 	 */
 	public function orHavingRaw(string $raw, string $operator, mixed $value)
@@ -1268,8 +1057,6 @@ class Query
 	/**
 	 * Adds a ORDER BY clause.
 	 *
-	 * @param  array|\mako\database\query\Raw|string $columns Column name or array of column names
-	 * @param  string                                $order   Sorting order
 	 * @return $this
 	 */
 	public function orderBy(array|Raw|string $columns, string $order = 'ASC')
@@ -1286,9 +1073,6 @@ class Query
 	/**
 	 * Adds a raw ORDER BY clause.
 	 *
-	 * @param  string $raw        Raw SQL
-	 * @param  array  $parameters Parameters
-	 * @param  string $order      Sorting order
 	 * @return $this
 	 */
 	public function orderByRaw(string $raw, array $parameters = [], string $order = 'ASC')
@@ -1299,7 +1083,6 @@ class Query
 	/**
 	 * Adds an ascending ORDER BY clause.
 	 *
-	 * @param  array|string $columns Column name or array of column names
 	 * @return $this
 	 */
 	public function ascending(array|string $columns)
@@ -1310,8 +1093,6 @@ class Query
 	/**
 	 * Adds a raw ascending ORDER BY clause.
 	 *
-	 * @param  string $raw        Raw SQL
-	 * @param  array  $parameters Parameters
 	 * @return $this
 	 */
 	public function ascendingRaw(string $raw, array $parameters = [])
@@ -1322,7 +1103,6 @@ class Query
 	/**
 	 * Adds a descending ORDER BY clause.
 	 *
-	 * @param  array|string $columns Column name or array of column names
 	 * @return $this
 	 */
 	public function descending(array|string $columns)
@@ -1333,8 +1113,6 @@ class Query
 	/**
 	 * Adds a raw descending ORDER BY clause.
 	 *
-	 * @param  string $raw        Raw SQL
-	 * @param  array  $parameters Parameters
 	 * @return $this
 	 */
 	public function descendingRaw(string $raw, array $parameters = [])
@@ -1357,7 +1135,6 @@ class Query
 	/**
 	 * Adds a LIMIT clause.
 	 *
-	 * @param  int   $limit Limit
 	 * @return $this
 	 */
 	public function limit(int $limit)
@@ -1370,7 +1147,6 @@ class Query
 	/**
 	 * Adds a OFFSET clause.
 	 *
-	 * @param  int   $offset Offset
 	 * @return $this
 	 */
 	public function offset(int $offset)
@@ -1383,7 +1159,6 @@ class Query
 	/**
 	 * Enable lock.
 	 *
-	 * @param  bool|string $lock TRUE for exclusive, FALSE for shared and string for custom
 	 * @return $this
 	 */
 	public function lock(bool|string $lock = true)
@@ -1406,7 +1181,6 @@ class Query
 	/**
 	 * Adds a query prefix.
 	 *
-	 * @param  string $prefix Prefix
 	 * @return $this
 	 */
 	public function prefix(string $prefix)
@@ -1418,9 +1192,6 @@ class Query
 
 	/**
 	 * Executes a SELECT query and returns the first row of the result set or NULL if nothing is found.
-	 *
-	 * @param  mixed ...$fetchMode Fetch mode
-	 * @return mixed
 	 */
 	protected function fetchFirst(mixed ...$fetchMode): mixed
 	{
@@ -1431,8 +1202,6 @@ class Query
 
 	/**
 	 * Executes a SELECT query and returns the first row of the result set or NULL if nothing is found.
-	 *
-	 * @return mixed
 	 */
 	public function first(): mixed
 	{
@@ -1441,10 +1210,6 @@ class Query
 
 	/**
 	 * Executes a SELECT query and returns the first row of the result set or throw an exception if nothing is found.
-	 *
-	 * @param  string $exception    Exception class
-	 * @param  mixed  ...$fetchMode Fetch mode
-	 * @return mixed
 	 */
 	protected function fetchFirstOrThrow(string $exception, mixed ...$fetchMode): mixed
 	{
@@ -1455,9 +1220,6 @@ class Query
 
 	/**
 	 * Executes a SELECT query and returns the first row of the result set or throw an exception if nothing is found.
-	 *
-	 * @param  string $exception Exception class
-	 * @return mixed
 	 */
 	public function firstOrThrow(string $exception = NotFoundException::class): mixed
 	{
@@ -1466,9 +1228,6 @@ class Query
 
 	/**
 	 * Creates a result set.
-	 *
-	 * @param  array                          $results Results
-	 * @return \mako\database\query\ResultSet
 	 */
 	protected function createResultSet(array $results): ResultSet
 	{
@@ -1477,10 +1236,6 @@ class Query
 
 	/**
 	 * Executes a SELECT query and returns an array containing all of the result set rows.
-	 *
-	 * @param  bool                                 $returnResultSet Return result set?
-	 * @param  mixed                                ...$fetchMode    Fetch mode
-	 * @return array|\mako\database\query\ResultSet
 	 */
 	protected function fetchAll(bool $returnResultSet, mixed ...$fetchMode): array|ResultSet
 	{
@@ -1493,8 +1248,6 @@ class Query
 
 	/**
 	 * Executes a SELECT query and returns an array containing all of the result set rows.
-	 *
-	 * @return \mako\database\query\ResultSet
 	 */
 	public function all(): ResultSet
 	{
@@ -1503,9 +1256,6 @@ class Query
 
 	/**
 	 * Executes a SELECT query and returns the value of the chosen column of the first row of the result set.
-	 *
-	 * @param  string|null $column The column to select
-	 * @return mixed
 	 */
 	public function column(?string $column = null): mixed
 	{
@@ -1521,9 +1271,6 @@ class Query
 
 	/**
 	 * Executes a SELECT query and returns an array containing the values of the indicated 0-indexed column.
-	 *
-	 * @param  string|null $column The column to select
-	 * @return array
 	 */
 	public function columns(?string $column = null): array
 	{
@@ -1539,10 +1286,6 @@ class Query
 
 	/**
 	 * Executes a SELECT query and returns an array where the first column is used as keys and the second as values.
-	 *
-	 * @param  string $key   The column to use as keys
-	 * @param  string $value The column to use as values
-	 * @return array
 	 */
 	public function pairs(string $key, string $value): array
 	{
@@ -1555,9 +1298,6 @@ class Query
 
 	/**
 	 * Executes a SELECT query and returns a generator that lets you iterate over the results.
-	 *
-	 * @param  mixed      ...$fetchMode Fetch mode
-	 * @return \Generator
 	 */
 	protected function fetchYield(mixed ...$fetchMode): Generator
 	{
@@ -1568,8 +1308,6 @@ class Query
 
 	/**
 	 * Executes a SELECT query and returns a generator that lets you iterate over the results.
-	 *
-	 * @return \Generator
 	 */
 	public function yield(): Generator
 	{
@@ -1578,8 +1316,6 @@ class Query
 
 	/**
 	 * Returns the number of records that the query will return.
-	 *
-	 * @return int
 	 */
 	protected function paginationCount(): int
 	{
@@ -1598,10 +1334,6 @@ class Query
 
 	/**
 	 * Paginates the results using a pagination instance.
-	 *
-	 * @param  int|null                       $itemsPerPage Number of items per page
-	 * @param  array                          $options      Pagination options
-	 * @return \mako\database\query\ResultSet
 	 */
 	public function paginate(?int $itemsPerPage = null, array $options = []): ResultSet
 	{
@@ -1625,11 +1357,6 @@ class Query
 
 	/**
 	 * Fetches data in batches and passes them to the processor closure.
-	 *
-	 * @param \Closure $processor   Closure that processes the results
-	 * @param int      $batchSize   Batch size
-	 * @param int      $offsetStart Offset start
-	 * @param int|null $offsetEnd   Offset end
 	 */
 	public function batch(Closure $processor, int $batchSize = 1000, int $offsetStart = 0, ?int $offsetEnd = null): void
 	{
@@ -1668,8 +1395,6 @@ class Query
 	 * Sets the selected column of the query to the chosen aggreate.
 	 * Executes the query and returns the result if not in subquery context.
 	 *
-	 * @param  string                                $function Aggregate function
-	 * @param  array|\mako\database\query\Raw|string $column   Column name or array of column names
 	 * @return mixed|void
 	 */
 	protected function aggregate(string $function, array|Raw|string $column)
@@ -1686,9 +1411,6 @@ class Query
 
 	/**
 	 * Returns the minimum value for the chosen column.
-	 *
-	 * @param  string $column Column name
-	 * @return mixed
 	 */
 	public function min(string $column): mixed
 	{
@@ -1697,9 +1419,6 @@ class Query
 
 	/**
 	 * Returns the maximum value for the chosen column.
-	 *
-	 * @param  string $column Column name
-	 * @return mixed
 	 */
 	public function max(string $column): mixed
 	{
@@ -1708,9 +1427,6 @@ class Query
 
 	/**
 	 * Returns sum of all the values in the chosen column.
-	 *
-	 * @param  string $column Column name
-	 * @return mixed
 	 */
 	public function sum(string $column): mixed
 	{
@@ -1719,9 +1435,6 @@ class Query
 
 	/**
 	 * Returns the average value for the chosen column.
-	 *
-	 * @param  string $column Column name
-	 * @return mixed
 	 */
 	public function avg(string $column): mixed
 	{
@@ -1730,9 +1443,6 @@ class Query
 
 	/**
 	 * Returns the number of rows.
-	 *
-	 * @param  \mako\database\query\Raw|string $column Column name
-	 * @return int
 	 */
 	public function count(Raw|string $column = '*'): int
 	{
@@ -1741,9 +1451,6 @@ class Query
 
 	/**
 	 * Returns the number of distinct values of the chosen column.
-	 *
-	 * @param  array|string $column Column name or array of column names
-	 * @return int
 	 */
 	public function countDistinct(array|string $column): int
 	{
@@ -1752,9 +1459,6 @@ class Query
 
 	/**
 	 * Inserts a single row of data into the chosen table.
-	 *
-	 * @param  array $values Associative array of column values
-	 * @return bool
 	 */
 	public function insert(array $values = []): bool
 	{
@@ -1766,8 +1470,6 @@ class Query
 	/**
 	 * Inserts a single row of data into the chosen table and returns the auto increment id.
 	 *
-	 * @param  array     $values     Associative array of column values
-	 * @param  string    $primaryKey Primary key
 	 * @return false|int
 	 */
 	public function insertAndGetId(array $values = [], string $primaryKey = 'id')
@@ -1777,9 +1479,6 @@ class Query
 
 	/**
 	 * Inserts multiple rows of data into the chosen table.
-	 *
-	 * @param  array ...$values Associative array of column values
-	 * @return bool
 	 */
 	public function insertMultiple(array ...$values): bool
 	{
@@ -1790,9 +1489,6 @@ class Query
 
 	/**
 	 * Updates data from the chosen table.
-	 *
-	 * @param  array $values Associative array of column values
-	 * @return int
 	 */
 	public function update(array $values): int
 	{
@@ -1803,10 +1499,6 @@ class Query
 
 	/**
 	 * Increments column value.
-	 *
-	 * @param  string $column    Column name
-	 * @param  int    $increment Increment value
-	 * @return int
 	 */
 	public function increment(string $column, int $increment = 1): int
 	{
@@ -1815,10 +1507,6 @@ class Query
 
 	/**
 	 * Decrements column value.
-	 *
-	 * @param  string $column    Column name
-	 * @param  int    $decrement Decrement value
-	 * @return int
 	 */
 	public function decrement(string $column, int $decrement = 1): int
 	{
@@ -1827,8 +1515,6 @@ class Query
 
 	/**
 	 * Deletes data from the chosen table.
-	 *
-	 * @return int
 	 */
 	public function delete(): int
 	{

--- a/src/mako/database/query/Query.php
+++ b/src/mako/database/query/Query.php
@@ -170,7 +170,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function inSubqueryContext()
+	public function inSubqueryContext(): static
 	{
 		$this->inSubqueryContext = true;
 
@@ -333,7 +333,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function forCompiler(string $compilerClass, Closure $query)
+	public function forCompiler(string $compilerClass, Closure $query): static
 	{
 		if($this->compiler instanceof $compilerClass)
 		{
@@ -348,7 +348,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function with(string $name, array $columns, Subquery $query)
+	public function with(string $name, array $columns, Subquery $query): static
 	{
 		$this->commonTableExpressions['ctes'][] =
 		[
@@ -365,7 +365,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function withRecursive(string $name, array $columns, Subquery $query)
+	public function withRecursive(string $name, array $columns, Subquery $query): static
 	{
 		$this->commonTableExpressions['recursive'] = true;
 
@@ -377,7 +377,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	protected function setOperation(string $operation)
+	protected function setOperation(string $operation): static
 	{
 		$previous = clone $this;
 
@@ -397,7 +397,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function union()
+	public function union(): static
 	{
 		return $this->setOperation('UNION');
 	}
@@ -407,7 +407,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function unionAll()
+	public function unionAll(): static
 	{
 		return $this->setOperation('UNION ALL');
 	}
@@ -417,7 +417,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function intersect()
+	public function intersect(): static
 	{
 		return $this->setOperation('INTERSECT');
 	}
@@ -427,7 +427,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function intersectAll()
+	public function intersectAll(): static
 	{
 		return $this->setOperation('INTERSECT ALL');
 	}
@@ -437,7 +437,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function except()
+	public function except(): static
 	{
 		return $this->setOperation('EXCEPT');
 	}
@@ -447,7 +447,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function exceptAll()
+	public function exceptAll(): static
 	{
 		return $this->setOperation('EXCEPT ALL');
 	}
@@ -457,7 +457,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function table(array|Raw|Subquery|string|null $table)
+	public function table(array|Raw|Subquery|string|null $table): static
 	{
 		$this->table = $table;
 
@@ -469,7 +469,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function from(array|Raw|Subquery|string|null $table)
+	public function from(array|Raw|Subquery|string|null $table): static
 	{
 		return $this->table($table);
 	}
@@ -479,7 +479,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function into(array|Raw|Subquery|string|null $table)
+	public function into(array|Raw|Subquery|string|null $table): static
 	{
 		return $this->table($table);
 	}
@@ -489,7 +489,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function select(array $columns)
+	public function select(array $columns): static
 	{
 		$this->columns = $columns;
 
@@ -501,7 +501,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function selectRaw(string $sql, array $parameters = [])
+	public function selectRaw(string $sql, array $parameters = []): static
 	{
 		$this->columns = [new Raw($sql, $parameters)];
 
@@ -513,7 +513,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function distinct()
+	public function distinct(): static
 	{
 		$this->distinct = true;
 
@@ -525,7 +525,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function where(array|Closure|Raw|string $column, ?string $operator = null, mixed $value = null, string $separator = 'AND')
+	public function where(array|Closure|Raw|string $column, ?string $operator = null, mixed $value = null, string $separator = 'AND'): static
 	{
 		if($column instanceof Closure)
 		{
@@ -560,7 +560,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function whereRaw(array|Raw|string $column, array|string|null $operator = null, ?string $raw = null, string $separator = 'AND')
+	public function whereRaw(array|Raw|string $column, array|string|null $operator = null, ?string $raw = null, string $separator = 'AND'): static
 	{
 		if($raw === null)
 		{
@@ -582,7 +582,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orWhere(array|Closure|Raw|string $column, ?string $operator = null, mixed $value = null)
+	public function orWhere(array|Closure|Raw|string $column, ?string $operator = null, mixed $value = null): static
 	{
 		return $this->where($column, $operator, $value, 'OR');
 	}
@@ -592,7 +592,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orWhereRaw(array|Raw|string $column, array|string|null $operator = null, ?string $raw = null)
+	public function orWhereRaw(array|Raw|string $column, array|string|null $operator = null, ?string $raw = null): static
 	{
 		return $this->whereRaw($column, $operator, $raw, 'OR');
 	}
@@ -602,7 +602,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function whereDate(string $column, string $operator, DateTimeInterface|string $date, string $separator = 'AND')
+	public function whereDate(string $column, string $operator, DateTimeInterface|string $date, string $separator = 'AND'): static
 	{
 
 		$this->wheres[] =
@@ -622,7 +622,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orWhereDate(string $column, string $operator, DateTimeInterface|string $date)
+	public function orWhereDate(string $column, string $operator, DateTimeInterface|string $date): static
 	{
 		return $this->whereDate($column, $operator, $date, 'OR');
 	}
@@ -632,7 +632,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function whereColumn(array|string $column1, string $operator, array|string $column2, string $separator = 'AND')
+	public function whereColumn(array|string $column1, string $operator, array|string $column2, string $separator = 'AND'): static
 	{
 		$this->wheres[] =
 		[
@@ -651,7 +651,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orWhereColumn(array|string $column1, string $operator, array|string $column2)
+	public function orWhereColumn(array|string $column1, string $operator, array|string $column2): static
 	{
 		return $this->whereColumn($column1, $operator, $column2, 'OR');
 	}
@@ -661,7 +661,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function between(mixed $column, mixed $value1, mixed $value2, string $separator = 'AND', bool $not = false)
+	public function between(mixed $column, mixed $value1, mixed $value2, string $separator = 'AND', bool $not = false): static
 	{
 		$this->wheres[] =
 		[
@@ -681,7 +681,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orBetween(mixed $column, mixed $value1, mixed $value2)
+	public function orBetween(mixed $column, mixed $value1, mixed $value2): static
 	{
 		return $this->between($column, $value1, $value2, 'OR');
 	}
@@ -691,7 +691,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function notBetween(mixed $column, mixed $value1, mixed $value2)
+	public function notBetween(mixed $column, mixed $value1, mixed $value2): static
 	{
 		return $this->between($column, $value1, $value2, 'AND', true);
 	}
@@ -701,7 +701,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orNotBetween(mixed $column, mixed $value1, mixed $value2)
+	public function orNotBetween(mixed $column, mixed $value1, mixed $value2): static
 	{
 		return $this->between($column, $value1, $value2, 'OR', true);
 	}
@@ -711,7 +711,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function betweenDate(string $column, DateTimeInterface|string $date1, DateTimeInterface|string $date2, string $separator = 'AND', bool $not = false)
+	public function betweenDate(string $column, DateTimeInterface|string $date1, DateTimeInterface|string $date2, string $separator = 'AND', bool $not = false): static
 	{
 		$this->wheres[] =
 		[
@@ -731,7 +731,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orBetweenDate(string $column, DateTimeInterface|string $date1, DateTimeInterface|string $date2)
+	public function orBetweenDate(string $column, DateTimeInterface|string $date1, DateTimeInterface|string $date2): static
 	{
 		return $this->betweenDate($column, $date1, $date2, 'OR');
 	}
@@ -741,7 +741,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function notBetweenDate(string $column, DateTimeInterface|string $date1, DateTimeInterface|string $date2)
+	public function notBetweenDate(string $column, DateTimeInterface|string $date1, DateTimeInterface|string $date2): static
 	{
 		return $this->betweenDate($column, $date1, $date2, 'AND', true);
 	}
@@ -751,7 +751,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orNotBetweenDate(string $column, DateTimeInterface|string $date1, DateTimeInterface|string $date2)
+	public function orNotBetweenDate(string $column, DateTimeInterface|string $date1, DateTimeInterface|string $date2): static
 	{
 		return $this->betweenDate($column, $date1, $date2, 'OR', true);
 	}
@@ -761,7 +761,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function in(mixed $column, array|Raw|Subquery $values, string $separator = 'AND', bool $not = false)
+	public function in(mixed $column, array|Raw|Subquery $values, string $separator = 'AND', bool $not = false): static
 	{
 		$this->wheres[] =
 		[
@@ -780,7 +780,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orIn(mixed $column, array|Raw|Subquery $values)
+	public function orIn(mixed $column, array|Raw|Subquery $values): static
 	{
 		return $this->in($column, $values, 'OR');
 	}
@@ -790,7 +790,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function notIn(mixed $column, array|Raw|Subquery $values)
+	public function notIn(mixed $column, array|Raw|Subquery $values): static
 	{
 		return $this->in($column, $values, 'AND', true);
 	}
@@ -800,7 +800,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orNotIn(mixed $column, array|Raw|Subquery $values)
+	public function orNotIn(mixed $column, array|Raw|Subquery $values): static
 	{
 		return $this->in($column, $values, 'OR', true);
 	}
@@ -810,7 +810,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function isNull(mixed $column, string $separator = 'AND', bool $not = false)
+	public function isNull(mixed $column, string $separator = 'AND', bool $not = false): static
 	{
 		$this->wheres[] =
 		[
@@ -828,7 +828,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orIsNull(mixed $column)
+	public function orIsNull(mixed $column): static
 	{
 		return $this->isNull($column, 'OR');
 	}
@@ -838,7 +838,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function isNotNull(mixed $column)
+	public function isNotNull(mixed $column): static
 	{
 		return $this->isNull($column, 'AND', true);
 	}
@@ -848,7 +848,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orIsNotNull(mixed $column)
+	public function orIsNotNull(mixed $column): static
 	{
 		return $this->isNull($column, 'OR', true);
 	}
@@ -858,7 +858,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function exists(Subquery $query, string $separator = 'AND', bool $not = false)
+	public function exists(Subquery $query, string $separator = 'AND', bool $not = false): static
 	{
 		$this->wheres[] =
 		[
@@ -876,7 +876,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orExists(Subquery $query)
+	public function orExists(Subquery $query): static
 	{
 		return $this->exists($query, 'OR');
 	}
@@ -886,7 +886,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function notExists(Subquery $query)
+	public function notExists(Subquery $query): static
 	{
 		return $this->exists($query, 'AND', true);
 	}
@@ -896,7 +896,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orNotExists(Subquery $query)
+	public function orNotExists(Subquery $query): static
 	{
 		return $this->exists($query, 'OR', true);
 	}
@@ -906,7 +906,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function join(Raw|Subquery|string $table, Closure|Raw|string|null $column1 = null, ?string $operator = null, Raw|string|null $column2 = null, string $type = 'INNER JOIN')
+	public function join(Raw|Subquery|string $table, Closure|Raw|string|null $column1 = null, ?string $operator = null, Raw|string|null $column2 = null, string $type = 'INNER JOIN'): static
 	{
 		$join = new Join($type, $table);
 
@@ -929,7 +929,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function joinRaw(Raw|Subquery|string $table, Raw|string $column1, string $operator, string $raw, string $type = 'INNER JOIN')
+	public function joinRaw(Raw|Subquery|string $table, Raw|string $column1, string $operator, string $raw, string $type = 'INNER JOIN'): static
 	{
 		return $this->join($table, $column1, $operator, new Raw($raw), $type);
 	}
@@ -939,7 +939,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function leftJoin(Raw|Subquery|string $table, Closure|Raw|string|null $column1 = null, ?string $operator = null, Raw|string|null $column2 = null)
+	public function leftJoin(Raw|Subquery|string $table, Closure|Raw|string|null $column1 = null, ?string $operator = null, Raw|string|null $column2 = null): static
 	{
 		return $this->join($table, $column1, $operator, $column2, 'LEFT OUTER JOIN');
 	}
@@ -949,7 +949,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function leftJoinRaw(Raw|Subquery|string $table, Raw|string $column1, string $operator, string $raw)
+	public function leftJoinRaw(Raw|Subquery|string $table, Raw|string $column1, string $operator, string $raw): static
 	{
 		return $this->joinRaw($table, $column1, $operator, $raw, 'LEFT OUTER JOIN');
 	}
@@ -959,7 +959,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function rightJoin(Raw|Subquery|string $table, Closure|Raw|string|null $column1 = null, ?string $operator = null, Raw|string|null $column2 = null)
+	public function rightJoin(Raw|Subquery|string $table, Closure|Raw|string|null $column1 = null, ?string $operator = null, Raw|string|null $column2 = null): static
 	{
 		return $this->join($table, $column1, $operator, $column2, 'RIGHT OUTER JOIN');
 	}
@@ -969,7 +969,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function rightJoinRaw(Raw|Subquery|string $table, Raw|string $column1, string $operator, string $raw)
+	public function rightJoinRaw(Raw|Subquery|string $table, Raw|string $column1, string $operator, string $raw): static
 	{
 		return $this->joinRaw($table, $column1, $operator, $raw, 'RIGHT OUTER JOIN');
 	}
@@ -979,7 +979,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function crossJoin(Raw|Subquery|string $table)
+	public function crossJoin(Raw|Subquery|string $table): static
 	{
 		return $this->join($table, type: 'CROSS JOIN');
 	}
@@ -989,7 +989,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function lateralJoin(Subquery $subquery, string $type = 'LEFT OUTER JOIN')
+	public function lateralJoin(Subquery $subquery, string $type = 'LEFT OUTER JOIN'): static
 	{
 		return $this->join($subquery, new Raw('TRUE'), type: "{$type} LATERAL");
 	}
@@ -999,7 +999,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function groupBy(array|string $columns)
+	public function groupBy(array|string $columns): static
 	{
 		$this->groupings = is_array($columns) ? $columns : [$columns];
 
@@ -1011,7 +1011,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function having(Raw|string $column, string $operator, mixed $value, string $separator = 'AND')
+	public function having(Raw|string $column, string $operator, mixed $value, string $separator = 'AND'): static
 	{
 		$this->havings[] =
 		[
@@ -1029,7 +1029,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function havingRaw(string $raw, string $operator, mixed $value, string $separator = 'AND')
+	public function havingRaw(string $raw, string $operator, mixed $value, string $separator = 'AND'): static
 	{
 		return $this->having(new Raw($raw), $operator, $value, $separator);
 	}
@@ -1039,7 +1039,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orHaving(Raw|string $column, string $operator, mixed $value)
+	public function orHaving(Raw|string $column, string $operator, mixed $value): static
 	{
 		return $this->having($column, $operator, $value, 'OR');
 	}
@@ -1049,7 +1049,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orHavingRaw(string $raw, string $operator, mixed $value)
+	public function orHavingRaw(string $raw, string $operator, mixed $value): static
 	{
 		return $this->havingRaw($raw, $operator, $value, 'OR');
 	}
@@ -1059,7 +1059,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orderBy(array|Raw|string $columns, string $order = 'ASC')
+	public function orderBy(array|Raw|string $columns, string $order = 'ASC'): static
 	{
 		$this->orderings[] =
 		[
@@ -1075,7 +1075,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function orderByRaw(string $raw, array $parameters = [], string $order = 'ASC')
+	public function orderByRaw(string $raw, array $parameters = [], string $order = 'ASC'): static
 	{
 		return $this->orderBy(new Raw($raw, $parameters), $order);
 	}
@@ -1085,7 +1085,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function ascending(array|string $columns)
+	public function ascending(array|string $columns): static
 	{
 		return $this->orderBy($columns, 'ASC');
 	}
@@ -1095,7 +1095,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function ascendingRaw(string $raw, array $parameters = [])
+	public function ascendingRaw(string $raw, array $parameters = []): static
 	{
 		return $this->orderByRaw($raw, $parameters, 'ASC');
 	}
@@ -1105,7 +1105,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function descending(array|string $columns)
+	public function descending(array|string $columns): static
 	{
 		return $this->orderBy($columns, 'DESC');
 	}
@@ -1115,7 +1115,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function descendingRaw(string $raw, array $parameters = [])
+	public function descendingRaw(string $raw, array $parameters = []): static
 	{
 		return $this->orderByRaw($raw, $parameters, 'DESC');
 	}
@@ -1125,7 +1125,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function clearOrderings()
+	public function clearOrderings(): static
 	{
 		$this->orderings = [];
 
@@ -1137,7 +1137,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function limit(int $limit)
+	public function limit(int $limit): static
 	{
 		$this->limit = (int) $limit;
 
@@ -1149,7 +1149,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function offset(int $offset)
+	public function offset(int $offset): static
 	{
 		$this->offset = (int) $offset;
 
@@ -1161,7 +1161,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function lock(bool|string $lock = true)
+	public function lock(bool|string $lock = true): static
 	{
 		$this->lock = $lock;
 
@@ -1173,7 +1173,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function sharedLock()
+	public function sharedLock(): static
 	{
 		return $this->lock(false);
 	}
@@ -1183,7 +1183,7 @@ class Query
 	 *
 	 * @return $this
 	 */
-	public function prefix(string $prefix)
+	public function prefix(string $prefix): static
 	{
 		$this->prefix = "{$prefix} ";
 

--- a/src/mako/database/query/Raw.php
+++ b/src/mako/database/query/Raw.php
@@ -14,9 +14,6 @@ class Raw
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param string $sql        Raw SQL
-	 * @param array  $parameters Parameters
 	 */
 	public function __construct(
 		protected string $sql,
@@ -26,8 +23,6 @@ class Raw
 
 	/**
 	 * Returns the raw SQL.
-	 *
-	 * @return string
 	 */
 	public function getSql(): string
 	{
@@ -36,8 +31,6 @@ class Raw
 
 	/**
 	 * Returns the parameters.
-	 *
-	 * @return array
 	 */
 	public function getParameters(): array
 	{

--- a/src/mako/database/query/Result.php
+++ b/src/mako/database/query/Result.php
@@ -21,8 +21,6 @@ class Result implements JsonSerializable, Stringable
 {
 	/**
 	 * Returns an array representation of the result.
-	 *
-	 * @return array
 	 */
 	public function toArray(): array
 	{
@@ -31,8 +29,6 @@ class Result implements JsonSerializable, Stringable
 
 	/**
 	 * Returns data which can be serialized by json_encode().
-	 *
-	 * @return mixed
 	 */
 	public function jsonSerialize(): mixed
 	{
@@ -41,9 +37,6 @@ class Result implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a json representation of the result.
-	 *
-	 * @param  int    $options JSON encode options
-	 * @return string
 	 */
 	public function toJson(int $options = 0): string
 	{
@@ -52,8 +45,6 @@ class Result implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a json representation of the result.
-	 *
-	 * @return string
 	 */
 	public function __toString(): string
 	{

--- a/src/mako/database/query/ResultSet.php
+++ b/src/mako/database/query/ResultSet.php
@@ -22,15 +22,11 @@ class ResultSet extends Collection implements JsonSerializable, Stringable
 {
 	/**
 	 * Pagination.
-	 *
-	 * @var \mako\pagination\PaginationInterface
 	 */
-	protected $pagination;
+	protected PaginationInterface|null $pagination = null;
 
 	/**
 	 * Sets the pagination.
-	 *
-	 * @param \mako\pagination\PaginationInterface $pagination Pagination
 	 */
 	public function setPagination(PaginationInterface $pagination): void
 	{
@@ -39,8 +35,6 @@ class ResultSet extends Collection implements JsonSerializable, Stringable
 
 	/**
 	 * Returns the pagination.
-	 *
-	 * @return \mako\pagination\PaginationInterface
 	 */
 	public function getPagination(): PaginationInterface
 	{
@@ -49,9 +43,6 @@ class ResultSet extends Collection implements JsonSerializable, Stringable
 
 	/**
 	 * Returns an array containing only the values of chosen column.
-	 *
-	 * @param  string $column Column name
-	 * @return array
 	 */
 	public function pluck(string $column): array
 	{
@@ -60,8 +51,6 @@ class ResultSet extends Collection implements JsonSerializable, Stringable
 
 	/**
 	 * Returns an array representation of the result set.
-	 *
-	 * @return array
 	 */
 	public function toArray(): array
 	{
@@ -77,8 +66,6 @@ class ResultSet extends Collection implements JsonSerializable, Stringable
 
 	/**
 	 * Returns data which can be serialized by json_encode().
-	 *
-	 * @return mixed
 	 */
 	public function jsonSerialize(): mixed
 	{
@@ -92,9 +79,6 @@ class ResultSet extends Collection implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a json representation of the result set.
-	 *
-	 * @param  int    $options JSON encode options
-	 * @return string
 	 */
 	public function toJson(int $options = 0): string
 	{
@@ -103,8 +87,6 @@ class ResultSet extends Collection implements JsonSerializable, Stringable
 
 	/**
 	 * Returns a json representation of the result set.
-	 *
-	 * @return string
 	 */
 	public function __toString(): string
 	{

--- a/src/mako/database/query/Subquery.php
+++ b/src/mako/database/query/Subquery.php
@@ -16,10 +16,6 @@ class Subquery
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \Closure    $query                   Builder closure
-	 * @param string|null $alias                   Subquery alias
-	 * @param bool        $providesBuilderInstance Does the subquery provide its own query builder instance?
 	 */
 	public function __construct(
 		protected Closure $query,
@@ -30,9 +26,6 @@ class Subquery
 
 	/**
 	 * Sets the subquery alias.
-	 *
-	 * @param  string                        $alias
-	 * @return \mako\database\query\Subquery
 	 */
 	public function as(string $alias): Subquery
 	{
@@ -43,8 +36,6 @@ class Subquery
 
 	/**
 	 * Returns the subquery alias.
-	 *
-	 * @return string|null
 	 */
 	public function getAlias(): ?string
 	{
@@ -53,8 +44,6 @@ class Subquery
 
 	/**
 	 * Returns the builder closure.
-	 *
-	 * @return \Closure
 	 */
 	public function getQuery(): Closure
 	{
@@ -63,8 +52,6 @@ class Subquery
 
 	/**
 	 * Returns TRUE if the subquery provides its own query builder instance and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function providesBuilderInstance(): bool
 	{

--- a/src/mako/database/query/compilers/Compiler.php
+++ b/src/mako/database/query/compilers/Compiler.php
@@ -40,22 +40,16 @@ class Compiler
 
 	/**
 	 * Datetime format.
-	 *
-	 * @var string
 	 */
-	protected static $dateFormat = 'Y-m-d H:i:s';
+	protected static string $dateFormat = 'Y-m-d H:i:s';
 
 	/**
 	 * Query parameters.
-	 *
-	 * @var array
 	 */
-	protected $params = [];
+	protected array $params = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\database\query\Query $query Query builder
 	 */
 	public function __construct(
 		protected Query $query
@@ -64,8 +58,6 @@ class Compiler
 
 	/**
 	 * Sets the date format.
-	 *
-	 * @param string $dateFormat Date format
 	 */
 	public static function setDateFormat(string $dateFormat): void
 	{
@@ -74,8 +66,6 @@ class Compiler
 
 	/**
 	 * Gets the date format.
-	 *
-	 * @return string
 	 */
 	public static function getDateFormat(): string
 	{
@@ -84,9 +74,6 @@ class Compiler
 
 	/**
 	 * Compiles a raw SQL statement.
-	 *
-	 * @param  \mako\database\query\Raw $raw Raw SQL
-	 * @return string
 	 */
 	protected function raw(Raw $raw): string
 	{
@@ -102,9 +89,6 @@ class Compiler
 
 	/**
 	 * Compiles a subselect and merges the parameters.
-	 *
-	 * @param  \mako\database\query\Query $query Query
-	 * @return string
 	 */
 	protected function subselect(Query $query): string
 	{
@@ -117,10 +101,6 @@ class Compiler
 
 	/**
 	 * Compiles a subquery.
-	 *
-	 * @param  \mako\database\query\Subquery $subquery Subquery container
-	 * @param  bool                          $enclose  Should the subquery be enclosed in parentheses?
-	 * @return string
 	 */
 	protected function subquery(Subquery $subquery, bool $enclose = true): string
 	{
@@ -147,9 +127,6 @@ class Compiler
 
 	/**
 	 * Returns an escaped identifier.
-	 *
-	 * @param  string $identifier Identifier to escape
-	 * @return string
 	 */
 	public function escapeIdentifier(string $identifier): string
 	{
@@ -158,9 +135,6 @@ class Compiler
 
 	/**
 	 * Returns an array of escaped identifiers.
-	 *
-	 * @param  array  $identifiers Identifiers to escape
-	 * @return string
 	 */
 	public function escapeIdentifiers(array $identifiers): string
 	{
@@ -174,9 +148,6 @@ class Compiler
 
 	/**
 	 * Does the string have a JSON path?
-	 *
-	 * @param  string $string String
-	 * @return bool
 	 */
 	protected function hasJsonPath(string $string): bool
 	{
@@ -185,10 +156,6 @@ class Compiler
 
 	/**
 	 * Builds a JSON value getter.
-	 *
-	 * @param  string $column   Column name
-	 * @param  array  $segments JSON path segments
-	 * @return string
 	 */
 	protected function buildJsonGet(string $column, array $segments): string
 	{
@@ -197,11 +164,6 @@ class Compiler
 
 	/**
 	 * Builds a JSON value setter.
-	 *
-	 * @param  string $column   Column name
-	 * @param  array  $segments JSON path segments
-	 * @param  string $param    Parameter
-	 * @return string
 	 */
 	protected function buildJsonSet(string $column, array $segments, string $param): string
 	{
@@ -210,9 +172,6 @@ class Compiler
 
 	/**
 	 * Escapes a table name.
-	 *
-	 * @param  string $table Table name
-	 * @return string
 	 */
 	public function escapeTableName(string $table): string
 	{
@@ -228,9 +187,6 @@ class Compiler
 
 	/**
 	 * Compiles a table.
-	 *
-	 * @param  \mako\database\query\Raw|\mako\database\query\Subquery|string $table Table
-	 * @return string
 	 */
 	public function table(Raw|Subquery|string $table): string
 	{
@@ -254,9 +210,6 @@ class Compiler
 
 	/**
 	 * Returns a comma-separated list of tables.
-	 *
-	 * @param  array  $tables Array of tables
-	 * @return string
 	 */
 	public function tables(array $tables): string
 	{
@@ -272,9 +225,6 @@ class Compiler
 
 	/**
 	 * Escapes a column name.
-	 *
-	 * @param  string $column Column name
-	 * @return string
 	 */
 	public function escapeColumnName(string $column): string
 	{
@@ -297,9 +247,6 @@ class Compiler
 
 	/**
 	 * Compiles a column name.
-	 *
-	 * @param  string $column Column name
-	 * @return string
 	 */
 	public function columnName(string $column): string
 	{
@@ -317,9 +264,6 @@ class Compiler
 
 	/**
 	 * Returns a comma-separated list of column names.
-	 *
-	 * @param  array  $columns Array of column names
-	 * @return string
 	 */
 	public function columnNames(array $columns): string
 	{
@@ -335,10 +279,6 @@ class Compiler
 
 	/**
 	 * Compiles a column.
-	 *
-	 * @param  \mako\database\query\Raw|\mako\database\query\Subquery|string $column     Column
-	 * @param  bool                                                          $allowAlias Allow aliases?
-	 * @return string
 	 */
 	public function column(Raw|Subquery|string $column, bool $allowAlias = false): string
 	{
@@ -362,10 +302,6 @@ class Compiler
 
 	/**
 	 * Returns a comma-separated list of compiled columns.
-	 *
-	 * @param  array  $columns    Array of columns
-	 * @param  bool   $allowAlias Allow aliases?
-	 * @return string
 	 */
 	public function columns(array $columns, bool $allowAlias = false): string
 	{
@@ -381,9 +317,6 @@ class Compiler
 
 	/**
 	 * Compiles common table expressions.
-	 *
-	 * @param  array  $commonTableExpressions Common table expressions
-	 * @return string
 	 */
 	protected function commonTableExpressions(array $commonTableExpressions): string
 	{
@@ -413,9 +346,6 @@ class Compiler
 
 	/**
 	 * Compiles set operations.
-	 *
-	 * @param  array  $setOperations Set operations
-	 * @return string
 	 */
 	protected function setOperations(array $setOperations): string
 	{
@@ -436,10 +366,6 @@ class Compiler
 
 	/**
 	 * Returns raw SQL or a paramter placeholder.
-	 *
-	 * @param  mixed  $param   Parameter
-	 * @param  bool   $enclose Should subqueries be enclosed in parentheses?
-	 * @return string
 	 */
 	protected function param(mixed $param, bool $enclose = true): string
 	{
@@ -474,10 +400,6 @@ class Compiler
 
 	/**
 	 * Returns a comma-separated list of parameters.
-	 *
-	 * @param  array  $params  Array of parameters
-	 * @param  bool   $enclose Should subqueries be enclosed in parentheses?
-	 * @return string
 	 */
 	protected function params(array $params, bool $enclose = true): string
 	{
@@ -493,9 +415,6 @@ class Compiler
 
 	/**
 	 * Returns a parameter placeholder.
-	 *
-	 * @param  mixed  $param Parameter
-	 * @return string
 	 */
 	protected function simpleParam(mixed $param): string
 	{
@@ -506,9 +425,6 @@ class Compiler
 
 	/**
 	 * Returns a comma-separated list of parameter placeholders.
-	 *
-	 * @param  array  $params Parameters
-	 * @return string
 	 */
 	protected function simpleParams(array $params): string
 	{
@@ -524,9 +440,6 @@ class Compiler
 
 	/**
 	 * Compiles the FROM clause.
-	 *
-	 * @param  array|\mako\database\query\Raw|\mako\database\query\Subquery|string|null $table Table
-	 * @return string
 	 */
 	protected function from(array|Raw|Subquery|string|null $table): string
 	{
@@ -540,9 +453,6 @@ class Compiler
 
 	/**
 	 * Compiles WHERE conditions.
-	 *
-	 * @param  array  $where Where clause
-	 * @return string
 	 */
 	protected function where(array $where): string
 	{
@@ -560,9 +470,6 @@ class Compiler
 
 	/**
 	 * Compiles a raw WHERE condition.
-	 *
-	 * @param  array  $where Where clause
-	 * @return string
 	 */
 	protected function whereRaw(array $where): string
 	{
@@ -571,9 +478,6 @@ class Compiler
 
 	/**
 	 * Compiles date comparison clauses.
-	 *
-	 * @param  array  $where Where clause
-	 * @return string
 	 */
 	protected function whereDate(array $where): string
 	{
@@ -582,9 +486,6 @@ class Compiler
 
 	/**
 	 * Compiles column comparison clauses.
-	 *
-	 * @param  array  $where Where clause
-	 * @return string
 	 */
 	protected function whereColumn(array $where): string
 	{
@@ -602,9 +503,6 @@ class Compiler
 
 	/**
 	 * Compiles BETWEEN clauses.
-	 *
-	 * @param  array  $where Where clause
-	 * @return string
 	 */
 	protected function between(array $where): string
 	{
@@ -613,9 +511,6 @@ class Compiler
 
 	/**
 	 * Compiles date range clauses.
-	 *
-	 * @param  array  $where Where clause
-	 * @return string
 	 */
 	protected function betweenDate(array $where): string
 	{
@@ -624,9 +519,6 @@ class Compiler
 
 	/**
 	 * Compiles IN clauses.
-	 *
-	 * @param  array  $where Where clause
-	 * @return string
 	 */
 	protected function in(array $where): string
 	{
@@ -637,9 +529,6 @@ class Compiler
 
 	/**
 	 * Compiles IS NULL clauses.
-	 *
-	 * @param  array  $where Where clause
-	 * @return string
 	 */
 	protected function null(array $where): string
 	{
@@ -648,9 +537,6 @@ class Compiler
 
 	/**
 	 * Compiles EXISTS clauses.
-	 *
-	 * @param  array  $where Exists clause
-	 * @return string
 	 */
 	protected function exists(array $where): string
 	{
@@ -659,9 +545,6 @@ class Compiler
 
 	/**
 	 * Compiles nested WHERE conditions.
-	 *
-	 * @param  array  $where Where clause
-	 * @return string
 	 */
 	protected function nestedWhere(array $where): string
 	{
@@ -670,9 +553,6 @@ class Compiler
 
 	/**
 	 * Compiles WHERE conditions.
-	 *
-	 * @param  array  $wheres Where conditions
-	 * @return string
 	 */
 	protected function whereConditions(array $wheres): string
 	{
@@ -692,9 +572,6 @@ class Compiler
 
 	/**
 	 * Compiles WHERE clauses.
-	 *
-	 * @param  array  $wheres Array of where clauses
-	 * @return string
 	 */
 	protected function wheres(array $wheres): string
 	{
@@ -708,9 +585,6 @@ class Compiler
 
 	/**
 	 * Compiles a JOIN condition.
-	 *
-	 * @param  array  $condition Join condition
-	 * @return string
 	 */
 	protected function joinCondition(array $condition): string
 	{
@@ -724,9 +598,6 @@ class Compiler
 
 	/**
 	 * Compiles nested JOIN condition.
-	 *
-	 * @param  array  $condition Join condition
-	 * @return string
 	 */
 	protected function nestedJoinCondition(array $condition): string
 	{
@@ -737,9 +608,6 @@ class Compiler
 
 	/**
 	 * Compiles JOIN conditions.
-	 *
-	 * @param  \mako\database\query\Join $join Join
-	 * @return string
 	 */
 	protected function joinConditions(Join $join): string
 	{
@@ -759,9 +627,6 @@ class Compiler
 
 	/**
 	 * Compiles JOIN clauses.
-	 *
-	 * @param  array  $joins Array of joins
-	 * @return string
 	 */
 	protected function joins(array $joins): string
 	{
@@ -784,9 +649,6 @@ class Compiler
 
 	/**
 	 * Compiles GROUP BY clauses.
-	 *
-	 * @param  array  $groupings Array of column names
-	 * @return string
 	 */
 	protected function groupings(array $groupings): string
 	{
@@ -795,9 +657,6 @@ class Compiler
 
 	/**
 	 * Compiles ORDER BY clauses.
-	 *
-	 * @param  array  $orderings Array of order by clauses
-	 * @return string
 	 */
 	protected function orderings(array $orderings): string
 	{
@@ -818,9 +677,6 @@ class Compiler
 
 	/**
 	 * Compiles HAVING conditions.
-	 *
-	 * @param  array  $havings Having conditions
-	 * @return string
 	 */
 	protected function havingCondictions(array $havings): string
 	{
@@ -840,9 +696,6 @@ class Compiler
 
 	/**
 	 * Compiles HAVING clauses.
-	 *
-	 * @param  array  $havings Array of having clauses
-	 * @return string
 	 */
 	protected function havings(array $havings): string
 	{
@@ -856,9 +709,6 @@ class Compiler
 
 	/**
 	 * Compiles LIMIT clauses.
-	 *
-	 * @param  int|null $limit Limit
-	 * @return string
 	 */
 	protected function limit(?int $limit): string
 	{
@@ -867,9 +717,6 @@ class Compiler
 
 	/**
 	 * Compiles OFFSET clauses.
-	 *
-	 * @param  int|null $offset Limit
-	 * @return string
 	 */
 	protected function offset(?int $offset): string
 	{
@@ -878,9 +725,6 @@ class Compiler
 
 	/**
 	 * Compiles locking clause.
-	 *
-	 * @param  bool|string|null $lock Lock
-	 * @return string
 	 */
 	protected function lock(bool|string|null $lock): string
 	{
@@ -889,8 +733,6 @@ class Compiler
 
 	/**
 	 * Compiles a SELECT query.
-	 *
-	 * @return array
 	 */
 	public function select(): array
 	{
@@ -914,8 +756,6 @@ class Compiler
 
 	/**
 	 * Returns a INSERT query without values.
-	 *
-	 * @return string
 	 */
 	protected function insertWithoutValues(): string
 	{
@@ -924,9 +764,6 @@ class Compiler
 
 	/**
 	 * Returns a INSERT query with values.
-	 *
-	 * @param  array  $values Array of values
-	 * @return string
 	 */
 	protected function insertWithValues(array $values): string
 	{
@@ -940,9 +777,6 @@ class Compiler
 
 	/**
 	 * Compiles a INSERT query.
-	 *
-	 * @param  array $values Array of values
-	 * @return array
 	 */
 	public function insert(array $values = []): array
 	{
@@ -954,9 +788,6 @@ class Compiler
 
 	/**
 	 * Compiles a INSERT query with multiple row inserts.
-	 *
-	 * @param  array ...$values Array of values
-	 * @return array
 	 */
 	public function insertMultiple(array ...$values): array
 	{
@@ -979,9 +810,6 @@ class Compiler
 
 	/**
 	 * Compiles update columns.
-	 *
-	 * @param  array  $columns Associative array of columns and values
-	 * @return string
 	 */
 	protected function updateColumns(array $columns): string
 	{
@@ -1010,9 +838,6 @@ class Compiler
 
 	/**
 	 * Compiles a UPDATE query.
-	 *
-	 * @param  array $values Array of values
-	 * @return array
 	 */
 	public function update(array $values): array
 	{
@@ -1028,8 +853,6 @@ class Compiler
 
 	/**
 	 * Compiles a DELETE query.
-	 *
-	 * @return array
 	 */
 	public function delete(): array
 	{

--- a/src/mako/database/query/compilers/Firebird.php
+++ b/src/mako/database/query/compilers/Firebird.php
@@ -18,7 +18,7 @@ class Firebird extends Compiler
 	/**
 	 * {@inheritDoc}
 	 */
-	protected static $dateFormat = 'Y-m-d H:i:s';
+	protected static string $dateFormat = 'Y-m-d H:i:s';
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/database/query/compilers/MySQL.php
+++ b/src/mako/database/query/compilers/MySQL.php
@@ -21,7 +21,7 @@ class MySQL extends Compiler
 	/**
 	 * {@inheritDoc}
 	 */
-	protected static $dateFormat = 'Y-m-d H:i:s';
+	protected static string $dateFormat = 'Y-m-d H:i:s';
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/database/query/compilers/Oracle.php
+++ b/src/mako/database/query/compilers/Oracle.php
@@ -21,7 +21,7 @@ class Oracle extends Compiler
 	/**
 	 * {@inheritDoc}
 	 */
-	protected static $dateFormat = 'Y-m-d H:i:s';
+	protected static string $dateFormat = 'Y-m-d H:i:s';
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/database/query/compilers/Postgres.php
+++ b/src/mako/database/query/compilers/Postgres.php
@@ -20,7 +20,7 @@ class Postgres extends Compiler
 	/**
 	 * {@inheritDoc}
 	 */
-	protected static $dateFormat = 'Y-m-d H:i:s';
+	protected static string $dateFormat = 'Y-m-d H:i:s';
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/database/query/compilers/SQLServer.php
+++ b/src/mako/database/query/compilers/SQLServer.php
@@ -23,7 +23,7 @@ class SQLServer extends Compiler
 	/**
 	 * {@inheritDoc}
 	 */
-	protected static $dateFormat = 'Y-m-d H:i:s.0000000';
+	protected static string $dateFormat = 'Y-m-d H:i:s.0000000';
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/database/query/compilers/SQLite.php
+++ b/src/mako/database/query/compilers/SQLite.php
@@ -19,7 +19,7 @@ class SQLite extends Compiler
 	/**
 	 * {@inheritDoc}
 	 */
-	protected static $dateFormat = 'Y-m-d H:i:s';
+	protected static string $dateFormat = 'Y-m-d H:i:s';
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/database/query/compilers/traits/JsonPathBuilderTrait.php
+++ b/src/mako/database/query/compilers/traits/JsonPathBuilderTrait.php
@@ -17,9 +17,6 @@ trait JsonPathBuilderTrait
 {
 	/**
 	 * Builds a JSON path.
-	 *
-	 * @param  array  $segments Path segments
-	 * @return string
 	 */
 	protected function buildJsonPath(array $segments): string
 	{

--- a/src/mako/database/query/helpers/HelperInterface.php
+++ b/src/mako/database/query/helpers/HelperInterface.php
@@ -17,9 +17,6 @@ interface HelperInterface
 	/**
 	 * Inserts data into the chosen table and returns the auto increment id.
 	 *
-	 * @param  \mako\database\query\Query $query      Query builder instance
-	 * @param  array                      $values     Associative array of column values
-	 * @param  string|null                $primaryKey Primary key name
 	 * @return false|int
 	 */
 	public function insertAndGetId(Query $query, array $values = [], ?string $primaryKey = null);

--- a/src/mako/database/types/Type.php
+++ b/src/mako/database/types/Type.php
@@ -14,8 +14,6 @@ abstract class Type implements TypeInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param mixed $value Value
 	 */
 	public function __construct(
 		protected mixed $value

--- a/src/mako/database/types/TypeInterface.php
+++ b/src/mako/database/types/TypeInterface.php
@@ -14,15 +14,11 @@ interface TypeInterface
 {
 	/**
 	 * Returns the PDO parameter type.
-	 *
-	 * @return int
 	 */
 	public function getType(): int;
 
 	/**
 	 * Returns the value.
-	 *
-	 * @return mixed
 	 */
 	public function getValue(): mixed;
 }

--- a/src/mako/error/ErrorHandler.php
+++ b/src/mako/error/ErrorHandler.php
@@ -40,43 +40,31 @@ class ErrorHandler
 {
 	/**
 	 * Is the shutdown handler disabled?
-	 *
-	 * @var bool
 	 */
-	protected $disableShutdownHandler = false;
+	protected bool $disableShutdownHandler = false;
 
 	/**
 	 * Exception handlers.
-	 *
-	 * @var array
 	 */
-	protected $handlers = [];
+	protected array $handlers = [];
 
 	/**
 	 * Logger instance.
-	 *
-	 * @var \Closure|\Psr\Log\LoggerInterface|null
 	 */
-	protected $logger;
+	protected Closure|LoggerInterface|null $logger = null;
 
 	/**
 	 * Exception types that shouldn't be logged.
-	 *
-	 * @var array
 	 */
 	protected $dontLog = [];
 
 	/**
 	 * Exception id.
-	 *
-	 * @var string|null
 	 */
-	protected $exceptionId = null;
+	protected string|null $exceptionId = null;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\syringe\Container $container Container
 	 */
 	public function __construct(
 		protected Container $container = new Container
@@ -93,8 +81,6 @@ class ErrorHandler
 
 	/**
 	 * Should errors be displayed?
-	 *
-	 * @return bool
 	 */
 	protected function displayErrors(): bool
 	{
@@ -110,8 +96,6 @@ class ErrorHandler
 
 	/**
 	 * Write to output.
-	 *
-	 * @param string $output String to write to output
 	 */
 	protected function write(string $output): void
 	{
@@ -127,8 +111,6 @@ class ErrorHandler
 
 	/**
 	 * Returns the fallback handler.
-	 *
-	 * @return \Closure
 	 */
 	protected function getFallbackHandler(): Closure
 	{
@@ -167,8 +149,6 @@ class ErrorHandler
 
 	/**
 	 * Set logger instance or closure that returns a logger instance.
-	 *
-	 * @param \Closure|\Psr\Log\LoggerInterface $logger Logger
 	 */
 	public function setLogger(Closure|LoggerInterface $logger): void
 	{
@@ -177,8 +157,6 @@ class ErrorHandler
 
 	/**
 	 * Return logger instance.
-	 *
-	 * @return \Psr\Log\LoggerInterface|null
 	 */
 	public function getLogger(): ?LoggerInterface
 	{
@@ -192,8 +170,6 @@ class ErrorHandler
 
 	/**
 	 * Disables logging for an exception type.
-	 *
-	 * @param array|string $exceptionType Exception type or array of exception types
 	 */
 	public function dontLog(array|string $exceptionType): void
 	{
@@ -210,10 +186,6 @@ class ErrorHandler
 
 	/**
 	 * Prepends an exception handler to the stack.
-	 *
-	 * @param string          $exceptionType Exception type
-	 * @param \Closure|string $handler       Exception handler
-	 * @param array           $parameters    Constructor parameters
 	 */
 	public function handle(string $exceptionType, Closure|string $handler, array $parameters = []): void
 	{
@@ -222,8 +194,6 @@ class ErrorHandler
 
 	/**
 	 * Clears all error handlers for an exception type.
-	 *
-	 * @param string $exceptionType Exception type
 	 */
 	public function clearHandlers(string $exceptionType): void
 	{
@@ -238,9 +208,6 @@ class ErrorHandler
 
 	/**
 	 * Replaces all error handlers for an exception type with a new one.
-	 *
-	 * @param string   $exceptionType Exception type
-	 * @param \Closure $handler       Exception handler
 	 */
 	public function replaceHandlers(string $exceptionType, Closure $handler): void
 	{
@@ -259,9 +226,6 @@ class ErrorHandler
 
 	/**
 	 * Should the exception be logged?
-	 *
-	 * @param  \Throwable $exception An exception object
-	 * @return bool
 	 */
 	protected function shouldExceptionBeLogged(Throwable $exception): bool
 	{
@@ -283,10 +247,6 @@ class ErrorHandler
 
 	/**
 	 * Creates and returns an error handler instance.
-	 *
-	 * @param  string                                $handler    Handler class name
-	 * @param  array                                 $parameters Constructor parameters
-	 * @return \mako\error\handlers\HandlerInterface
 	 */
 	protected function handlerFactory(string $handler, array $parameters): HandlerInterface
 	{
@@ -295,11 +255,6 @@ class ErrorHandler
 
 	/**
 	 * Handle the exception.
-	 *
-	 * @param  \Throwable      $exception  Exceotion
-	 * @param  \Closure|string $handler    Exception handler
-	 * @param  array           $parameters Constructor parameters
-	 * @return mixed
 	 */
 	protected function handleException(Throwable $exception, Closure|string $handler, array $parameters): mixed
 	{
@@ -320,8 +275,6 @@ class ErrorHandler
 
 	/**
 	 * Logs the exception.
-	 *
-	 * @param \Throwable $exception An exception object
 	 */
 	protected function logException(Throwable $exception): void
 	{
@@ -347,8 +300,6 @@ class ErrorHandler
 
 	/**
 	 * Handles uncaught exceptions.
-	 *
-	 * @param \Throwable $exception An exception object
 	 */
 	public function handler(Throwable $exception): never
 	{

--- a/src/mako/error/handlers/HandlerInterface.php
+++ b/src/mako/error/handlers/HandlerInterface.php
@@ -16,9 +16,6 @@ interface HandlerInterface
 {
 	/**
 	 * Handles the exception.
-	 *
-	 * @param  \Throwable $exception Exception to handle
-	 * @return mixed
 	 */
 	public function handle(Throwable $exception): mixed;
 }

--- a/src/mako/error/handlers/ProvidesExceptionIdInterface.php
+++ b/src/mako/error/handlers/ProvidesExceptionIdInterface.php
@@ -14,8 +14,6 @@ interface ProvidesExceptionIdInterface
 {
 	/**
 	 * Returns the exception id.
-	 *
-	 * @return string
 	 */
 	public function getExceptionId(): string;
 }

--- a/src/mako/error/handlers/cli/DevelopmentHandler.php
+++ b/src/mako/error/handlers/cli/DevelopmentHandler.php
@@ -22,8 +22,6 @@ class DevelopmentHandler implements HandlerInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\output\Output $output Output
 	 */
 	public function __construct(
 		protected Output $output
@@ -32,9 +30,6 @@ class DevelopmentHandler implements HandlerInterface
 
 	/**
 	 * Escape formatting tags.
-	 *
-	 * @param  string $string String to escape
-	 * @return string
 	 */
 	protected function escape(string $string): string
 	{
@@ -48,9 +43,6 @@ class DevelopmentHandler implements HandlerInterface
 
 	/**
 	 * Determines the exception type.
-	 *
-	 * @param  \Throwable $exception Throwable
-	 * @return string
 	 */
 	protected function determineExceptionType(Throwable $exception): string
 	{

--- a/src/mako/error/handlers/cli/ProductionHandler.php
+++ b/src/mako/error/handlers/cli/ProductionHandler.php
@@ -18,8 +18,6 @@ class ProductionHandler implements HandlerInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\output\Output $output Output
 	 */
 	public function __construct(
 		protected Output $output

--- a/src/mako/error/handlers/web/DevelopmentHandler.php
+++ b/src/mako/error/handlers/web/DevelopmentHandler.php
@@ -52,12 +52,7 @@ class DevelopmentHandler extends Handler implements HandlerInterface, ProvidesEx
 	protected const SOURCE_PADDING = 6;
 
 	/**
-	 * Constructor.
-	 *
-	 * @param \mako\http\Request            $request  Request
-	 * @param \mako\http\Response           $response Response
-	 * @param \mako\application\Application $app      Application
-	 * @param array                         $keep     Cookies and headers to keep
+	 * Constructor.                        $keep     Cookies and headers to keep.
 	 */
 	public function __construct(
 		protected Request $request,
@@ -71,9 +66,6 @@ class DevelopmentHandler extends Handler implements HandlerInterface, ProvidesEx
 
 	/**
 	 * Returns the exception type.
-	 *
-	 * @param  \Throwable $exception Exception
-	 * @return string
 	 */
 	protected function getExceptionType(Throwable $exception): string
 	{
@@ -94,9 +86,6 @@ class DevelopmentHandler extends Handler implements HandlerInterface, ProvidesEx
 
 	/**
 	 * Return a JSON representation of the exception.
-	 *
-	 * @param  \Throwable $exception Exception
-	 * @return string
 	 */
 	protected function getExceptionAsJson(Throwable $exception): string
 	{
@@ -115,9 +104,6 @@ class DevelopmentHandler extends Handler implements HandlerInterface, ProvidesEx
 
 	/**
 	 * Return a XML representation of the exception.
-	 *
-	 * @param  \Throwable $exception Exception
-	 * @return string
 	 */
 	protected function getExceptionAsXml(Throwable $exception): string
 	{
@@ -140,10 +126,6 @@ class DevelopmentHandler extends Handler implements HandlerInterface, ProvidesEx
 
 	/**
 	 * Returns the source code surrounding the error.
-	 *
-	 * @param  string     $file File path
-	 * @param  int        $line Error line
-	 * @return array|null
 	 */
 	protected function getSourceCode(string $file, int $line): ?array
 	{
@@ -178,9 +160,6 @@ class DevelopmentHandler extends Handler implements HandlerInterface, ProvidesEx
 
 	/**
 	 * Returns an enhanced stack trace.
-	 *
-	 * @param  \Throwable $exception Exception
-	 * @return array
 	 */
 	protected function getEnhancedStackTrace(Throwable $exception): array
 	{
@@ -235,9 +214,6 @@ class DevelopmentHandler extends Handler implements HandlerInterface, ProvidesEx
 
 	/**
 	 * Returns the previous exceptions.
-	 *
-	 * @param  \Throwable $exception Exception
-	 * @return array
 	 */
 	protected function getPreviousExceptions(Throwable $exception): array
 	{
@@ -260,8 +236,6 @@ class DevelopmentHandler extends Handler implements HandlerInterface, ProvidesEx
 
 	/**
 	 * Returns a Symfony var-dumper closure.
-	 *
-	 * @return \Closure
 	 */
 	protected function getDumper(): Closure
 	{
@@ -323,8 +297,6 @@ class DevelopmentHandler extends Handler implements HandlerInterface, ProvidesEx
 
 	/**
 	 * Returns the database queries.
-	 *
-	 * @return array|null
 	 */
 	protected function getQueries(): ?array
 	{
@@ -359,8 +331,6 @@ class DevelopmentHandler extends Handler implements HandlerInterface, ProvidesEx
 
 	/**
 	 * Returns a view factory.
-	 *
-	 * @return \mako\view\ViewFactory
 	 */
 	protected function getViewFactory(): ViewFactory
 	{
@@ -377,9 +347,6 @@ class DevelopmentHandler extends Handler implements HandlerInterface, ProvidesEx
 
 	/**
 	 * Returns a rendered error view.
-	 *
-	 * @param  \Throwable $exception Exception
-	 * @return string
 	 */
 	protected function getExceptionAsHtml(Throwable $exception): string
 	{
@@ -410,9 +377,6 @@ class DevelopmentHandler extends Handler implements HandlerInterface, ProvidesEx
 
 	/**
 	 * Builds a response.
-	 *
-	 * @param  \Throwable $exception Exception
-	 * @return array
 	 */
 	protected function buildResponse(Throwable $exception): array
 	{

--- a/src/mako/error/handlers/web/Handler.php
+++ b/src/mako/error/handlers/web/Handler.php
@@ -26,15 +26,11 @@ abstract class Handler implements ProvidesExceptionIdInterface
 
 	/**
 	 * Exception id.
-	 *
-	 * @var string
 	 */
-	protected $exceptionId;
+	protected string $exceptionId;
 
 	/**
 	 * Generates an exception id.
-	 *
-	 * @return string
 	 */
 	protected function generateExceptionId(): string
 	{
@@ -51,9 +47,6 @@ abstract class Handler implements ProvidesExceptionIdInterface
 
 	/**
 	 * Returns the status code that we should send.
-	 *
-	 * @param  \Throwable $exception Exception
-	 * @return int
 	 */
 	protected function getStatusCode(Throwable $exception): int
 	{
@@ -62,9 +55,6 @@ abstract class Handler implements ProvidesExceptionIdInterface
 
 	/**
 	 * Sends response and adds any aditional headers.
-	 *
-	 * @param \mako\http\Response $response  Response
-	 * @param \Throwable          $exception Exception
 	 */
 	protected function sendResponse(Response $response, Throwable $exception): void
 	{

--- a/src/mako/error/handlers/web/ProductionHandler.php
+++ b/src/mako/error/handlers/web/ProductionHandler.php
@@ -27,11 +27,6 @@ class ProductionHandler extends Handler implements HandlerInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\http\Request          $request  Request
-	 * @param \mako\http\Response         $response Response
-	 * @param \mako\view\ViewFactory|null $view     View factory
-	 * @param array                       $keep     Cookies and headers to keep
 	 */
 	public function __construct(
 		protected Request $request,
@@ -50,9 +45,6 @@ class ProductionHandler extends Handler implements HandlerInterface
 
 	/**
 	 * Returns status code and message.
-	 *
-	 * @param  \Throwable $exception Exception
-	 * @return array
 	 */
 	protected function getStatusCodeMessageAndMetadata(Throwable $exception): array
 	{
@@ -78,9 +70,6 @@ class ProductionHandler extends Handler implements HandlerInterface
 
 	/**
 	 * Return a JSON representation of the exception.
-	 *
-	 * @param  \Throwable $exception Exception
-	 * @return string
 	 */
 	protected function getExceptionAsJson(Throwable $exception): string
 	{
@@ -89,9 +78,6 @@ class ProductionHandler extends Handler implements HandlerInterface
 
 	/**
 	 * Return a XML representation of the exception.
-	 *
-	 * @param  \Throwable $exception Exception
-	 * @return string
 	 */
 	protected function getExceptionAsXml(Throwable $exception): string
 	{
@@ -130,9 +116,6 @@ class ProductionHandler extends Handler implements HandlerInterface
 
 	/**
 	 * Returns a rendered error view.
-	 *
-	 * @param  \Throwable $exception Exception
-	 * @return string
 	 */
 	protected function getExceptionAsHtml(Throwable $exception): string
 	{
@@ -164,9 +147,6 @@ class ProductionHandler extends Handler implements HandlerInterface
 
 	/**
 	 * Returns a plain text representation of the error.
-	 *
-	 * @param  \Throwable $exception Exception
-	 * @return string
 	 */
 	protected function getExceptionAsPlainText(Throwable $exception): string
 	{
@@ -177,9 +157,6 @@ class ProductionHandler extends Handler implements HandlerInterface
 
 	/**
 	 * Returns a response.
-	 *
-	 * @param  \Throwable $exception Exception
-	 * @return array
 	 */
 	protected function buildResponse(Throwable $exception): array
 	{

--- a/src/mako/file/FileInfo.php
+++ b/src/mako/file/FileInfo.php
@@ -23,8 +23,6 @@ class FileInfo extends SplFileInfo
 {
 	/**
 	 * Returns the MIME type of the file.
-	 *
-	 * @return string|null
 	 */
 	public function getMimeType(): ?string
 	{
@@ -39,8 +37,6 @@ class FileInfo extends SplFileInfo
 
 	/**
 	 * Returns the MIME encoding of the file.
-	 *
-	 * @return string|null
 	 */
 	public function getMimeEncoding(): ?string
 	{
@@ -55,10 +51,6 @@ class FileInfo extends SplFileInfo
 
 	/**
 	 * Generates a hash using the contents of the file.
-	 *
-	 * @param  string $algorithm Hashing algorithm
-	 * @param  bool   $raw       Output raw binary data?
-	 * @return string
 	 */
 	public function getHash(string $algorithm = 'sha256', bool $raw = false): string
 	{
@@ -67,11 +59,6 @@ class FileInfo extends SplFileInfo
 
 	/**
 	 * Returns TRUE if the file matches the provided hash and FALSE if not.
-	 *
-	 * @param  string $hash      Hash
-	 * @param  string $algorithm Hashing algorithm
-	 * @param  bool   $raw       Is the provided hash raw?
-	 * @return bool
 	 */
 	public function validateHash(string $hash, string $algorithm = 'sha256', bool $raw = false): bool
 	{
@@ -80,11 +67,6 @@ class FileInfo extends SplFileInfo
 
 	/**
 	 * Generates a HMAC using the contents of the file.
-	 *
-	 * @param  string $key       Shared secret key
-	 * @param  string $algorithm Hashing algorithm
-	 * @param  bool   $raw       Output raw binary data?
-	 * @return string
 	 */
 	public function getHmac(string $key, string $algorithm = 'sha256', bool $raw = false): string
 	{
@@ -93,12 +75,6 @@ class FileInfo extends SplFileInfo
 
 	/**
 	 * Returns TRUE if the file matches the provided HMAC and FALSE if not.
-	 *
-	 * @param  string $hmac      HMAC
-	 * @param  string $key       Key
-	 * @param  string $algorithm Hashing algorithm
-	 * @param  bool   $raw       Is the provided HMAC raw?
-	 * @return bool
 	 */
 	public function validateHmac(string $hmac, string $key, string $algorithm = 'sha256', bool $raw = false): bool
 	{

--- a/src/mako/file/FileSystem.php
+++ b/src/mako/file/FileSystem.php
@@ -102,6 +102,8 @@ class FileSystem
 
 	/**
 	 * Returns the target of a link.
+	 *
+	 * @return false|string
 	 */
 	public function getLinkTarget(string $path)
 	{

--- a/src/mako/file/FileSystem.php
+++ b/src/mako/file/FileSystem.php
@@ -41,9 +41,6 @@ class FileSystem
 {
 	/**
 	 * Returns TRUE if a resource exists and FALSE if not.
-	 *
-	 * @param  string $path Path to file
-	 * @return bool
 	 */
 	public function has(string $path): bool
 	{
@@ -52,9 +49,6 @@ class FileSystem
 
 	/**
 	 * Returns TRUE if the provided path is a file and FALSE if not.
-	 *
-	 * @param  string $path Path
-	 * @return bool
 	 */
 	public function isFile(string $path): bool
 	{
@@ -63,9 +57,6 @@ class FileSystem
 
 	/**
 	 * Returns TRUE if the provided path is a directory and FALSE if not.
-	 *
-	 * @param  string $path Path to directory
-	 * @return bool
 	 */
 	public function isDirectory(string $path): bool
 	{
@@ -74,9 +65,6 @@ class FileSystem
 
 	/**
 	 * Returns TRUE if a file or directory is empty and FALSE if not.
-	 *
-	 * @param  string $path Path to directory
-	 * @return bool
 	 */
 	public function isEmpty(string $path): bool
 	{
@@ -90,9 +78,6 @@ class FileSystem
 
 	/**
 	 * Returns TRUE if the file is readable and FALSE if not.
-	 *
-	 * @param  string $path Path to file
-	 * @return bool
 	 */
 	public function isReadable(string $path): bool
 	{
@@ -101,9 +86,6 @@ class FileSystem
 
 	/**
 	 * Returns TRUE if the file or directory is writable and FALSE if not.
-	 *
-	 * @param  string $path Path to file
-	 * @return bool
 	 */
 	public function isWritable(string $path): bool
 	{
@@ -112,9 +94,6 @@ class FileSystem
 
 	/**
 	 * Returns TRUE if the provided path is a link and FALSE if not.
-	 *
-	 * @param  string $path Path
-	 * @return bool
 	 */
 	public function isLink(string $path): bool
 	{
@@ -123,9 +102,6 @@ class FileSystem
 
 	/**
 	 * Returns the target of a link.
-	 *
-	 * @param  string       $path Path
-	 * @return false|string
 	 */
 	public function getLinkTarget(string $path)
 	{
@@ -134,10 +110,6 @@ class FileSystem
 
 	/**
 	 * Creates a symbolic link.
-	 *
-	 * @param  string $path     Path
-	 * @param  string $linkName Link name
-	 * @return bool
 	 */
 	public function createSymbolicLink(string $path, string $linkName): bool
 	{
@@ -146,10 +118,6 @@ class FileSystem
 
 	/**
 	 * Creates a hard link.
-	 *
-	 * @param  string $path     Path
-	 * @param  string $linkName Link name
-	 * @return bool
 	 */
 	public function createHardLink(string $path, string $linkName): bool
 	{
@@ -158,9 +126,6 @@ class FileSystem
 
 	/**
 	 * Returns the time (unix timestamp) the file was last modified.
-	 *
-	 * @param  string $path Path to file
-	 * @return int
 	 */
 	public function lastModified(string $path): int
 	{
@@ -169,9 +134,6 @@ class FileSystem
 
 	/**
 	 * Returns the fize of the file in bytes.
-	 *
-	 * @param  string $path Path to file
-	 * @return int
 	 */
 	public function size(string $path): int
 	{
@@ -180,9 +142,6 @@ class FileSystem
 
 	/**
 	 * Returns the extension of the file.
-	 *
-	 * @param  string $path Path to file
-	 * @return string
 	 */
 	public function extension(string $path): string
 	{
@@ -191,10 +150,6 @@ class FileSystem
 
 	/**
 	 * Copies a file.
-	 *
-	 * @param  string $source      Path to source file
-	 * @param  string $destination Path to the destination file
-	 * @return bool
 	 */
 	public function copy(string $source, string $destination): bool
 	{
@@ -203,10 +158,6 @@ class FileSystem
 
 	/**
 	 * Renames a file or directory.
-	 *
-	 * @param  string $oldName Old name
-	 * @param  string $newName New name
-	 * @return bool
 	 */
 	public function rename(string $oldName, string $newName): bool
 	{
@@ -215,9 +166,6 @@ class FileSystem
 
 	/**
 	 * Deletes the file from disk.
-	 *
-	 * @param  string $path Path to file
-	 * @return bool
 	 */
 	public function remove(string $path): bool
 	{
@@ -226,9 +174,6 @@ class FileSystem
 
 	/**
 	 * Deletes a directory and its contents from disk.
-	 *
-	 * @param  string $path Path to directory
-	 * @return bool
 	 */
 	public function removeDirectory(string $path): bool
 	{
@@ -250,8 +195,6 @@ class FileSystem
 	/**
 	 * Returns an array of pathnames matching the provided pattern.
 	 *
-	 * @param  string      $pattern Patern
-	 * @param  int         $flags   Flags
 	 * @return array|false
 	 */
 	public function glob(string $pattern, int $flags = 0)
@@ -262,7 +205,6 @@ class FileSystem
 	/**
 	 * Returns the contents of the file.
 	 *
-	 * @param  string       $path File path
 	 * @return false|string
 	 */
 	public function get(string $path)
@@ -273,9 +215,6 @@ class FileSystem
 	/**
 	 * Writes the supplied data to a file.
 	 *
-	 * @param  string    $path File path
-	 * @param  mixed     $data File data
-	 * @param  bool      $lock Acquire an exclusive write lock?
 	 * @return false|int
 	 */
 	public static function put(string $path, mixed $data, bool $lock = false)
@@ -286,9 +225,6 @@ class FileSystem
 	/**
 	 * Prepends the supplied data to a file.
 	 *
-	 * @param  string    $path File path
-	 * @param  mixed     $data File data
-	 * @param  bool      $lock Acquire an exclusive write lock?
 	 * @return false|int
 	 */
 	public static function prepend(string $path, mixed $data, bool $lock = false)
@@ -299,9 +235,6 @@ class FileSystem
 	/**
 	 * Appends the supplied data to a file.
 	 *
-	 * @param  string    $path File path
-	 * @param  mixed     $data File data
-	 * @param  bool      $lock Acquire an exclusive write lock?
 	 * @return false|int
 	 */
 	public static function append(string $path, mixed $data, bool $lock = false)
@@ -311,10 +244,6 @@ class FileSystem
 
 	/**
 	 * Truncates a file.
-	 *
-	 * @param  string $path File path
-	 * @param  bool   $lock Acquire an exclusive write lock?
-	 * @return bool
 	 */
 	public static function truncate(string $path, bool $lock = false): bool
 	{
@@ -323,11 +252,6 @@ class FileSystem
 
 	/**
 	 *  Creates a directory.
-	 *
-	 * @param  string $path      Path to directory
-	 * @param  int    $mode      Mode
-	 * @param  bool   $recursive Recursive
-	 * @return bool
 	 */
 	public function createDirectory(string $path, int $mode = 0777, bool $recursive = false): bool
 	{
@@ -336,9 +260,6 @@ class FileSystem
 
 	/**
 	 * Returns the total size of a filesystem or disk partition in bytes.
-	 *
-	 * @param  string|null $path A directory of the filesystem or disk partition
-	 * @return float
 	 */
 	public function getDiskSize(?string $path = null): float
 	{
@@ -347,9 +268,6 @@ class FileSystem
 
 	/**
 	 * Returns the total number of available bytes on the filesystem or disk partition.
-	 *
-	 * @param  string|null $path A directory of the filesystem or disk partition
-	 * @return float
 	 */
 	public function getFreeSpaceOnDisk(?string $path = null): float
 	{
@@ -358,9 +276,6 @@ class FileSystem
 
 	/**
 	 * Includes a file.
-	 *
-	 * @param  string $path Path to file
-	 * @return mixed
 	 */
 	public function include(string $path): mixed
 	{
@@ -369,9 +284,6 @@ class FileSystem
 
 	/**
 	 * Includes a file it hasn't already been included.
-	 *
-	 * @param  string $path Path to file
-	 * @return mixed
 	 */
 	public function includeOnce(string $path): mixed
 	{
@@ -380,9 +292,6 @@ class FileSystem
 
 	/**
 	 * Requires a file.
-	 *
-	 * @param  string $path Path to file
-	 * @return mixed
 	 */
 	public function require(string $path): mixed
 	{
@@ -391,9 +300,6 @@ class FileSystem
 
 	/**
 	 * Requires a file if it hasn't already been required.
-	 *
-	 * @param  string $path Path to file
-	 * @return mixed
 	 */
 	public function requireOnce(string $path): mixed
 	{
@@ -402,9 +308,6 @@ class FileSystem
 
 	/**
 	 * Returns a FileInfo object.
-	 *
-	 * @param  string              $path Path to file
-	 * @return \mako\file\FileInfo
 	 */
 	public function info(string $path): FileInfo
 	{
@@ -414,9 +317,6 @@ class FileSystem
 	/**
 	 * Returns a SplFileObject.
 	 *
-	 * @param  string         $path           Path to file
-	 * @param  string         $openMode       Open mode
-	 * @param  bool           $useIncludePath Use include path?
 	 * @return \SplFileObject
 	 */
 	public function file(string $path, string $openMode = 'r', bool $useIncludePath = false)

--- a/src/mako/file/Finder.php
+++ b/src/mako/file/Finder.php
@@ -42,7 +42,7 @@ class Finder
 	 *
 	 * @return $this
 	 */
-	public function setPattern(string $pattern)
+	public function setPattern(string $pattern): static
 	{
 		$this->pattern = $pattern;
 
@@ -62,7 +62,7 @@ class Finder
 	 *
 	 * @return $this
 	 */
-	public function setMaxDepth(int $maxDepth)
+	public function setMaxDepth(int $maxDepth): static
 	{
 		$this->maxDepth = $maxDepth;
 

--- a/src/mako/file/Finder.php
+++ b/src/mako/file/Finder.php
@@ -21,22 +21,16 @@ class Finder
 {
 	/**
 	 * The pattern that the files should match.
-	 *
-	 * @var string
 	 */
-	protected $pattern;
+	protected string|null $pattern = null;
 
 	/**
 	 * Maximum search depth.
-	 *
-	 * @var int
 	 */
-	protected $maxDepth;
+	protected int|null $maxDepth = null;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array $paths The paths that we should search
 	 */
 	public function __construct(
 		protected array $paths
@@ -46,7 +40,6 @@ class Finder
 	/**
 	 * Sets a pattern that the files should match.
 	 *
-	 * @param  string $pattern
 	 * @return $this
 	 */
 	public function setPattern(string $pattern)
@@ -58,8 +51,6 @@ class Finder
 
 	/**
 	 * Returns the pattern that the files should match.
-	 *
-	 * @return string|null
 	 */
 	public function getPattern(): ?string
 	{
@@ -69,7 +60,6 @@ class Finder
 	/**
 	 * Sets the maximum search depth.
 	 *
-	 * @param  int   $maxDepth
 	 * @return $this
 	 */
 	public function setMaxDepth(int $maxDepth)
@@ -81,8 +71,6 @@ class Finder
 
 	/**
 	 * Returns the the maximum search depth.
-	 *
-	 * @return int|null
 	 */
 	public function getMaxDepth(): ?int
 	{
@@ -91,9 +79,6 @@ class Finder
 
 	/**
 	 * Creates an iterator instance.
-	 *
-	 * @param  string    $path
-	 * @return \Iterator
 	 */
 	protected function createIterator(string $path): Iterator
 	{
@@ -114,8 +99,6 @@ class Finder
 
 	/**
 	 * Finds all files in the given paths.
-	 *
-	 * @return \Generator
 	 */
 	public function find(): Generator
 	{
@@ -127,9 +110,6 @@ class Finder
 
 	/**
 	 * Finds all files in the given paths.
-	 *
-	 * @param  string     $className Class name
-	 * @return \Generator
 	 */
 	public function findAs(string $className): Generator
 	{

--- a/src/mako/functions.php
+++ b/src/mako/functions.php
@@ -15,7 +15,7 @@ use function substr;
 /**
  * Builds and returns a "function" used for middleware, route constraints and validation rules.
  */
-function f(string $_name, ...$_arguments): string
+function f(string $_name, mixed ...$_arguments): string
 {
 	if(empty($_arguments))
 	{

--- a/src/mako/functions.php
+++ b/src/mako/functions.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
 namespace mako;
 
 use function filter_var;
@@ -9,10 +14,6 @@ use function substr;
 
 /**
  * Builds and returns a "function" used for middleware, route constraints and validation rules.
- *
- * @param  string $_name         Function name
- * @param  mixed  ...$_arguments Function arguments
- * @return string
  */
 function f(string $_name, ...$_arguments): string
 {
@@ -26,12 +27,6 @@ function f(string $_name, ...$_arguments): string
 
 /**
  * Returns the value of the chosen environment variable or NULL if it does not exist.
- *
- * @param  string $variableName Variable name
- * @param  mixed  $default      Default value to return if the variable does not exist
- * @param  bool   $isBool       Set to TRUE to treat the value as a boolean
- * @param  bool   $localOnly    Set to TRUE to only return local environment variables
- * @return mixed
  */
 function env(string $variableName, mixed $default = null, bool $isBool = false, bool $localOnly = false): mixed
 {

--- a/src/mako/gatekeeper/Gatekeeper.php
+++ b/src/mako/gatekeeper/Gatekeeper.php
@@ -47,29 +47,21 @@ class Gatekeeper
 
 	/**
 	 * Default adapter name.
-	 *
-	 * @var string
 	 */
-	protected $defaultAdapter;
+	protected string $defaultAdapter;
 
 	/**
 	 * Adapters.
-	 *
-	 * @var array
 	 */
-	protected $adapters = [];
+	protected array $adapters = [];
 
 	/**
 	 * Adapter factories.
-	 *
-	 * @var array
 	 */
-	protected $adapterFactories = [];
+	protected array $adapterFactories = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array|\mako\gatekeeper\adapters\AdapterInterface $adapter Array containing the adapter name and closure factory or an adapter instance
 	 */
 	public function __construct(array|AdapterInterface $adapter)
 	{
@@ -78,9 +70,6 @@ class Gatekeeper
 
 	/**
 	 * Registers an adapter instance.
-	 *
-	 * @param  \mako\gatekeeper\adapters\AdapterInterface $adapter Adapter instance
-	 * @return string
 	 */
 	protected function registerAdapterInstance(AdapterInterface $adapter): string
 	{
@@ -91,10 +80,6 @@ class Gatekeeper
 
 	/**
 	 * Registers an adapter factory.
-	 *
-	 * @param  string   $name    Adapter name
-	 * @param  \Closure $factory Adapter factory
-	 * @return string
 	 */
 	protected function registerAdapterFactory(string $name, Closure $factory): string
 	{
@@ -105,9 +90,6 @@ class Gatekeeper
 
 	/**
 	 * Registers an adapter.
-	 *
-	 * @param  array|\mako\gatekeeper\adapters\AdapterInterface $adapter Array containing the adapter name and closure factory or an adapter instance
-	 * @return string
 	 */
 	protected function registerAdapter(array|AdapterInterface $adapter): string
 	{
@@ -123,9 +105,6 @@ class Gatekeeper
 
 	/**
 	 * Registers a new adapter.
-	 *
-	 * @param  array|\mako\gatekeeper\adapters\AdapterInterface $adapter Array containing the adapter name and closure factory or an adapter instance
-	 * @return \mako\gatekeeper\Gatekeeper
 	 */
 	public function extend(array|AdapterInterface $adapter): Gatekeeper
 	{
@@ -136,9 +115,6 @@ class Gatekeeper
 
 	/**
 	 * Sets the defaut adapter name.
-	 *
-	 * @param  string                      $name Adapter name
-	 * @return \mako\gatekeeper\Gatekeeper
 	 */
 	public function useAsDefaultAdapter(string $name): Gatekeeper
 	{
@@ -149,9 +125,6 @@ class Gatekeeper
 
 	/**
 	 * Creates an adapter instance using a factory.
-	 *
-	 * @param  string                                     $name Adapter name
-	 * @return \mako\gatekeeper\adapters\AdapterInterface
 	 */
 	protected function adapterFactory(string $name): AdapterInterface
 	{
@@ -162,9 +135,6 @@ class Gatekeeper
 
 	/**
 	 * Returns an adapter instance.
-	 *
-	 * @param  string|null                                $name Adapter name
-	 * @return \mako\gatekeeper\adapters\AdapterInterface
 	 */
 	public function adapter(?string $name = null): AdapterInterface
 	{
@@ -175,10 +145,6 @@ class Gatekeeper
 
 	/**
 	 * Magic shortcut to the default adapter.
-	 *
-	 * @param  string $name      Method name
-	 * @param  array  $arguments Method arguments
-	 * @return mixed
 	 */
 	public function __call(string $name, array $arguments): mixed
 	{

--- a/src/mako/gatekeeper/adapters/Adapter.php
+++ b/src/mako/gatekeeper/adapters/Adapter.php
@@ -10,7 +10,9 @@ namespace mako\gatekeeper\adapters;
 use mako\gatekeeper\entities\group\Group;
 use mako\gatekeeper\entities\user\User;
 use mako\gatekeeper\entities\user\UserEntityInterface;
+use mako\gatekeeper\repositories\group\GroupRepository;
 use mako\gatekeeper\repositories\group\GroupRepositoryInterface;
+use mako\gatekeeper\repositories\user\UserRepository;
 use mako\gatekeeper\repositories\user\UserRepositoryInterface;
 
 /**
@@ -23,24 +25,18 @@ abstract class Adapter implements AdapterInterface, WithGroupsInterface
 {
 	/**
 	 * User repository.
-	 *
-	 * @var \mako\gatekeeper\repositories\user\UserRepository|null
 	 */
-	protected $userRepository;
+	protected UserRepository|null $userRepository = null;
 
 	/**
 	 * Group repository.
-	 *
-	 * @var \mako\gatekeeper\repositories\group\GroupRepository|null
 	 */
-	protected $groupRepository;
+	protected GroupRepository|null $groupRepository = null;
 
 	/**
 	 * User entity.
-	 *
-	 * @var \mako\gatekeeper\entities\user\User|null
 	 */
-	protected $user;
+	protected User|null $user = null;
 
 	/**
 	 * {@inheritDoc}
@@ -100,13 +96,6 @@ abstract class Adapter implements AdapterInterface, WithGroupsInterface
 
 	/**
 	 * Creates a new user and returns the user object.
-	 *
-	 * @param  string                              $email      Email address
-	 * @param  string                              $username   Username
-	 * @param  string                              $password   Password
-	 * @param  bool                                $activate   Will activate the user if set to true
-	 * @param  array                               $properties Additional user properties
-	 * @return \mako\gatekeeper\entities\user\User
 	 */
 	public function createUser(string $email, string $username, string $password, bool $activate = false, array $properties = []): User
 	{
@@ -123,10 +112,6 @@ abstract class Adapter implements AdapterInterface, WithGroupsInterface
 
 	/**
 	 * Creates a new group and returns the group object.
-	 *
-	 * @param  string                                $name       Group name
-	 * @param  array                                 $properties Additional group properties
-	 * @return \mako\gatekeeper\entities\group\Group
 	 */
 	public function createGroup(string $name, array $properties = []): Group
 	{
@@ -140,9 +125,6 @@ abstract class Adapter implements AdapterInterface, WithGroupsInterface
 
 	/**
 	 * Activates a user based on the provided action token.
-	 *
-	 * @param  string $token Action token
-	 * @return bool
 	 */
 	public function activateUser(string $token): bool
 	{

--- a/src/mako/gatekeeper/adapters/AdapterInterface.php
+++ b/src/mako/gatekeeper/adapters/AdapterInterface.php
@@ -17,50 +17,36 @@ interface AdapterInterface
 {
 	/**
 	 * Returns the adapter name.
-	 *
-	 * @return string
 	 */
 	public function getName(): string;
 
 	/**
 	 * Sets the user repository.
-	 *
-	 * @param \mako\gatekeeper\repositories\user\UserRepositoryInterface $userRepository User repository
 	 */
 	public function setUserRepository(UserRepositoryInterface $userRepository): void;
 
 	/**
 	 * Returns the user repository.
-	 *
-	 * @return \mako\gatekeeper\repositories\user\UserRepositoryInterface|null
 	 */
 	public function getUserRepository(): ?UserRepositoryInterface;
 
 	/**
 	 * Sets the active user.
-	 *
-	 * @param \mako\gatekeeper\entities\user\UserEntityInterface $user User entity
 	 */
 	public function setUser(UserEntityInterface $user): void;
 
 	/**
 	 * Returns the active user or null if there isn't one.
-	 *
-	 * @return \mako\gatekeeper\entities\user\UserEntityInterface|null
 	 */
 	public function getUser(): ?UserEntityInterface;
 
 	/**
 	 * Returns TRUE if we don't have an authenticated user and FALSE if we do.
-	 *
-	 * @return bool
 	 */
 	public function isGuest(): bool;
 
 	/**
 	 * Returns TRUE if we have an authenticated user and FALSE if we don't.
-	 *
-	 * @return bool
 	 */
 	public function isLoggedIn(): bool;
 }

--- a/src/mako/gatekeeper/adapters/Session.php
+++ b/src/mako/gatekeeper/adapters/Session.php
@@ -28,10 +28,8 @@ class Session extends Adapter
 {
 	/**
 	 * Adapter options.
-	 *
-	 * @var array
 	 */
-	protected $options =
+	protected array $options =
 	[
 		'auth_key'       => 'gatekeeper_auth_key',
 		'cookie_options' =>
@@ -51,20 +49,11 @@ class Session extends Adapter
 
 	/**
 	 * Has the user logged out?
-	 *
-	 * @var bool
 	 */
-	protected $hasLoggedOut = false;
+	protected bool $hasLoggedOut = false;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\gatekeeper\repositories\user\UserRepository   $userRepository  User repository
-	 * @param \mako\gatekeeper\repositories\group\GroupRepository $groupRepository Group repository
-	 * @param \mako\http\Request                                  $request         Request instance
-	 * @param \mako\http\Response                                 $response        Response instance
-	 * @param \mako\session\Session                               $session         Session instance
-	 * @param array                                               $options         Options
 	 */
 	public function __construct(
 		UserRepository $userRepository,
@@ -146,9 +135,6 @@ class Session extends Adapter
 	 * Returns TRUE if the identifier + password combination matches and the user is activated, not locked and not banned.
 	 * A status code will be retured in all other situations.
 	 *
-	 * @param  int|string  $identifier User email or username
-	 * @param  string|null $password   User password
-	 * @param  bool        $force      Skip the password check?
 	 * @return int|true
 	 */
 	protected function authenticate(int|string $identifier, ?string $password, bool $force = false)
@@ -213,10 +199,6 @@ class Session extends Adapter
 	 * Returns TRUE if the identifier + password combination matches and the user is activated, not locked and not banned.
 	 * A status code will be retured in all other situations.
 	 *
-	 * @param  int|string|null $identifier User identifier
-	 * @param  string|null     $password   User password
-	 * @param  bool            $remember   Set a remember me cookie?
-	 * @param  bool            $force      Login the user without checking the password?
 	 * @return int|true
 	 */
 	public function login(int|string|null $identifier, ?string $password, bool $remember = false, bool $force = false)
@@ -252,8 +234,6 @@ class Session extends Adapter
 	 * Returns TRUE if the identifier exists and the user is activated, not locked and not banned.
 	 * A status code will be retured in all other situations.
 	 *
-	 * @param  int|string $identifier User identifier
-	 * @param  bool       $remember   Set a remember me cookie?
 	 * @return int|true
 	 */
 	public function forceLogin(int|string $identifier, bool $remember = false)
@@ -263,9 +243,6 @@ class Session extends Adapter
 
 	/**
 	 * Returns a basic authentication response if login is required and null if not.
-	 *
-	 * @param  bool $clearResponse Clear all previously set headers and cookies from the response?
-	 * @return bool
 	 */
 	public function basicAuth(bool $clearResponse = false): bool
 	{

--- a/src/mako/gatekeeper/adapters/WithGroupsInterface.php
+++ b/src/mako/gatekeeper/adapters/WithGroupsInterface.php
@@ -16,15 +16,11 @@ interface WithGroupsInterface
 {
 	/**
 	 * Sets the group repository.
-	 *
-	 * @param \mako\gatekeeper\repositories\group\GroupRepositoryInterface $groupRepository Group repository
 	 */
 	public function setGroupRepository(GroupRepositoryInterface $groupRepository): void;
 
 	/**
 	 * Returns the group repository.
-	 *
-	 * @return \mako\gatekeeper\repositories\group\GroupRepositoryInterface|null
 	 */
 	public function getGroupRepository(): ?GroupRepositoryInterface;
 }

--- a/src/mako/gatekeeper/authorization/AuthorizableInterface.php
+++ b/src/mako/gatekeeper/authorization/AuthorizableInterface.php
@@ -14,18 +14,11 @@ interface AuthorizableInterface
 {
 	/**
 	 * Sets the authorizer.
-	 *
-	 * @param \mako\gatekeeper\authorization\AuthorizerInterface $authorizer Authorizer
 	 */
 	public function setAuthorizer(AuthorizerInterface $authorizer): void;
 
 	/**
 	 * Returns TRUE if allowed to perform the action on the entity and FALSE if not.
-	 *
-	 * @param  string        $action        Action
-	 * @param  object|string $entity        Entity
-	 * @param  mixed         ...$parameters Additional parameters
-	 * @return bool
 	 */
 	public function can(string $action, object|string $entity, mixed ...$parameters): bool;
 }

--- a/src/mako/gatekeeper/authorization/Authorizer.php
+++ b/src/mako/gatekeeper/authorization/Authorizer.php
@@ -22,15 +22,11 @@ class Authorizer implements AuthorizerInterface
 {
 	/**
 	 * Policies.
-	 *
-	 * @var array
 	 */
-	protected $policies = [];
+	protected array $policies = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\syringe\Container $container Container
 	 */
 	public function __construct(
 		protected Container $container = new Container
@@ -47,9 +43,6 @@ class Authorizer implements AuthorizerInterface
 
 	/**
 	 * Policy factory.
-	 *
-	 * @param  object|string                                           $entity Entity instance or class name
-	 * @return \mako\gatekeeper\authorization\policies\PolicyInterface
 	 */
 	protected function policyFactory(object|string $entity): PolicyInterface
 	{

--- a/src/mako/gatekeeper/authorization/AuthorizerInterface.php
+++ b/src/mako/gatekeeper/authorization/AuthorizerInterface.php
@@ -16,20 +16,11 @@ interface AuthorizerInterface
 {
 	/**
 	 * Registers an authorization policy.
-	 *
-	 * @param string $entityClass Entity class
-	 * @param string $policyClass Policy class
 	 */
 	public function registerPolicy(string $entityClass, string $policyClass): void;
 
 	/**
 	 * Returns TRUE if the user is allowed to perform the action on the entity.
-	 *
-	 * @param  \mako\gatekeeper\entities\user\UserEntityInterface|null $user          User entity
-	 * @param  string                                                  $action        Action
-	 * @param  object|string                                           $entity        Entity instance or class name
-	 * @param  mixed                                                   ...$parameters Additional parameters
-	 * @return bool
 	 */
 	public function can(?UserEntityInterface $user, string $action, object|string $entity, mixed ...$parameters): bool;
 }

--- a/src/mako/gatekeeper/authorization/http/routing/traits/AuthorizationTrait.php
+++ b/src/mako/gatekeeper/authorization/http/routing/traits/AuthorizationTrait.php
@@ -19,10 +19,6 @@ trait AuthorizationTrait
 {
 	/**
 	 * Throws a ForbiddenException if the user is not allowed to perform the action on the entity.
-	 *
-	 * @param string        $action        Action
-	 * @param object|string $entity        Entity instance or class name
-	 * @param mixed         ...$parameters Additional parameters
 	 */
 	protected function authorize(string $action, object|string $entity, mixed ...$parameters): void
 	{

--- a/src/mako/gatekeeper/authorization/policies/PolicyInterface.php
+++ b/src/mako/gatekeeper/authorization/policies/PolicyInterface.php
@@ -16,11 +16,6 @@ interface PolicyInterface
 {
 	/**
 	 * Return a boolean to skip further authorization or null to continue.
-	 *
-	 * @param  \mako\gatekeeper\entities\user\UserEntityInterface|null $user   User entity
-	 * @param  string                                                  $action Action
-	 * @param  object|string                                           $entity Entity instance or class name
-	 * @return bool|null
 	 */
 	public function before(?UserEntityInterface $user, string $action, object|string $entity): ?bool;
 }

--- a/src/mako/gatekeeper/authorization/traits/AuthorizableTrait.php
+++ b/src/mako/gatekeeper/authorization/traits/AuthorizableTrait.php
@@ -16,15 +16,11 @@ trait AuthorizableTrait
 {
 	/**
 	 * Authorizer.
-	 *
-	 * @var \mako\gatekeeper\authorization\AuthorizerInterface
 	 */
-	protected $authorizer;
+	protected AuthorizerInterface $authorizer;
 
 	/**
 	 * Sets the authorizer.
-	 *
-	 * @param \mako\gatekeeper\authorization\AuthorizerInterface $authorizer Authorizer
 	 */
 	public function setAuthorizer(AuthorizerInterface $authorizer): void
 	{
@@ -33,11 +29,6 @@ trait AuthorizableTrait
 
 	/**
 	 * Returns TRUE if allowed to perform the action on the entity and FALSE if not.
-	 *
-	 * @param  string        $action        Action
-	 * @param  object|string $entity        Entity
-	 * @param  mixed         ...$parameters Additional parameters
-	 * @return bool
 	 */
 	public function can(string $action, object|string $entity, mixed ...$parameters): bool
 	{

--- a/src/mako/gatekeeper/entities/group/Group.php
+++ b/src/mako/gatekeeper/entities/group/Group.php
@@ -36,8 +36,6 @@ class Group extends ORM implements GroupEntityInterface
 
 	/**
 	 * Group users.
-	 *
-	 * @return \mako\database\midgard\relations\ManyToMany
 	 */
 	public function users(): ManyToMany
 	{
@@ -54,8 +52,6 @@ class Group extends ORM implements GroupEntityInterface
 
 	/**
 	 * Sets the group name.
-	 *
-	 * @param string $name Group name
 	 */
 	public function setName(string $name): void
 	{
@@ -72,9 +68,6 @@ class Group extends ORM implements GroupEntityInterface
 
 	/**
 	 * Adds a user to the group.
-	 *
-	 * @param  \mako\gatekeeper\entities\user\User $user User
-	 * @return bool
 	 */
 	public function addUser(User $user): bool
 	{
@@ -93,9 +86,6 @@ class Group extends ORM implements GroupEntityInterface
 
 	/**
 	 * Removes a user from the group.
-	 *
-	 * @param  \mako\gatekeeper\entities\user\User $user User
-	 * @return bool
 	 */
 	public function removeUser(User $user): bool
 	{
@@ -114,9 +104,6 @@ class Group extends ORM implements GroupEntityInterface
 
 	/**
 	 * Returns TRUE if a user is a member of the group and FALSE if not.
-	 *
-	 * @param  \mako\gatekeeper\entities\user\User $user User
-	 * @return bool
 	 */
 	public function isMember(User $user)
 	{

--- a/src/mako/gatekeeper/entities/group/Group.php
+++ b/src/mako/gatekeeper/entities/group/Group.php
@@ -29,10 +29,8 @@ class Group extends ORM implements GroupEntityInterface
 
 	/**
 	 * Table name.
-	 *
-	 * @var string
 	 */
-	protected $tableName = 'groups';
+	protected string $tableName = 'groups';
 
 	/**
 	 * Group users.

--- a/src/mako/gatekeeper/entities/group/GroupEntityInterface.php
+++ b/src/mako/gatekeeper/entities/group/GroupEntityInterface.php
@@ -14,15 +14,11 @@ interface GroupEntityInterface
 {
 	/**
 	 * Returns the group id.
-	 *
-	 * @return mixed
 	 */
 	public function getId(): mixed;
 
 	/**
 	 * Returns the group name.
-	 *
-	 * @return string
 	 */
 	public function getName(): string;
 }

--- a/src/mako/gatekeeper/entities/user/MemberInterface.php
+++ b/src/mako/gatekeeper/entities/user/MemberInterface.php
@@ -14,9 +14,6 @@ interface MemberInterface
 {
 	/**
 	 * Returns TRUE if a user is a member of the group(s) and FALSE if not.
-	 *
-	 * @param  array|int|string $group Group name, group id or an array of group names or group ids
-	 * @return bool
 	 */
 	public function isMemberOf(array|int|string $group): bool;
 }

--- a/src/mako/gatekeeper/entities/user/User.php
+++ b/src/mako/gatekeeper/entities/user/User.php
@@ -101,7 +101,7 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 	/**
 	 * Sets the user email address.
 	 */
-	public function setEmail($email): void
+	public function setEmail(string $email): void
 	{
 		$this->email = $email;
 	}

--- a/src/mako/gatekeeper/entities/user/User.php
+++ b/src/mako/gatekeeper/entities/user/User.php
@@ -50,17 +50,13 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Table name.
-	 *
-	 * @var string
 	 */
-	protected $tableName = 'users';
+	protected string $tableName = 'users';
 
 	/**
 	 * Type casting.
-	 *
-	 * @var array
 	 */
-	protected $cast = ['last_fail_at' => 'date', 'locked_until' => 'date'];
+	protected array $cast = ['last_fail_at' => 'date', 'locked_until' => 'date'];
 
 	/**
 	 * User groups.

--- a/src/mako/gatekeeper/entities/user/User.php
+++ b/src/mako/gatekeeper/entities/user/User.php
@@ -64,8 +64,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * User groups.
-	 *
-	 * @return \mako\database\midgard\relations\ManyToMany
 	 */
 	public function groups(): ManyToMany
 	{
@@ -74,8 +72,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Returns a hasher instance.
-	 *
-	 * @return \mako\security\password\HasherInterface
 	 */
 	protected function getHasher(): HasherInterface
 	{
@@ -84,9 +80,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Password mutator.
-	 *
-	 * @param  string $password Password
-	 * @return string
 	 */
 	protected function passwordMutator(string $password): string
 	{
@@ -95,8 +88,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Generates a new token.
-	 *
-	 * @return string
 	 */
 	protected function generateToken(): string
 	{
@@ -113,8 +104,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Sets the user email address.
-	 *
-	 * @param string $email Email address
 	 */
 	public function setEmail($email): void
 	{
@@ -123,8 +112,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Returns the user email address.
-	 *
-	 * @return string
 	 */
 	public function getEmail(): string
 	{
@@ -133,8 +120,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Sets the username.
-	 *
-	 * @param string $username Username
 	 */
 	public function setUsername(string $username): void
 	{
@@ -151,8 +136,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Sets the user password.
-	 *
-	 * @param string $password Password
 	 */
 	public function setPassword(string $password): void
 	{
@@ -161,8 +144,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Returns the user password hash.
-	 *
-	 * @return string
 	 */
 	public function getPassword(): string
 	{
@@ -171,8 +152,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Sets the user IP address.
-	 *
-	 * @param string $ip IP address
 	 */
 	public function setIp(string $ip): void
 	{
@@ -181,8 +160,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Returns the user IP address.
-	 *
-	 * @return string
 	 */
 	public function getIp(): string
 	{
@@ -191,8 +168,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Generates a new action token.
-	 *
-	 * @return string
 	 */
 	public function generateActionToken(): string
 	{
@@ -201,8 +176,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Returns the user action token.
-	 *
-	 * @return string
 	 */
 	public function getActionToken(): string
 	{
@@ -211,8 +184,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Generates a new access token.
-	 *
-	 * @return string
 	 */
 	public function generateAccessToken(): string
 	{
@@ -221,8 +192,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Returns the user access token.
-	 *
-	 * @return string
 	 */
 	public function getAccessToken(): string
 	{
@@ -247,8 +216,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Returns TRUE of the user is activated and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isActivated(): bool
 	{
@@ -273,8 +240,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Returns TRUE if the user is banned and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isBanned(): bool
 	{
@@ -283,12 +248,8 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Returns TRUE if the provided password is correct and FALSE if not.
-	 *
-	 * @param  string $password Provided password
-	 * @param  bool   $autoSave Autosave rehashed password?
-	 * @return bool
 	 */
-	public function validatePassword(string $password, $autoSave = true): bool
+	public function validatePassword(string $password, bool $autoSave = true): bool
 	{
 		$hasher = $this->getHasher();
 
@@ -337,8 +298,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Locks the account until the given date.
-	 *
-	 * @param \DateTimeInterface $time Date
 	 */
 	public function lockUntil(DateTimeInterface $time): void
 	{
@@ -347,10 +306,8 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Returns null if the account isn't locked and a date time instance if it's locked.
-	 *
-	 * @return \DateTimeInterface|\mako\chrono\Time|null
 	 */
-	public function lockedUntil()
+	public function lockedUntil(): DateTimeInterface|Time|null
 	{
 		return $this->locked_until;
 	}
@@ -365,8 +322,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Returns TRUE if the account is locked and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isLocked(): bool
 	{
@@ -375,8 +330,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Returns the number of failed login attempts.
-	 *
-	 * @return int
 	 */
 	public function getFailedAttempts(): int
 	{
@@ -385,21 +338,14 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Gets the time of the last failed attempt.
-	 *
-	 * @return \DateTimeInterface|\mako\chrono\Time|null
 	 */
-	public function getLastFailAt()
+	public function getLastFailAt(): DateTimeInterface|Time|null
 	{
 		return $this->last_fail_at;
 	}
 
 	/**
 	 * Throttles login attempts.
-	 *
-	 * @param  int  $maxLoginAttempts Maximum number of failed login attempts
-	 * @param  int  $lockTime         Number of seconds for which the account gets locked after reaching the maximum number of login attempts
-	 * @param  bool $autoSave         Autosave changes?
-	 * @return bool
 	 */
 	public function throttle(int $maxLoginAttempts, int $lockTime, bool $autoSave = true): bool
 	{
@@ -435,9 +381,6 @@ class User extends ORM implements AuthorizableInterface, MemberInterface, UserEn
 
 	/**
 	 * Resets the login throttling.
-	 *
-	 * @param  bool $autoSave Autosave changes?
-	 * @return bool
 	 */
 	public function resetThrottle(bool $autoSave = true): bool
 	{

--- a/src/mako/gatekeeper/entities/user/UserEntityInterface.php
+++ b/src/mako/gatekeeper/entities/user/UserEntityInterface.php
@@ -14,15 +14,11 @@ interface UserEntityInterface
 {
 	/**
 	 * Returns the user id.
-	 *
-	 * @return mixed
 	 */
 	public function getId(): mixed;
 
 	/**
 	 * Returns the user username.
-	 *
-	 * @return string
 	 */
 	public function getUsername(): string;
 }

--- a/src/mako/gatekeeper/repositories/group/GroupRepository.php
+++ b/src/mako/gatekeeper/repositories/group/GroupRepository.php
@@ -23,15 +23,11 @@ class GroupRepository implements GroupRepositoryInterface
 {
 	/**
 	 * Group identifier.
-	 *
-	 * @var string
 	 */
-	protected $identifier = 'name';
+	protected string $identifier = 'name';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string $model Model name
 	 */
 	public function __construct(
 		protected string $model
@@ -40,8 +36,6 @@ class GroupRepository implements GroupRepositoryInterface
 
 	/**
 	 * Returns a model instance.
-	 *
-	 * @return \mako\gatekeeper\entities\group\Group
 	 */
 	protected function getModel(): Group
 	{
@@ -67,8 +61,6 @@ class GroupRepository implements GroupRepositoryInterface
 
 	/**
 	 * Sets the user identifier.
-	 *
-	 * @param string $identifier User identifier
 	 */
 	public function setIdentifier(string $identifier): void
 	{
@@ -82,9 +74,6 @@ class GroupRepository implements GroupRepositoryInterface
 
 	/**
 	 * Fetches a group by its name.
-	 *
-	 * @param  string                                     $name Group name
-	 * @return \mako\gatekeeper\entities\group\Group|null
 	 */
 	public function getByName(string $name): ?Group
 	{
@@ -93,9 +82,6 @@ class GroupRepository implements GroupRepositoryInterface
 
 	/**
 	 * Fetches a group by its id.
-	 *
-	 * @param  int                                        $id Group id
-	 * @return \mako\gatekeeper\entities\group\Group|null
 	 */
 	public function getById(int $id): ?Group
 	{
@@ -104,8 +90,6 @@ class GroupRepository implements GroupRepositoryInterface
 
 	/**
 	 * {@inheritDoc}
-	 *
-	 * @return \mako\gatekeeper\entities\group\Group|null
 	 */
 	public function getByIdentifier(int|string $identifier): ?Group
 	{

--- a/src/mako/gatekeeper/repositories/group/GroupRepositoryInterface.php
+++ b/src/mako/gatekeeper/repositories/group/GroupRepositoryInterface.php
@@ -16,17 +16,11 @@ interface GroupRepositoryInterface
 {
 	/**
 	 * Creates and returns a group.
-	 *
-	 * @param  array                                                $properties Group properties
-	 * @return \mako\gatekeeper\entities\group\GroupEntityInterface
 	 */
 	public function createGroup(array $properties = []): GroupEntityInterface;
 
 	/**
 	 * Gets a group by its identifier.
-	 *
-	 * @param  int|string                                                $identifier Group identifier
-	 * @return \mako\gatekeeper\entities\group\GroupEntityInterface|null
 	 */
 	public function getByIdentifier(int|string $identifier): ?GroupEntityInterface;
 }

--- a/src/mako/gatekeeper/repositories/user/UserRepository.php
+++ b/src/mako/gatekeeper/repositories/user/UserRepository.php
@@ -25,16 +25,11 @@ class UserRepository implements UserRepositoryInterface
 {
 	/**
 	 * User identifier.
-	 *
-	 * @var string
 	 */
-	protected $identifier = 'email';
+	protected string $identifier = 'email';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string                                                  $model      Model name
-	 * @param \mako\gatekeeper\authorization\AuthorizerInterface|null $authorizer Authorizer
 	 */
 	public function __construct(
 		protected string $model,
@@ -44,8 +39,6 @@ class UserRepository implements UserRepositoryInterface
 
 	/**
 	 * Returns a model instance.
-	 *
-	 * @return \mako\gatekeeper\entities\user\User
 	 */
 	protected function getModel(): User
 	{
@@ -54,8 +47,6 @@ class UserRepository implements UserRepositoryInterface
 
 	/**
 	 * Sets the user identifier.
-	 *
-	 * @param string $identifier User identifier
 	 */
 	public function setIdentifier(string $identifier): void
 	{
@@ -69,9 +60,6 @@ class UserRepository implements UserRepositoryInterface
 
 	/**
 	 * Sets the authorizer.
-	 *
-	 * @param  \mako\gatekeeper\entities\user\User|null $user User
-	 * @return \mako\gatekeeper\entities\user\User|null
 	 */
 	protected function setAuthorizer(?User $user): ?User
 	{
@@ -106,9 +94,6 @@ class UserRepository implements UserRepositoryInterface
 
 	/**
 	 * Fetches a user by its action token.
-	 *
-	 * @param  string                                   $token Action token
-	 * @return \mako\gatekeeper\entities\user\User|null
 	 */
 	public function getByActionToken(string $token): ?User
 	{
@@ -117,9 +102,6 @@ class UserRepository implements UserRepositoryInterface
 
 	/**
 	 * Fetches a user by its access token.
-	 *
-	 * @param  string                                   $token Access token
-	 * @return \mako\gatekeeper\entities\user\User|null
 	 */
 	public function getByAccessToken(string $token): ?User
 	{
@@ -128,9 +110,6 @@ class UserRepository implements UserRepositoryInterface
 
 	/**
 	 * Fetches a user by its email address.
-	 *
-	 * @param  string                                   $email Email address
-	 * @return \mako\gatekeeper\entities\user\User|null
 	 */
 	public function getByEmail(string $email): ?User
 	{
@@ -139,9 +118,6 @@ class UserRepository implements UserRepositoryInterface
 
 	/**
 	 * Fetches a user by its username.
-	 *
-	 * @param  string                                   $username Username
-	 * @return \mako\gatekeeper\entities\user\User|null
 	 */
 	public function getByUsername(string $username): ?User
 	{
@@ -150,9 +126,6 @@ class UserRepository implements UserRepositoryInterface
 
 	/**
 	 * Fetches a user by its id.
-	 *
-	 * @param  int                                      $id User id
-	 * @return \mako\gatekeeper\entities\user\User|null
 	 */
 	public function getById(int $id): ?User
 	{

--- a/src/mako/gatekeeper/repositories/user/UserRepositoryInterface.php
+++ b/src/mako/gatekeeper/repositories/user/UserRepositoryInterface.php
@@ -16,17 +16,11 @@ interface UserRepositoryInterface
 {
 	/**
 	 * Creates and returns a user.
-	 *
-	 * @param  array                                              $properties User properties
-	 * @return \mako\gatekeeper\entities\user\UserEntityInterface
 	 */
 	public function createUser(array $properties = []): UserEntityInterface;
 
 	/**
 	 * Fetches a user by its identifier.
-	 *
-	 * @param  int|string                                              $identifier User identifier
-	 * @return \mako\gatekeeper\entities\user\UserEntityInterface|null
 	 */
 	public function getByIdentifier(int|string $identifier): ?UserEntityInterface;
 }

--- a/src/mako/http/Request.php
+++ b/src/mako/http/Request.php
@@ -55,164 +55,116 @@ class Request
 
 	/**
 	 * Script name.
-	 *
-	 * @var string
 	 */
-	protected $scriptName;
+	protected string $scriptName;
 
 	/**
 	 * Get data.
-	 *
-	 * @var \mako\http\request\Parameters
 	 */
-	protected $query;
+	protected Parameters $query;
 
 	/**
 	 * Post data.
-	 *
-	 * @var \mako\http\request\Parameters
 	 */
-	protected $post;
+	protected Parameters $post;
 
 	/**
 	 * Cookie data.
-	 *
-	 * @var \mako\http\request\Cookies
 	 */
-	protected $cookies;
+	protected Cookies $cookies;
 
 	/**
 	 * File data.
-	 *
-	 * @var \mako\http\request\Files
 	 */
-	protected $files;
+	protected Files $files;
 
 	/**
 	 * Server info.
-	 *
-	 * @var \mako\http\request\Server
 	 */
-	protected $server;
+	protected Server $server;
 
 	/**
 	 * Request headers.
-	 *
-	 * @var \mako\http\request\Headers
 	 */
-	protected $headers;
+	protected Headers $headers;
 
 	/**
 	 * Raw request body.
-	 *
-	 * @var string
 	 */
-	protected $rawBody;
+	protected string|null $rawBody = null;
 
 	/**
 	 * Parsed request body.
-	 *
-	 * @var \mako\http\request\Body
 	 */
-	protected $parsedBody;
+	protected Body|null $parsedBody = null;
 
 	/**
 	 * Content type.
-	 *
-	 * @var string
 	 */
-	protected $contentType;
+	protected string|null $contentType = null;
 
 	/**
 	 * Array of trusted proxy IP addresses.
-	 *
-	 * @var array
 	 */
-	protected $trustedProxies = [];
+	protected array $trustedProxies = [];
 
 	/**
 	 * Ip address of the client that made the request.
-	 *
-	 * @var string
 	 */
-	protected $ip;
+	protected string|null $ip = null;
 
 	/**
 	 * Base path of the request.
-	 *
-	 * @var string
 	 */
-	protected $basePath;
+	protected string|null $basePath = null;
 
 	/**
 	 * Base URL of the request.
-	 *
-	 * @var string
 	 */
-	protected $baseURL;
+	protected string|null $baseURL = null;
 
 	/**
 	 * Holds the request path.
-	 *
-	 * @var string
 	 */
-	protected $path;
+	protected string $path;
 
 	/**
 	 * Request language.
-	 *
-	 * @var array
 	 */
-	protected $language;
+	protected array|null $language = null;
 
 	/**
 	 * Request language prefix.
-	 *
-	 * @var string
 	 */
-	protected $languagePrefix;
+	protected string|null $languagePrefix = null;
 
 	/**
 	 * Which request method was used?
-	 *
-	 * @var string
 	 */
-	protected $method;
+	protected string $method;
 
 	/**
 	 * The actual request method that was used.
-	 *
-	 * @var string
 	 */
-	protected $realMethod;
+	protected string $realMethod;
 
 	/**
 	 * Was this request made using HTTPS?
-	 *
-	 * @var bool
 	 */
-	protected $isSecure;
+	protected bool|null $isSecure = null;
 
 	/**
 	 * The route that matched the request.
-	 *
-	 * @var \mako\http\routing\Route
 	 */
-	protected $route;
+	protected Route|null $route = null;
 
 	/**
 	 * Request attribuntes.
-	 *
-	 * @var array
 	 */
-	protected $attributes = [];
+	protected array $attributes = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array                      $request    Request data and options
-	 * @param \mako\security\Signer|null $signer     Signer instance used to validate signed cookies
-	 * @param string|null                $scriptName Script name
 	 */
 	public function __construct(array $request = [], ?Signer $signer = null, ?string $scriptName = null)
 	{
@@ -246,10 +198,6 @@ class Request
 
 	/**
 	 * Strips the locale segment from the path.
-	 *
-	 * @param  array  $languages Locale segments
-	 * @param  string $path      Path
-	 * @return string
 	 */
 	protected function stripLocaleSegment(array $languages, string $path): string
 	{
@@ -272,9 +220,6 @@ class Request
 
 	/**
 	 * Determines the request path.
-	 *
-	 * @param  array  $languages Locale segments
-	 * @return string
 	 */
 	protected function determinePath(array $languages): string
 	{
@@ -317,8 +262,6 @@ class Request
 
 	/**
 	 * Determines the request method.
-	 *
-	 * @return string
 	 */
 	protected function determineMethod(): string
 	{
@@ -335,8 +278,6 @@ class Request
 	/**
 	 * Returns the content type of the request body.
 	 * An empty string will be returned if the header is missing.
-	 *
-	 * @return string
 	 */
 	public function getContentType(): string
 	{
@@ -350,8 +291,6 @@ class Request
 
 	/**
 	 * Returns the base name of the script that handled the request.
-	 *
-	 * @return string
 	 */
 	public function getScriptName(): string
 	{
@@ -360,8 +299,6 @@ class Request
 
 	/**
 	 * Set the route that matched the request.
-	 *
-	 * @param \mako\http\routing\Route $route Route
 	 */
 	public function setRoute(Route $route): void
 	{
@@ -370,8 +307,6 @@ class Request
 
 	/**
 	 * Returns the route that matched the request.
-	 *
-	 * @return \mako\http\routing\Route|null
 	 */
 	public function getRoute(): ?Route
 	{
@@ -380,9 +315,6 @@ class Request
 
 	/**
 	 * Sets a request attribute.
-	 *
-	 * @param string $name  Attribute name
-	 * @param mixed  $value Attribute value
 	 */
 	public function setAttribute(string $name, mixed $value): void
 	{
@@ -391,10 +323,6 @@ class Request
 
 	/**
 	 * Gets a request attribute.
-	 *
-	 * @param  string $name    Attribute name
-	 * @param  mixed  $default Default value
-	 * @return mixed
 	 */
 	public function getAttribute(string $name, mixed $default = null): mixed
 	{
@@ -403,8 +331,6 @@ class Request
 
 	/**
 	 * Returns the raw request body.
-	 *
-	 * @return string
 	 */
 	public function getRawBody(): string
 	{
@@ -428,8 +354,6 @@ class Request
 
 	/**
 	 * Returns the query string.
-	 *
-	 * @return \mako\http\request\Parameters
 	 */
 	public function getQuery(): Parameters
 	{
@@ -438,8 +362,6 @@ class Request
 
 	/**
 	 * Returns the post data.
-	 *
-	 * @return \mako\http\request\Parameters
 	 */
 	public function getPost(): Parameters
 	{
@@ -448,8 +370,6 @@ class Request
 
 	/**
 	 * Returns the cookies.
-	 *
-	 * @return \mako\http\request\Cookies
 	 */
 	public function getCookies(): Cookies
 	{
@@ -458,8 +378,6 @@ class Request
 
 	/**
 	 * Returns the files.
-	 *
-	 * @return \mako\http\request\Files
 	 */
 	public function getFiles(): Files
 	{
@@ -468,8 +386,6 @@ class Request
 
 	/**
 	 * Returns the files.
-	 *
-	 * @return \mako\http\request\Server
 	 */
 	public function getServer(): Server
 	{
@@ -478,8 +394,6 @@ class Request
 
 	/**
 	 * Returns the files.
-	 *
-	 * @return \mako\http\request\Headers
 	 */
 	public function getHeaders(): Headers
 	{
@@ -488,8 +402,6 @@ class Request
 
 	/**
 	 * Returns the parsed request body.
-	 *
-	 * @return \mako\http\request\Body
 	 */
 	public function getBody(): Body
 	{
@@ -503,8 +415,6 @@ class Request
 
 	/**
 	 * Returns TRUE if the request has form data and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	protected function hasFormData(): bool
 	{
@@ -520,8 +430,6 @@ class Request
 
 	/**
 	 * Returns the data of the current request method.
-	 *
-	 * @return \mako\http\request\Parameters
 	 */
 	public function getData(): Parameters
 	{
@@ -539,8 +447,6 @@ class Request
 
 	/**
 	 * Set the trusted proxies.
-	 *
-	 * @param array $trustedProxies Array of trusted proxy IP addresses
 	 */
 	public function setTrustedProxies(array $trustedProxies): void
 	{
@@ -549,9 +455,6 @@ class Request
 
 	/**
 	 * Is this IP a trusted proxy?
-	 *
-	 * @param  string $ip IP address
-	 * @return bool
 	 */
 	protected function isTrustedProxy(string $ip): bool
 	{
@@ -568,8 +471,6 @@ class Request
 
 	/**
 	 * Returns the ip of the client that made the request.
-	 *
-	 * @return string
 	 */
 	public function getIp(): string
 	{
@@ -607,8 +508,6 @@ class Request
 
 	/**
 	 * Returns TRUE if the request was made using Ajax and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isAjax(): bool
 	{
@@ -617,8 +516,6 @@ class Request
 
 	/**
 	 * Returns TRUE if the request was made using HTTPS and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isSecure(): bool
 	{
@@ -637,8 +534,6 @@ class Request
 
 	/**
 	 * Returns TRUE if the request method is considered safe and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isSafe(): bool
 	{
@@ -647,8 +542,6 @@ class Request
 
 	/**
 	 * Returns TRUE if the request method is considered idempotent and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isIdempotent(): bool
 	{
@@ -657,8 +550,6 @@ class Request
 
 	/**
 	 * Returns TRUE if the request method is considered cacheable and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isCacheable(): bool
 	{
@@ -667,8 +558,6 @@ class Request
 
 	/**
 	 * Is PHP running as a CGI program?
-	 *
-	 * @return bool
 	 */
 	public function isCGI(): bool
 	{
@@ -677,8 +566,6 @@ class Request
 
 	/**
 	 * Returns the base path of the request.
-	 *
-	 * @return string
 	 */
 	public function getBasePath(): string
 	{
@@ -694,8 +581,6 @@ class Request
 
 	/**
 	 * Returns the base url of the request.
-	 *
-	 * @return string
 	 */
 	public function getBaseURL(): string
 	{
@@ -729,8 +614,6 @@ class Request
 
 	/**
 	 * Returns the request path.
-	 *
-	 * @return string
 	 */
 	public function getPath(): string
 	{
@@ -739,8 +622,6 @@ class Request
 
 	/**
 	 * Returns TRUE if the resource was requested with a "clean" URL and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isClean(): bool
 	{
@@ -749,8 +630,6 @@ class Request
 
 	/**
 	 * Returns the request language.
-	 *
-	 * @return array|null
 	 */
 	public function getLanguage(): ?array
 	{
@@ -759,8 +638,6 @@ class Request
 
 	/**
 	 * Returns the request language prefix.
-	 *
-	 * @return string|null
 	 */
 	public function getLanguagePrefix(): ?string
 	{
@@ -769,8 +646,6 @@ class Request
 
 	/**
 	 * Returns the request method that was used.
-	 *
-	 * @return string
 	 */
 	public function getMethod(): string
 	{
@@ -779,8 +654,6 @@ class Request
 
 	/**
 	 * Returns the real request method that was used.
-	 *
-	 * @return string
 	 */
 	public function getRealMethod(): string
 	{
@@ -789,8 +662,6 @@ class Request
 
 	/**
 	 * Returns TRUE if the request method has been faked and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isFaked(): bool
 	{
@@ -799,8 +670,6 @@ class Request
 
 	/**
 	 * Returns the basic HTTP authentication username or null.
-	 *
-	 * @return string|null
 	 */
 	public function getUsername(): ?string
 	{
@@ -809,8 +678,6 @@ class Request
 
 	/**
 	 * Returns the basic HTTP authentication password or null.
-	 *
-	 * @return string|null
 	 */
 	public function getPassword(): ?string
 	{
@@ -819,9 +686,6 @@ class Request
 
 	/**
 	 * Returns the referrer.
-	 *
-	 * @param  mixed $default Value to return if no referrer is set
-	 * @return mixed
 	 */
 	public function getReferrer(mixed $default = null): mixed
 	{

--- a/src/mako/http/Response.php
+++ b/src/mako/http/Response.php
@@ -39,59 +39,43 @@ class Response
 
 	/**
 	 * Response body.
-	 *
-	 * @var mixed
 	 */
-	protected $body;
+	protected mixed $body;
 
 	/**
 	 * Response content type.
-	 *
-	 * @var string
 	 */
-	protected $contentType = 'text/html';
+	protected string $contentType = 'text/html';
 
 	/**
 	 * Status code.
-	 *
-	 * @var int
 	 */
-	protected $statusCode = self::DEFAULT_STATUS;
+	protected int $statusCode = self::DEFAULT_STATUS;
 
 	/**
 	 * Response headers.
-	 *
-	 * @var \mako\http\response\Headers
 	 */
-	protected $headers;
+	protected Headers $headers;
 
 	/**
 	 * Cookies.
-	 *
-	 * @var \mako\http\response\Cookies
 	 */
-	protected $cookies;
+	protected Cookies $cookies;
 
 	/**
 	 * Compress output?
-	 *
-	 * @var bool
 	 */
-	protected $outputCompression = false;
+	protected bool $outputCompression = false;
 
 	/**
 	 * Enable response cache?
-	 *
-	 * @var bool
 	 */
-	protected $responseCache = false;
+	protected bool $responseCache = false;
 
 	/**
 	 * HTTP status codes.
-	 *
-	 * @var array
 	 */
-	protected $statusCodes =
+	protected array $statusCodes =
 	[
 		// 1xx Informational
 
@@ -181,10 +165,6 @@ class Response
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\http\Request         $request Request instance
-	 * @param string                     $charset Response character set
-	 * @param \mako\security\Signer|null $signer  Signer instance used to sign cookies
 	 */
 	public function __construct(
 		protected Request $request,
@@ -199,8 +179,6 @@ class Response
 
 	/**
 	 * Returns the request instance.
-	 *
-	 * @return \mako\http\Request
 	 */
 	public function getRequest(): Request
 	{
@@ -209,9 +187,6 @@ class Response
 
 	/**
 	 * Sets the response body.
-	 *
-	 * @param  mixed               $body Response body
-	 * @return \mako\http\Response
 	 */
 	public function setBody(mixed $body): Response
 	{
@@ -222,8 +197,6 @@ class Response
 
 	/**
 	 * Returns the response body.
-	 *
-	 * @return mixed
 	 */
 	public function getBody(): mixed
 	{
@@ -232,8 +205,6 @@ class Response
 
 	/**
 	 * Clears the response body.
-	 *
-	 * @return \mako\http\Response
 	 */
 	public function clearBody(): Response
 	{
@@ -244,10 +215,6 @@ class Response
 
 	/**
 	 * Sets the response content type.
-	 *
-	 * @param  string              $contentType Content type
-	 * @param  string|null         $charset     Charset
-	 * @return \mako\http\Response
 	 */
 	public function setType(string $contentType, ?string $charset = null): Response
 	{
@@ -263,8 +230,6 @@ class Response
 
 	/**
 	 * Returns the response content type.
-	 *
-	 * @return string
 	 */
 	public function getType(): string
 	{
@@ -273,9 +238,6 @@ class Response
 
 	/**
 	 * Sets the response character set.
-	 *
-	 * @param  string              $charset Character set
-	 * @return \mako\http\Response
 	 */
 	public function setCharset(string $charset): Response
 	{
@@ -286,8 +248,6 @@ class Response
 
 	/**
 	 * Returns the response character set.
-	 *
-	 * @return string
 	 */
 	public function getCharset(): string
 	{
@@ -296,9 +256,6 @@ class Response
 
 	/**
 	 * Sets the HTTP status code.
-	 *
-	 * @param  int                 $statusCode HTTP status code
-	 * @return \mako\http\Response
 	 */
 	public function setStatus(int $statusCode): Response
 	{
@@ -312,8 +269,6 @@ class Response
 
 	/**
 	 * Returns the HTTP status code.
-	 *
-	 * @return int
 	 */
 	public function getStatus(): int
 	{
@@ -322,8 +277,6 @@ class Response
 
 	/**
 	 * Returns response header collection.
-	 *
-	 * @return \mako\http\response\Headers
 	 */
 	public function getHeaders(): Headers
 	{
@@ -332,8 +285,6 @@ class Response
 
 	/**
 	 * Returns response cookie collection.
-	 *
-	 * @return \mako\http\response\Cookies
 	 */
 	public function getCookies(): Cookies
 	{
@@ -342,8 +293,6 @@ class Response
 
 	/**
 	 * Clears the response body, cookies and headers.
-	 *
-	 * @return \mako\http\Response
 	 */
 	public function clear(): Response
 	{
@@ -358,9 +307,6 @@ class Response
 
 	/**
 	 * Clears the response body in addition to cookies and headers that don't match the provided names or patterns.
-	 *
-	 * @param  array               $exceptions Exceptions
-	 * @return \mako\http\Response
 	 */
 	public function clearExcept(array $exceptions): Response
 	{
@@ -375,8 +321,6 @@ class Response
 
 	/**
 	 * Resets the response.
-	 *
-	 * @return \mako\http\Response
 	 */
 	public function reset(): Response
 	{
@@ -387,9 +331,6 @@ class Response
 
 	/**
 	 * Resets the response except for cookies and headers that match the provided names or patterns.
-	 *
-	 * @param  array               $exceptions Exceptions
-	 * @return \mako\http\Response
 	 */
 	public function resetExcept(array $exceptions): Response
 	{
@@ -449,8 +390,6 @@ class Response
 
 	/**
 	 * Is the response cacheable?
-	 *
-	 * @return bool
 	 */
 	public function isCacheable(): bool
 	{
@@ -474,8 +413,6 @@ class Response
 
 	/**
 	 * Enables ETag response cache.
-	 *
-	 * @return \mako\http\Response
 	 */
 	public function enableCaching(): Response
 	{
@@ -486,8 +423,6 @@ class Response
 
 	/**
 	 * Disables ETag response cache.
-	 *
-	 * @return \mako\http\Response
 	 */
 	public function disableCaching(): Response
 	{
@@ -498,8 +433,6 @@ class Response
 
 	/**
 	 * Enables output compression.
-	 *
-	 * @return \mako\http\Response
 	 */
 	public function enableCompression(): Response
 	{
@@ -510,8 +443,6 @@ class Response
 
 	/**
 	 * Disables output compression.
-	 *
-	 * @return \mako\http\Response
 	 */
 	public function disableCompression(): Response
 	{

--- a/src/mako/http/exceptions/BadRequestException.php
+++ b/src/mako/http/exceptions/BadRequestException.php
@@ -17,7 +17,7 @@ class BadRequestException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $defaultMessage = 'The server was unable to process the request.';
+	protected string $defaultMessage = 'The server was unable to process the request.';
 
 	/**
 	 * Constructor.

--- a/src/mako/http/exceptions/BadRequestException.php
+++ b/src/mako/http/exceptions/BadRequestException.php
@@ -17,13 +17,10 @@ class BadRequestException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $defaultMessage = 'The server was unable to process the request.';
+	protected string|null $defaultMessage = 'The server was unable to process the request.';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string          $message  Exception message
-	 * @param \Throwable|null $previous Previous exception
 	 */
 	public function __construct(string $message = '', ?Throwable $previous = null)
 	{

--- a/src/mako/http/exceptions/ForbiddenException.php
+++ b/src/mako/http/exceptions/ForbiddenException.php
@@ -17,7 +17,7 @@ class ForbiddenException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $defaultMessage = 'You don\'t have permission to access the requested resource.';
+	protected string $defaultMessage = 'You don\'t have permission to access the requested resource.';
 
 	/**
 	 * Constructor.

--- a/src/mako/http/exceptions/ForbiddenException.php
+++ b/src/mako/http/exceptions/ForbiddenException.php
@@ -17,13 +17,10 @@ class ForbiddenException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $defaultMessage = 'You don\'t have permission to access the requested resource.';
+	protected string|null $defaultMessage = 'You don\'t have permission to access the requested resource.';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string          $message  Exception message
-	 * @param \Throwable|null $previous Previous exception
 	 */
 	public function __construct(string $message = '', ?Throwable $previous = null)
 	{

--- a/src/mako/http/exceptions/GoneException.php
+++ b/src/mako/http/exceptions/GoneException.php
@@ -17,7 +17,7 @@ class GoneException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $defaultMessage = 'The resource you requested is no longer available and will not be available again.';
+	protected string $defaultMessage = 'The resource you requested is no longer available and will not be available again.';
 
 	/**
 	 * Constructor.

--- a/src/mako/http/exceptions/GoneException.php
+++ b/src/mako/http/exceptions/GoneException.php
@@ -17,13 +17,10 @@ class GoneException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $defaultMessage = 'The resource you requested is no longer available and will not be available again.';
+	protected string|null $defaultMessage = 'The resource you requested is no longer available and will not be available again.';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string          $message  Exception message
-	 * @param \Throwable|null $previous Previous exception
 	 */
 	public function __construct(string $message = '', ?Throwable $previous = null)
 	{

--- a/src/mako/http/exceptions/HttpStatusException.php
+++ b/src/mako/http/exceptions/HttpStatusException.php
@@ -37,7 +37,7 @@ class HttpStatusException extends HttpException
 	 *
 	 * @return $this
 	 */
-	public function setMetadata(array $metadata)
+	public function setMetadata(array $metadata): static
 	{
 		$this->metadata = $metadata;
 

--- a/src/mako/http/exceptions/HttpStatusException.php
+++ b/src/mako/http/exceptions/HttpStatusException.php
@@ -17,7 +17,7 @@ class HttpStatusException extends HttpException
 	/**
 	 * Default message.
 	 */
-	protected string|null $defaultMessage = null;
+	protected string $defaultMessage = '';
 
 	/**
 	 * Exception metadata.
@@ -29,7 +29,7 @@ class HttpStatusException extends HttpException
 	 */
 	public function __construct(int $code, string $message = '', ?Throwable $previous = null)
 	{
-		parent::__construct($message ?: (string) $this->defaultMessage, $code, $previous);
+		parent::__construct($message ?: $this->defaultMessage, $code, $previous);
 	}
 
 	/**

--- a/src/mako/http/exceptions/HttpStatusException.php
+++ b/src/mako/http/exceptions/HttpStatusException.php
@@ -16,24 +16,16 @@ class HttpStatusException extends HttpException
 {
 	/**
 	 * Default message.
-	 *
-	 * @var string|null
 	 */
-	protected $defaultMessage;
+	protected string|null $defaultMessage = null;
 
 	/**
 	 * Exception metadata.
-	 *
-	 * @var array
 	 */
-	protected $metadata = [];
+	protected array $metadata = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param int             $code     Exception code
-	 * @param string          $message  Exception message
-	 * @param \Throwable|null $previous Previous exception
 	 */
 	public function __construct(int $code, string $message = '', ?Throwable $previous = null)
 	{
@@ -43,7 +35,6 @@ class HttpStatusException extends HttpException
 	/**
 	 * Sets exception metadata.
 	 *
-	 * @param  array $metadata Exception metadata
 	 * @return $this
 	 */
 	public function setMetadata(array $metadata)
@@ -55,8 +46,6 @@ class HttpStatusException extends HttpException
 
 	/**
 	 * Returns exception metadata.
-	 *
-	 * @return array
 	 */
 	public function getMetadata(): array
 	{

--- a/src/mako/http/exceptions/InvalidTokenException.php
+++ b/src/mako/http/exceptions/InvalidTokenException.php
@@ -17,13 +17,10 @@ class InvalidTokenException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $defaultMessage = 'An invalid or expired token was provided.';
+	protected string|null $defaultMessage = 'An invalid or expired token was provided.';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string          $message  Exception message
-	 * @param \Throwable|null $previous Previous exception
 	 */
 	public function __construct(string $message = '', ?Throwable $previous = null)
 	{

--- a/src/mako/http/exceptions/InvalidTokenException.php
+++ b/src/mako/http/exceptions/InvalidTokenException.php
@@ -17,7 +17,7 @@ class InvalidTokenException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $defaultMessage = 'An invalid or expired token was provided.';
+	protected string $defaultMessage = 'An invalid or expired token was provided.';
 
 	/**
 	 * Constructor.

--- a/src/mako/http/exceptions/MethodNotAllowedException.php
+++ b/src/mako/http/exceptions/MethodNotAllowedException.php
@@ -17,14 +17,10 @@ class MethodNotAllowedException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $defaultMessage = 'The request method that was used is not supported by this resource.';
+	protected string|null $defaultMessage = 'The request method that was used is not supported by this resource.';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array           $allowedMethods Allowed methods
-	 * @param string          $message        Exception message
-	 * @param \Throwable|null $previous       Previous exception
 	 */
 	public function __construct(
 		protected array $allowedMethods = [],
@@ -37,10 +33,8 @@ class MethodNotAllowedException extends HttpStatusException
 
 	/**
 	 * Returns the allowed methods.
-	 *
-	 * @return array
 	 */
-	public function getAllowedMethods()
+	public function getAllowedMethods(): array
 	{
 		return $this->allowedMethods;
 	}

--- a/src/mako/http/exceptions/MethodNotAllowedException.php
+++ b/src/mako/http/exceptions/MethodNotAllowedException.php
@@ -17,7 +17,7 @@ class MethodNotAllowedException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $defaultMessage = 'The request method that was used is not supported by this resource.';
+	protected string $defaultMessage = 'The request method that was used is not supported by this resource.';
 
 	/**
 	 * Constructor.

--- a/src/mako/http/exceptions/NotFoundException.php
+++ b/src/mako/http/exceptions/NotFoundException.php
@@ -17,13 +17,10 @@ class NotFoundException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $defaultMessage = 'The resource you requested could not be found. It may have been moved or deleted.';
+	protected string|null $defaultMessage = 'The resource you requested could not be found. It may have been moved or deleted.';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string          $message  Exception message
-	 * @param \Throwable|null $previous Previous exception
 	 */
 	public function __construct(string $message = '', ?Throwable $previous = null)
 	{

--- a/src/mako/http/exceptions/NotFoundException.php
+++ b/src/mako/http/exceptions/NotFoundException.php
@@ -17,7 +17,7 @@ class NotFoundException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $defaultMessage = 'The resource you requested could not be found. It may have been moved or deleted.';
+	protected string $defaultMessage = 'The resource you requested could not be found. It may have been moved or deleted.';
 
 	/**
 	 * Constructor.

--- a/src/mako/http/exceptions/RangeNotSatisfiableException.php
+++ b/src/mako/http/exceptions/RangeNotSatisfiableException.php
@@ -17,7 +17,7 @@ class RangeNotSatisfiableException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $defaultMessage = 'The requested range is not satisfiable.';
+	protected string $defaultMessage = 'The requested range is not satisfiable.';
 
 	/**
 	 * Constructor.

--- a/src/mako/http/exceptions/RangeNotSatisfiableException.php
+++ b/src/mako/http/exceptions/RangeNotSatisfiableException.php
@@ -17,13 +17,10 @@ class RangeNotSatisfiableException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $defaultMessage = 'The requested range is not satisfiable.';
+	protected string|null $defaultMessage = 'The requested range is not satisfiable.';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string          $message  Exception message
-	 * @param \Throwable|null $previous Previous exception
 	 */
 	public function __construct(string $message = '', ?Throwable $previous = null)
 	{

--- a/src/mako/http/exceptions/ServiceUnavailableException.php
+++ b/src/mako/http/exceptions/ServiceUnavailableException.php
@@ -17,13 +17,10 @@ class ServiceUnavailableException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $defaultMessage = 'The service is currently unavailable.';
+	protected string|null $defaultMessage = 'The service is currently unavailable.';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string          $message  Exception message
-	 * @param \Throwable|null $previous Previous exception
 	 */
 	public function __construct(string $message = '', ?Throwable $previous = null)
 	{

--- a/src/mako/http/exceptions/ServiceUnavailableException.php
+++ b/src/mako/http/exceptions/ServiceUnavailableException.php
@@ -17,7 +17,7 @@ class ServiceUnavailableException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $defaultMessage = 'The service is currently unavailable.';
+	protected string $defaultMessage = 'The service is currently unavailable.';
 
 	/**
 	 * Constructor.

--- a/src/mako/http/exceptions/TooManyRequestsException.php
+++ b/src/mako/http/exceptions/TooManyRequestsException.php
@@ -17,7 +17,7 @@ class TooManyRequestsException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $defaultMessage = 'You have made too many requests to the server.';
+	protected string $defaultMessage = 'You have made too many requests to the server.';
 
 	/**
 	 * Constructor.

--- a/src/mako/http/exceptions/TooManyRequestsException.php
+++ b/src/mako/http/exceptions/TooManyRequestsException.php
@@ -17,13 +17,10 @@ class TooManyRequestsException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $defaultMessage = 'You have made too many requests to the server.';
+	protected string|null $defaultMessage = 'You have made too many requests to the server.';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string          $message  Exception message
-	 * @param \Throwable|null $previous Previous exception
 	 */
 	public function __construct(string $message = '', ?Throwable $previous = null)
 	{

--- a/src/mako/http/exceptions/UnauthorizedException.php
+++ b/src/mako/http/exceptions/UnauthorizedException.php
@@ -17,13 +17,10 @@ class UnauthorizedException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $defaultMessage = 'You don\'t have permission to access the requested resource.';
+	protected string|null $defaultMessage = 'You don\'t have permission to access the requested resource.';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string          $message  Exception message
-	 * @param \Throwable|null $previous Previous exception
 	 */
 	public function __construct(string $message = '', ?Throwable $previous = null)
 	{

--- a/src/mako/http/exceptions/UnauthorizedException.php
+++ b/src/mako/http/exceptions/UnauthorizedException.php
@@ -17,7 +17,7 @@ class UnauthorizedException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $defaultMessage = 'You don\'t have permission to access the requested resource.';
+	protected string $defaultMessage = 'You don\'t have permission to access the requested resource.';
 
 	/**
 	 * Constructor.

--- a/src/mako/http/exceptions/UnsupportedMediaTypeException.php
+++ b/src/mako/http/exceptions/UnsupportedMediaTypeException.php
@@ -17,7 +17,7 @@ class UnsupportedMediaTypeException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected string|null $defaultMessage = 'The media type is not supported.';
+	protected string $defaultMessage = 'The media type is not supported.';
 
 	/**
 	 * Constructor.

--- a/src/mako/http/exceptions/UnsupportedMediaTypeException.php
+++ b/src/mako/http/exceptions/UnsupportedMediaTypeException.php
@@ -17,13 +17,10 @@ class UnsupportedMediaTypeException extends HttpStatusException
 	/**
 	 * {@inheritDoc}
 	 */
-	protected $defaultMessage = 'The media type is not supported.';
+	protected string|null $defaultMessage = 'The media type is not supported.';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string          $message  Exception message
-	 * @param \Throwable|null $previous Previous exception
 	 */
 	public function __construct(string $message = '', ?Throwable $previous = null)
 	{

--- a/src/mako/http/request/Body.php
+++ b/src/mako/http/request/Body.php
@@ -22,9 +22,6 @@ class Body extends Parameters
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param string $rawBody     Raw request body
-	 * @param string $contentType Content type
 	 */
 	public function __construct(string $rawBody, string $contentType)
 	{
@@ -33,12 +30,8 @@ class Body extends Parameters
 
 	/**
 	 * Converts the request body into an associative array.
-	 *
-	 * @param  string $rawBody     Raw request body
-	 * @param  string $contentType Content type
-	 * @return array
 	 */
-	protected function parseBody($rawBody, $contentType): array
+	protected function parseBody(string $rawBody, string $contentType): array
 	{
 		if($contentType === 'application/x-www-form-urlencoded')
 		{

--- a/src/mako/http/request/Cookies.php
+++ b/src/mako/http/request/Cookies.php
@@ -22,9 +22,6 @@ class Cookies implements Countable, IteratorAggregate
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param array                      $cookies Cookies
-	 * @param \mako\security\Signer|null $signer  Signer
 	 */
 	public function __construct(
 		protected array $cookies = [],
@@ -34,8 +31,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Returns the numner of cookies.
-	 *
-	 * @return int
 	 */
 	public function count(): int
 	{
@@ -44,8 +39,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Retruns an array iterator object.
-	 *
-	 * @return \ArrayIterator
 	 */
 	public function getIterator(): ArrayIterator
 	{
@@ -54,9 +47,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Adds a cookie.
-	 *
-	 * @param string $name  Cookie name
-	 * @param string $value Cookie value
 	 */
 	public function add(string $name, string $value): void
 	{
@@ -65,9 +55,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Adds a signed cookie.
-	 *
-	 * @param string $name  Cookie name
-	 * @param string $value Cookie value
 	 */
 	public function addSigned(string $name, string $value): void
 	{
@@ -81,9 +68,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Returns TRUE if the cookie exists and FALSE if not.
-	 *
-	 * @param  string $name Cookie name
-	 * @return bool
 	 */
 	public function has(string $name): bool
 	{
@@ -92,10 +76,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Gets a cookie value.
-	 *
-	 * @param  string $name    Cookie name
-	 * @param  mixed  $default Default value
-	 * @return mixed
 	 */
 	public function get(string $name, mixed $default = null): mixed
 	{
@@ -104,10 +84,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Gets a signed cookie value.
-	 *
-	 * @param  string $name    Cookie name
-	 * @param  mixed  $default Default value
-	 * @return mixed
 	 */
 	public function getSigned(string $name, mixed $default = null): mixed
 	{
@@ -126,8 +102,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Removes a cookie.
-	 *
-	 * @param string $name Cookie name
 	 */
 	public function remove(string $name): void
 	{
@@ -136,8 +110,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Returns all the cookies.
-	 *
-	 * @return array
 	 */
 	public function all(): array
 	{

--- a/src/mako/http/request/Files.php
+++ b/src/mako/http/request/Files.php
@@ -26,9 +26,6 @@ class Files extends Parameters
 
 	/**
 	 * Creates a UploadedFile object.
-	 *
-	 * @param  array                           $file File info
-	 * @return \mako\http\request\UploadedFile
 	 */
 	protected function createUploadedFile(array $file): UploadedFile
 	{
@@ -37,9 +34,6 @@ class Files extends Parameters
 
 	/**
 	 * Normalizes a multi file upload array to a more manageable format.
-	 *
-	 * @param  array $files File upload array
-	 * @return array
 	 */
 	protected function normalizeMultiUpload(array $files): array
 	{
@@ -62,9 +56,6 @@ class Files extends Parameters
 
 	/**
 	 * Converts the $_FILES array to an array of UploadedFile objects.
-	 *
-	 * @param  array $files File upload array
-	 * @return array
 	 */
 	protected function convertToUploadedFileObjects(array $files): array
 	{

--- a/src/mako/http/request/Headers.php
+++ b/src/mako/http/request/Headers.php
@@ -46,7 +46,7 @@ class Headers implements Countable, IteratorAggregate
 	/**
 	 * Acceptable encodings.
 	 */
-	protected $acceptableEncodings;
+	protected array|null $acceptableEncodings = null;
 
 	/**
 	 * Constructor.

--- a/src/mako/http/request/Headers.php
+++ b/src/mako/http/request/Headers.php
@@ -30,36 +30,26 @@ class Headers implements Countable, IteratorAggregate
 {
 	/**
 	 * Acceptable content types.
-	 *
-	 * @var array|null
 	 */
-	protected $acceptableContentTypes;
+	protected array|null $acceptableContentTypes = null;
 
 	/**
 	 * Acceptable languages.
-	 *
-	 * @var array|null
 	 */
-	protected $acceptableLanguages;
+	protected array|null $acceptableLanguages = null;
 
 	/**
 	 * Acceptable character sets.
-	 *
-	 * @var array|null
 	 */
-	protected $acceptableCharsets;
+	protected array|null $acceptableCharsets = null;
 
 	/**
 	 * Acceptable encodings.
-	 *
-	 * @var array|null
 	 */
 	protected $acceptableEncodings;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array $headers Headers
 	 */
 	public function __construct(
 		protected array $headers = []
@@ -68,8 +58,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Returns the numner of headers.
-	 *
-	 * @return int
 	 */
 	public function count(): int
 	{
@@ -78,8 +66,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Retruns an array iterator object.
-	 *
-	 * @return \ArrayIterator
 	 */
 	public function getIterator(): ArrayIterator
 	{
@@ -88,9 +74,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Normalizes header names.
-	 *
-	 * @param  string $name Header name
-	 * @return string
 	 */
 	protected function normalizeName(string $name): string
 	{
@@ -99,9 +82,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Adds a header.
-	 *
-	 * @param string $name  Header name
-	 * @param string $value Header value
 	 */
 	public function add(string $name, string $value): void
 	{
@@ -110,9 +90,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Returns TRUE if the header exists and FALSE if not.
-	 *
-	 * @param  string $name Header name
-	 * @return bool
 	 */
 	public function has(string $name): bool
 	{
@@ -121,10 +98,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Gets a header value.
-	 *
-	 * @param  string $name    Header name
-	 * @param  mixed  $default Default value
-	 * @return mixed
 	 */
 	public function get(string $name, mixed $default = null): mixed
 	{
@@ -133,8 +106,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Removes a header.
-	 *
-	 * @param string $name Header name
 	 */
 	public function remove(string $name): void
 	{
@@ -143,8 +114,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Returns all the headers.
-	 *
-	 * @return array
 	 */
 	public function all(): array
 	{
@@ -153,9 +122,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Parses a accpet header and returns the values in descending order of preference.
-	 *
-	 * @param  string|null $headerValue Header value
-	 * @return array
 	 */
 	protected function parseAcceptHeader(?string $headerValue): array
 	{
@@ -197,9 +163,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Returns an array of acceptable content types in descending order of preference.
-	 *
-	 * @param  string|null $default Default content type
-	 * @return array
 	 */
 	public function getAcceptableContentTypes(?string $default = null): array
 	{
@@ -213,13 +176,10 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Returns an array of acceptable content types in descending order of preference.
-	 *
-	 * @param  string|null $default Default language
-	 * @return array
 	 */
 	public function getAcceptableLanguages(?string $default = null): array
 	{
-		if(!isset($this->acceptableLanguages))
+		if($this->acceptableLanguages === null)
 		{
 			$this->acceptableLanguages = $this->parseAcceptHeader($this->get('accept-language'));
 		}
@@ -229,13 +189,10 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Returns an array of acceptable content types in descending order of preference.
-	 *
-	 * @param  string|null $default Default charset
-	 * @return array
 	 */
 	public function getAcceptableCharsets(?string $default = null): array
 	{
-		if(!isset($this->acceptableCharsets))
+		if($this->acceptableCharsets === null)
 		{
 			$this->acceptableCharsets = $this->parseAcceptHeader($this->get('accept-charset'));
 		}
@@ -245,13 +202,10 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Returns an array of acceptable content types in descending order of preference.
-	 *
-	 * @param  string|null $default Default encoding
-	 * @return array
 	 */
 	public function getAcceptableEncodings(?string $default = null): array
 	{
-		if(!isset($this->acceptableEncodings))
+		if($this->acceptableEncodings === null)
 		{
 			$this->acceptableEncodings = $this->parseAcceptHeader($this->get('accept-encoding'));
 		}
@@ -261,8 +215,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Returns the bearer token or NULL if there isn't one.
-	 *
-	 * @return string|null
 	 */
 	public function getBearerToken(): ?string
 	{

--- a/src/mako/http/request/Parameters.php
+++ b/src/mako/http/request/Parameters.php
@@ -24,8 +24,6 @@ class Parameters implements Countable, IteratorAggregate
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param array $parameters Parameters
 	 */
 	public function __construct(
 		protected array $parameters = []
@@ -34,8 +32,6 @@ class Parameters implements Countable, IteratorAggregate
 
 	/**
 	 * Returns the numner of items in the collection.
-	 *
-	 * @return int
 	 */
 	public function count(): int
 	{
@@ -44,8 +40,6 @@ class Parameters implements Countable, IteratorAggregate
 
 	/**
 	 * Retruns an array iterator object.
-	 *
-	 * @return \ArrayIterator
 	 */
 	public function getIterator(): ArrayIterator
 	{
@@ -54,9 +48,6 @@ class Parameters implements Countable, IteratorAggregate
 
 	/**
 	 * Adds a parameter.
-	 *
-	 * @param string $name  Parameter name
-	 * @param mixed  $value Parameter value
 	 */
 	public function add(string $name, mixed $value): void
 	{
@@ -65,9 +56,6 @@ class Parameters implements Countable, IteratorAggregate
 
 	/**
 	 * Returns TRUE if the parameter exists and FALSE if not.
-	 *
-	 * @param  string $name Parameter name
-	 * @return bool
 	 */
 	public function has(string $name): bool
 	{
@@ -76,10 +64,6 @@ class Parameters implements Countable, IteratorAggregate
 
 	/**
 	 * Gets a parameter value.
-	 *
-	 * @param  string $name    Parameter name
-	 * @param  mixed  $default Default value
-	 * @return mixed
 	 */
 	public function get(string $name, mixed $default = null): mixed
 	{
@@ -88,8 +72,6 @@ class Parameters implements Countable, IteratorAggregate
 
 	/**
 	 * Removes a parameter.
-	 *
-	 * @param string $name Parameter name
 	 */
 	public function remove(string $name): void
 	{
@@ -98,8 +80,6 @@ class Parameters implements Countable, IteratorAggregate
 
 	/**
 	 * Returns all the parameters.
-	 *
-	 * @return array
 	 */
 	public function all(): array
 	{
@@ -108,10 +88,6 @@ class Parameters implements Countable, IteratorAggregate
 
 	/**
 	 * Returns request data where keys not in the whitelist have been removed.
-	 *
-	 * @param  array $keys     Keys to whitelist
-	 * @param  array $defaults Default values
-	 * @return array
 	 */
 	public function whitelisted(array $keys, array $defaults = []): array
 	{
@@ -120,10 +96,6 @@ class Parameters implements Countable, IteratorAggregate
 
 	/**
 	 * Returns request data where keys in the blacklist have been removed.
-	 *
-	 * @param  array $keys     Keys to whitelist
-	 * @param  array $defaults Default values
-	 * @return array
 	 */
 	public function blacklisted(array $keys, array $defaults = []): array
 	{

--- a/src/mako/http/request/Server.php
+++ b/src/mako/http/request/Server.php
@@ -18,8 +18,6 @@ class Server extends Parameters
 {
 	/**
 	 * Returns all the request headers.
-	 *
-	 * @return array
 	 */
 	public function getHeaders(): array
 	{

--- a/src/mako/http/request/UploadedFile.php
+++ b/src/mako/http/request/UploadedFile.php
@@ -21,12 +21,6 @@ class UploadedFile extends FileInfo
 {
 	/**
 	 * Constuctor.
-	 *
-	 * @param string $path      File path
-	 * @param string $filename  Filename
-	 * @param int    $size      File size
-	 * @param string $type      File mime type
-	 * @param int    $errorCode File error code
 	 */
 	public function __construct(
 		string $path,
@@ -41,8 +35,6 @@ class UploadedFile extends FileInfo
 
 	/**
 	 * Returns the filename reported by the client.
-	 *
-	 * @return string
 	 */
 	public function getReportedFilename(): string
 	{
@@ -51,8 +43,6 @@ class UploadedFile extends FileInfo
 
 	/**
 	 * Returns the size reported by the client in bytes.
-	 *
-	 * @return int
 	 */
 	public function getReportedSize(): int
 	{
@@ -61,8 +51,6 @@ class UploadedFile extends FileInfo
 
 	/**
 	 * Returns the mime type reported by the client.
-	 *
-	 * @return string
 	 */
 	public function getReportedMimeType(): string
 	{
@@ -71,8 +59,6 @@ class UploadedFile extends FileInfo
 
 	/**
 	 * Does the file have an error?
-	 *
-	 * @return bool
 	 */
 	public function hasError(): bool
 	{
@@ -81,8 +67,6 @@ class UploadedFile extends FileInfo
 
 	/**
 	 * Returns the file error code.
-	 *
-	 * @return int
 	 */
 	public function getErrorCode(): int
 	{
@@ -91,8 +75,6 @@ class UploadedFile extends FileInfo
 
 	/**
 	 * Returns a human friendly error message.
-	 *
-	 * @return string
 	 */
 	public function getErrorMessage(): string
 	{
@@ -112,8 +94,6 @@ class UploadedFile extends FileInfo
 
 	/**
 	 * Returns TRUE if the file has been uploaded and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isUploaded(): bool
 	{
@@ -122,9 +102,6 @@ class UploadedFile extends FileInfo
 
 	/**
 	 * Moves the file to the desired path.
-	 *
-	 * @param  string $path Storage path
-	 * @return bool
 	 */
 	protected function moveUploadedFile(string $path): bool
 	{
@@ -133,9 +110,6 @@ class UploadedFile extends FileInfo
 
 	/**
 	 * Moves the file to the desired path.
-	 *
-	 * @param  string $path Storage path
-	 * @return bool
 	 */
 	public function moveTo(string $path): bool
 	{

--- a/src/mako/http/response/Cookies.php
+++ b/src/mako/http/response/Cookies.php
@@ -27,10 +27,8 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Default options.
-	 *
-	 * @var array
 	 */
-	protected $defaults =
+	protected array $defaults =
 	[
 		'path'     => '/',
 		'domain'   => '',
@@ -41,15 +39,11 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Cookies.
-	 *
-	 * @var array
 	 */
-	protected $cookies = [];
+	protected array $cookies = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\security\Signer|null $signer Signer
 	 */
 	public function __construct(
 		protected ?Signer $signer = null
@@ -58,8 +52,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Returns the numner of cookies.
-	 *
-	 * @return int
 	 */
 	public function count(): int
 	{
@@ -68,8 +60,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Retruns an array iterator object.
-	 *
-	 * @return \ArrayIterator
 	 */
 	public function getIterator(): ArrayIterator
 	{
@@ -78,9 +68,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Set default options values.
-	 *
-	 * @param  array                       $defaults Default option values
-	 * @return \mako\http\response\Cookies
 	 */
 	public function setOptions(array $defaults): Cookies
 	{
@@ -91,13 +78,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Adds a unsigned cookie.
-	 *
-	 * @param  string                      $name    Cookie name
-	 * @param  string                      $value   Cookie value
-	 * @param  int                         $ttl     Time to live - if omitted or set to 0 the cookie will expire when the browser closes
-	 * @param  array                       $options Cookie options
-	 * @param  bool                        $raw     Set the cookie without urlencoding the value?
-	 * @return \mako\http\response\Cookies
 	 */
 	public function add(string $name, string $value, int $ttl = 0, array $options = [], bool $raw = false): Cookies
 	{
@@ -116,12 +96,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Adds a raw unsigned cookie.
-	 *
-	 * @param  string                      $name    Cookie name
-	 * @param  string                      $value   Cookie value
-	 * @param  int                         $ttl     Time to live - if omitted or set to 0 the cookie will expire when the browser closes
-	 * @param  array                       $options Cookie options
-	 * @return \mako\http\response\Cookies
 	 */
 	public function addRaw(string $name, string $value, int $ttl = 0, array $options = []): Cookies
 	{
@@ -130,13 +104,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Adds a signed cookie.
-	 *
-	 * @param  string                      $name    Cookie name
-	 * @param  string                      $value   Cookie value
-	 * @param  int                         $ttl     Time to live - if omitted or set to 0 the cookie will expire when the browser closes
-	 * @param  array                       $options Cookie options
-	 * @param  bool                        $raw     Set the cookie without urlencoding the value?
-	 * @return \mako\http\response\Cookies
 	 */
 	public function addSigned(string $name, string $value, int $ttl = 0, array $options = [], bool $raw = false): Cookies
 	{
@@ -150,12 +117,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Adds a raw signed cookie.
-	 *
-	 * @param  string                      $name    Cookie name
-	 * @param  string                      $value   Cookie value
-	 * @param  int                         $ttl     Time to live - if omitted or set to 0 the cookie will expire when the browser closes
-	 * @param  array                       $options Cookie options
-	 * @return \mako\http\response\Cookies
 	 */
 	public function addRawSigned(string $name, string $value, int $ttl, array $options = []): Cookies
 	{
@@ -164,9 +125,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Returns TRUE if the cookie exists and FALSE if not.
-	 *
-	 * @param  string $name Cookie name
-	 * @return bool
 	 */
 	public function has(string $name): bool
 	{
@@ -175,9 +133,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Removes a cookie.
-	 *
-	 * @param  string                      $name Cookie name
-	 * @return \mako\http\response\Cookies
 	 */
 	public function remove(string $name): Cookies
 	{
@@ -188,10 +143,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Deletes a cookie.
-	 *
-	 * @param  string                      $name    Cookie name
-	 * @param  array                       $options Cookie options
-	 * @return \mako\http\response\Cookies
 	 */
 	public function delete(string $name, array $options = []): Cookies
 	{
@@ -202,8 +153,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Clears all the cookies.
-	 *
-	 * @return \mako\http\response\Cookies
 	 */
 	public function clear(): Cookies
 	{
@@ -214,9 +163,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Clears all the cookies except those that patch the provided names or patterns.
-	 *
-	 * @param  array                       $cookies Cookie names or patterns
-	 * @return \mako\http\response\Cookies
 	 */
 	public function clearExcept(array $cookies): Cookies
 	{
@@ -227,8 +173,6 @@ class Cookies implements Countable, IteratorAggregate
 
 	/**
 	 * Returns all the cookies.
-	 *
-	 * @return array
 	 */
 	public function all(): array
 	{

--- a/src/mako/http/response/Headers.php
+++ b/src/mako/http/response/Headers.php
@@ -28,15 +28,11 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Headers.
-	 *
-	 * @var array
 	 */
-	protected $headers = [];
+	protected array $headers = [];
 
 	/**
 	 * Returns the numner of headers.
-	 *
-	 * @return int
 	 */
 	public function count(): int
 	{
@@ -45,8 +41,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Retruns an array iterator object.
-	 *
-	 * @return \ArrayIterator
 	 */
 	public function getIterator(): ArrayIterator
 	{
@@ -55,9 +49,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Normalizes header names.
-	 *
-	 * @param  string $name Header name
-	 * @return string
 	 */
 	protected function normalizeName(string $name): string
 	{
@@ -66,11 +57,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Adds a response header.
-	 *
-	 * @param  string                      $name    Header name
-	 * @param  string                      $value   Header value
-	 * @param  bool                        $replace Replace header?
-	 * @return \mako\http\response\Headers
 	 */
 	public function add(string $name, string $value, bool $replace = true): Headers
 	{
@@ -94,9 +80,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Returns TRUE if the header exists and FALSE if not.
-	 *
-	 * @param  string $name Header name
-	 * @return bool
 	 */
 	public function has(string $name): bool
 	{
@@ -105,11 +88,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Return TRUE if the header has the value and FALSE if not.
-	 *
-	 * @param  string $name          Header name
-	 * @param  string $value         Header value
-	 * @param  bool   $caseSensitive Should the comparison be case-sensitive?
-	 * @return bool
 	 */
 	public function hasValue(string $name, string $value, bool $caseSensitive = true): bool
 	{
@@ -128,9 +106,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Removes a header.
-	 *
-	 * @param  string                      $name Header name
-	 * @return \mako\http\response\Headers
 	 */
 	public function remove(string $name): Headers
 	{
@@ -141,8 +116,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Clears all the headers.
-	 *
-	 * @return \mako\http\response\Headers
 	 */
 	public function clear(): Headers
 	{
@@ -153,9 +126,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Clears all the headers except those that patch the provided names or patterns.
-	 *
-	 * @param  array                       $headers Header names or patterns
-	 * @return \mako\http\response\Headers
 	 */
 	public function clearExcept(array $headers): Headers
 	{
@@ -166,8 +136,6 @@ class Headers implements Countable, IteratorAggregate
 
 	/**
 	 * Returns all the headers.
-	 *
-	 * @return array
 	 */
 	public function all(): array
 	{

--- a/src/mako/http/response/builders/JSON.php
+++ b/src/mako/http/response/builders/JSON.php
@@ -20,18 +20,11 @@ class JSON implements ResponseBuilderInterface
 {
 	/**
 	 * Callback.
-	 *
-	 * @var string|null
 	 */
-	protected $callback;
+	protected string|null $callback = null;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param mixed       $data       Data
-	 * @param int         $options    JSON encode options
-	 * @param int|null    $statusCode Status code
-	 * @param string|null $charset    Character set
 	 */
 	public function __construct(
 		protected mixed $data,
@@ -43,9 +36,6 @@ class JSON implements ResponseBuilderInterface
 
 	/**
 	 * Enables JSONP support.
-	 *
-	 * @param  string                            $callback Query string field
-	 * @return \mako\http\response\builders\JSON
 	 */
 	public function asJsonpWith(string $callback): JSON
 	{
@@ -56,9 +46,6 @@ class JSON implements ResponseBuilderInterface
 
 	/**
 	 * Sets the response character set.
-	 *
-	 * @param  string                            $charset Character set
-	 * @return \mako\http\response\builders\JSON
 	 */
 	public function setCharset(string $charset): JSON
 	{
@@ -69,8 +56,6 @@ class JSON implements ResponseBuilderInterface
 
 	/**
 	 * Returns the response character set.
-	 *
-	 * @return string|null
 	 */
 	public function getCharset(): ?string
 	{
@@ -79,9 +64,6 @@ class JSON implements ResponseBuilderInterface
 
 	/**
 	 * Sets the HTTP status code.
-	 *
-	 * @param  int                               $statusCode Status code
-	 * @return \mako\http\response\builders\JSON
 	 */
 	public function setStatus(int $statusCode): JSON
 	{
@@ -92,8 +74,6 @@ class JSON implements ResponseBuilderInterface
 
 	/**
 	 * Returns the HTTP status code.
-	 *
-	 * @return int|null
 	 */
 	public function getStatus(): ?int
 	{
@@ -102,9 +82,6 @@ class JSON implements ResponseBuilderInterface
 
 	/**
 	 * Ensures a valid callback name.
-	 *
-	 * @param  string $callback Callback name
-	 * @return string
 	 */
 	protected function normalizeCallback(string $callback): string
 	{
@@ -123,7 +100,7 @@ class JSON implements ResponseBuilderInterface
 	{
 		$json = json_encode($this->data, $this->options);
 
-		if(!empty($this->callback) && ($callback = $request->getQuery()->get($this->callback)) !== null)
+		if($this->callback !== null && ($callback = $request->getQuery()->get($this->callback)) !== null)
 		{
 			$response->setType('text/javascript');
 

--- a/src/mako/http/response/builders/ResponseBuilderInterface.php
+++ b/src/mako/http/response/builders/ResponseBuilderInterface.php
@@ -17,9 +17,6 @@ interface ResponseBuilderInterface
 {
 	/**
 	 * Builds the response.
-	 *
-	 * @param \mako\http\Request  $request  Request instance
-	 * @param \mako\http\Response $response Response instance
 	 */
 	public function build(Request $request, Response $response): void;
 }

--- a/src/mako/http/response/senders/File.php
+++ b/src/mako/http/response/senders/File.php
@@ -37,44 +37,31 @@ class File implements ResponseSenderInterface
 {
 	/**
 	 * File size.
-	 *
-	 * @var int
 	 */
-	protected $fileSize;
+	protected int $fileSize;
 
 	/**
 	 * Filename.
-	 *
-	 * @var string|null
 	 */
-	protected $filename;
+	protected string|null $filename = null;
 
 	/**
 	 * Content disposition.
-	 *
-	 * @var string|null
 	 */
-	protected $disposition;
+	protected string|null $disposition = null;
 
 	/**
 	 * Content type.
-	 *
-	 * @var string|null
 	 */
-	protected $contentType;
+	protected string|null $contentType = null;
 
 	/**
 	 * Callback.
-	 *
-	 * @var \Closure|null
 	 */
-	protected $callback;
+	protected Closure|null $callback = null;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\file\FileSystem $fileSystem FileSytem instance
-	 * @param string                $filePath   File path
 	 */
 	public function __construct(
 		protected FileSystem $fileSystem,
@@ -91,9 +78,6 @@ class File implements ResponseSenderInterface
 
 	/**
 	 * Sets the filename.
-	 *
-	 * @param  string                           $name Filename
-	 * @return \mako\http\response\senders\File
 	 */
 	public function setName(string $name): File
 	{
@@ -104,9 +88,6 @@ class File implements ResponseSenderInterface
 
 	/**
 	 * Sets the content disposition.
-	 *
-	 * @param  string                           $disposition Content disposition
-	 * @return \mako\http\response\senders\File
 	 */
 	public function setDisposition(string $disposition): File
 	{
@@ -117,9 +98,6 @@ class File implements ResponseSenderInterface
 
 	/**
 	 * Sets the response content type.
-	 *
-	 * @param  string                           $type Mime type
-	 * @return \mako\http\response\senders\File
 	 */
 	public function setType(string $type): File
 	{
@@ -130,9 +108,6 @@ class File implements ResponseSenderInterface
 
 	/**
 	 * Sets the callback closure.
-	 *
-	 * @param  \Closure                         $callback Callback closure
-	 * @return \mako\http\response\senders\File
 	 */
 	public function done(Closure $callback): File
 	{
@@ -143,8 +118,6 @@ class File implements ResponseSenderInterface
 
 	/**
 	 * Returns the filename.
-	 *
-	 * @return string
 	 */
 	protected function getName(): string
 	{
@@ -153,8 +126,6 @@ class File implements ResponseSenderInterface
 
 	/**
 	 * Returns the content disposition.
-	 *
-	 * @return string
 	 */
 	protected function getDisposition(): string
 	{
@@ -163,8 +134,6 @@ class File implements ResponseSenderInterface
 
 	/**
 	 * Returns the content type.
-	 *
-	 * @return string
 	 */
 	protected function getContenType(): string
 	{
@@ -174,7 +143,6 @@ class File implements ResponseSenderInterface
 	/**
 	 * Calculates the content range that should be served.
 	 *
-	 * @param  string      $range Request range
 	 * @return array|false
 	 */
 	protected function calculateRange(string $range)
@@ -225,9 +193,6 @@ class File implements ResponseSenderInterface
 
 	/**
 	 * Sends the file.
-	 *
-	 * @param int $start Starting point
-	 * @param int $end   Ending point
 	 */
 	protected function sendFile(int $start, int $end): void
 	{

--- a/src/mako/http/response/senders/File.php
+++ b/src/mako/http/response/senders/File.php
@@ -43,22 +43,22 @@ class File implements ResponseSenderInterface
 	/**
 	 * Filename.
 	 */
-	protected string|null $filename = null;
+	protected string $filename;
 
 	/**
 	 * Content disposition.
 	 */
-	protected string|null $disposition = null;
+	protected string $disposition;
 
 	/**
 	 * Content type.
 	 */
-	protected string|null $contentType = null;
+	protected string $contentType;
 
 	/**
 	 * Callback.
 	 */
-	protected Closure|null $callback = null;
+	protected Closure $callback;
 
 	/**
 	 * Constructor.

--- a/src/mako/http/response/senders/Redirect.php
+++ b/src/mako/http/response/senders/Redirect.php
@@ -70,16 +70,11 @@ class Redirect implements ResponseSenderInterface
 
 	/**
 	 * Status code.
-	 *
-	 * @var int
 	 */
-	protected $statusCode;
+	protected int $statusCode;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string $location   Location
-	 * @param int    $statusCode Status code
 	 */
 	public function __construct(
 		protected string $location,
@@ -91,9 +86,6 @@ class Redirect implements ResponseSenderInterface
 
 	/**
 	 * Sets the HTTP status code.
-	 *
-	 * @param  int                                  $statusCode Status code
-	 * @return \mako\http\response\senders\Redirect
 	 */
 	public function setStatus(int $statusCode): Redirect
 	{
@@ -109,8 +101,6 @@ class Redirect implements ResponseSenderInterface
 
 	/**
 	 * Sets the HTTP status code to 301.
-	 *
-	 * @return \mako\http\response\senders\Redirect
 	 */
 	public function movedPermanently(): Redirect
 	{
@@ -121,8 +111,6 @@ class Redirect implements ResponseSenderInterface
 
 	/**
 	 * Sets the HTTP status code to 302.
-	 *
-	 * @return \mako\http\response\senders\Redirect
 	 */
 	public function found(): Redirect
 	{
@@ -133,8 +121,6 @@ class Redirect implements ResponseSenderInterface
 
 	/**
 	 * Sets the HTTP status code to 303.
-	 *
-	 * @return \mako\http\response\senders\Redirect
 	 */
 	public function seeOther(): Redirect
 	{
@@ -145,8 +131,6 @@ class Redirect implements ResponseSenderInterface
 
 	/**
 	 * Sets the HTTP status code to 307.
-	 *
-	 * @return \mako\http\response\senders\Redirect
 	 */
 	public function temporaryRedirect(): Redirect
 	{
@@ -157,8 +141,6 @@ class Redirect implements ResponseSenderInterface
 
 	/**
 	 * Sets the HTTP status code to 308.
-	 *
-	 * @return \mako\http\response\senders\Redirect
 	 */
 	public function permanentRedirect(): Redirect
 	{
@@ -169,8 +151,6 @@ class Redirect implements ResponseSenderInterface
 
 	/**
 	 * Returns the HTTP status code.
-	 *
-	 * @return int
 	 */
 	public function getStatus(): int
 	{

--- a/src/mako/http/response/senders/ResponseSenderInterface.php
+++ b/src/mako/http/response/senders/ResponseSenderInterface.php
@@ -17,9 +17,6 @@ interface ResponseSenderInterface
 {
 	/**
 	 * Sends the response.
-	 *
-	 * @param \mako\http\Request  $request  Request instance
-	 * @param \mako\http\Response $response Response instance
 	 */
 	public function send(Request $request, Response $response): void;
 }

--- a/src/mako/http/response/senders/Stream.php
+++ b/src/mako/http/response/senders/Stream.php
@@ -24,17 +24,11 @@ class Stream implements ResponseSenderInterface
 {
 	/**
 	 * Is PHP running as a CGI program?
-	 *
-	 * @var bool
 	 */
-	protected $isCGI;
+	protected bool $isCGI;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \Closure    $stream      Stream
-	 * @param string|null $contentType Content type
-	 * @param string|null $charset     Character set
 	 */
 	public function __construct(
 		protected Closure $stream,
@@ -45,9 +39,6 @@ class Stream implements ResponseSenderInterface
 
 	/**
 	 * Sets the response content type.
-	 *
-	 * @param  string                             $contentType Content type
-	 * @return \mako\http\response\senders\Stream
 	 */
 	public function setType(string $contentType): Stream
 	{
@@ -58,8 +49,6 @@ class Stream implements ResponseSenderInterface
 
 	/**
 	 * Returns the response content type.
-	 *
-	 * @return string|null
 	 */
 	public function getType(): ?string
 	{
@@ -68,9 +57,6 @@ class Stream implements ResponseSenderInterface
 
 	/**
 	 * Sets the response character set.
-	 *
-	 * @param  string                             $charset Character set
-	 * @return \mako\http\response\senders\Stream
 	 */
 	public function setCharset(string $charset): Stream
 	{
@@ -81,8 +67,6 @@ class Stream implements ResponseSenderInterface
 
 	/**
 	 * Returns the response character set.
-	 *
-	 * @return string|null
 	 */
 	public function getCharset(): ?string
 	{
@@ -91,9 +75,6 @@ class Stream implements ResponseSenderInterface
 
 	/**
 	 * Flushes a chunck of data.
-	 *
-	 * @param string|null $chunk      Chunck of data to flush
-	 * @param bool        $flushEmpty Flush empty chunk?
 	 */
 	public function flush(?string $chunk, bool $flushEmpty = false): void
 	{

--- a/src/mako/http/response/traits/PatternMatcherTrait.php
+++ b/src/mako/http/response/traits/PatternMatcherTrait.php
@@ -17,10 +17,6 @@ trait PatternMatcherTrait
 {
 	/**
 	 * Returns TRUE if the string matches one of the patterns and FALSE if not.
-	 *
-	 * @param  string $string   String
-	 * @param  array  $patterns Patterns
-	 * @return bool
 	 */
 	protected function matchesPatterns(string $string, array $patterns): bool
 	{

--- a/src/mako/http/routing/Dispatcher.php
+++ b/src/mako/http/routing/Dispatcher.php
@@ -41,31 +41,21 @@ class Dispatcher
 
 	/**
 	 * Route middleware.
-	 *
-	 * @var array
 	 */
-	protected $middleware = [];
+	protected array $middleware = [];
 
 	/**
 	 * Global middleware.
-	 *
-	 * @var array
 	 */
-	protected $globalMiddleware = [];
+	protected array $globalMiddleware = [];
 
 	/**
 	 * Middleware priority.
-	 *
-	 * @var array
 	 */
-	protected $middlewarePriority = [];
+	protected array $middlewarePriority = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\http\Request      $request   Request instance
-	 * @param \mako\http\Response     $response  Response instance
-	 * @param \mako\syringe\Container $container Container
 	 */
 	public function __construct(
 		protected Request $request,
@@ -76,9 +66,6 @@ class Dispatcher
 
 	/**
 	 * Sets the middleware priority.
-	 *
-	 * @param  array                         $priority Middleware priority
-	 * @return \mako\http\routing\Dispatcher
 	 */
 	public function setMiddlewarePriority(array $priority): Dispatcher
 	{
@@ -89,8 +76,6 @@ class Dispatcher
 
 	/**
 	 * Resets middleware priority.
-	 *
-	 * @return \mako\http\routing\Dispatcher
 	 */
 	public function resetMiddlewarePriority(): Dispatcher
 	{
@@ -101,11 +86,6 @@ class Dispatcher
 
 	/**
 	 * Registers middleware.
-	 *
-	 * @param  string                        $name       Middleware name or class name
-	 * @param  string|null                   $middleware Middleware class name
-	 * @param  int|null                      $priority   Middleware priority
-	 * @return \mako\http\routing\Dispatcher
 	 */
 	public function registerMiddleware(string $name, ?string $middleware = null, ?int $priority = null): Dispatcher
 	{
@@ -121,9 +101,6 @@ class Dispatcher
 
 	/**
 	 * Sets the chosen middleware as global.
-	 *
-	 * @param  array                         $middleware Array of middleware names
-	 * @return \mako\http\routing\Dispatcher
 	 */
 	public function setMiddlewareAsGlobal(array $middleware): Dispatcher
 	{
@@ -134,9 +111,6 @@ class Dispatcher
 
 	/**
 	 * Resolves the middleware.
-	 *
-	 * @param  string $middleware middleware
-	 * @return array
 	 */
 	protected function resolveMiddleware(string $middleware): array
 	{
@@ -152,9 +126,6 @@ class Dispatcher
 
 	/**
 	 * Orders resolved middleware by priority.
-	 *
-	 * @param  array $middleware Array of middleware
-	 * @return array
 	 */
 	protected function orderMiddlewareByPriority(array $middleware): array
 	{
@@ -172,9 +143,6 @@ class Dispatcher
 
 	/**
 	 * Adds route middleware to the stack.
-	 *
-	 * @param \mako\onion\Onion $onion      Middleware stack
-	 * @param array             $middleware Array of middleware
 	 */
 	protected function addMiddlewareToStack(Onion $onion, array $middleware): void
 	{
@@ -205,10 +173,6 @@ class Dispatcher
 
 	/**
 	 * Executes a closure action.
-	 *
-	 * @param  \Closure            $action     Closure
-	 * @param  array               $parameters Parameters
-	 * @return \mako\http\Response
 	 */
 	protected function executeClosure(Closure $action, array $parameters): Response
 	{
@@ -217,10 +181,6 @@ class Dispatcher
 
 	/**
 	 * Executes a controller action.
-	 *
-	 * @param  array|string        $action     Controller
-	 * @param  array               $parameters Parameters
-	 * @return \mako\http\Response
 	 */
 	protected function executeController(array|string $action, array $parameters): Response
 	{
@@ -261,9 +221,6 @@ class Dispatcher
 
 	/**
 	 * Executes the route action.
-	 *
-	 * @param  \mako\http\routing\Route $route Route
-	 * @return \mako\http\Response
 	 */
 	protected function executeAction(Route $route): Response
 	{
@@ -281,9 +238,6 @@ class Dispatcher
 
 	/**
 	 * Dispatches the route and returns the response.
-	 *
-	 * @param  \mako\http\routing\Route $route Route
-	 * @return \mako\http\Response
 	 */
 	public function dispatch(Route $route): Response
 	{

--- a/src/mako/http/routing/Route.php
+++ b/src/mako/http/routing/Route.php
@@ -28,8 +28,6 @@ class Route
 {
 	/**
 	 * Route prefix.
-	 *
-	 * @var string
 	 */
 	protected string $prefix = '';
 

--- a/src/mako/http/routing/Route.php
+++ b/src/mako/http/routing/Route.php
@@ -31,50 +31,35 @@ class Route
 	 *
 	 * @var string
 	 */
-	protected $prefix;
+	protected string $prefix = '';
 
 	/**
 	 * Does the route have a trailing slash?
-	 *
-	 * @var bool
 	 */
-	protected $hasTrailingSlash;
+	protected bool $hasTrailingSlash;
 
 	/**
 	 * Route patterns.
-	 *
-	 * @var array
 	 */
-	protected $patterns = [];
+	protected array $patterns = [];
 
 	/**
 	 * Middleware.
-	 *
-	 * @var array
 	 */
-	protected $middleware = [];
+	protected array $middleware = [];
 
 	/**
 	 * Constraints.
-	 *
-	 * @var array
 	 */
-	protected $constraints = [];
+	protected array $constraints = [];
 
 	/**
 	 * Parameters.
-	 *
-	 * @var array
 	 */
-	protected $parameters = [];
+	protected array $parameters = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array                 $methods Route methods
-	 * @param string                $route   Route
-	 * @param array|\Closure|string $action  Route action
-	 * @param string|null           $name    Route name
 	 */
 	public function __construct(
 		protected array $methods,
@@ -88,8 +73,6 @@ class Route
 
 	/**
 	 * Returns the HTTP methods the route responds to.
-	 *
-	 * @return array
 	 */
 	public function getMethods(): array
 	{
@@ -98,8 +81,6 @@ class Route
 
 	/**
 	 * Returns the route.
-	 *
-	 * @return string
 	 */
 	public function getRoute(): string
 	{
@@ -108,8 +89,6 @@ class Route
 
 	/**
 	 * Returns the route action.
-	 *
-	 * @return array|\Closure|string
 	 */
 	public function getAction(): array|Closure|string
 	{
@@ -118,8 +97,6 @@ class Route
 
 	/**
 	 * Returns the route name.
-	 *
-	 * @return string|null
 	 */
 	public function getName(): ?string
 	{
@@ -128,10 +105,6 @@ class Route
 
 	/**
 	 * Returns attribute values.
-	 *
-	 * @param  array  $attributes An array of reflection attributes
-	 * @param  string $method     Attribute method
-	 * @return array
 	 */
 	protected function getAttributeValues(array $attributes, string $method): array
 	{
@@ -148,8 +121,6 @@ class Route
 
 	/**
 	 * Returns the middleware.
-	 *
-	 * @return array
 	 */
 	public function getMiddleware(): array
 	{
@@ -169,8 +140,6 @@ class Route
 
 	/**
 	 * Returns the constraints.
-	 *
-	 * @return array
 	 */
 	public function getConstraints(): array
 	{
@@ -190,8 +159,6 @@ class Route
 
 	/**
 	 * Sets the route parameters.
-	 *
-	 * @param array $parameters Parameters
 	 */
 	public function setParameters(array $parameters): void
 	{
@@ -200,8 +167,6 @@ class Route
 
 	/**
 	 * Returns all the route parameters.
-	 *
-	 * @return array
 	 */
 	public function getParameters(): array
 	{
@@ -210,10 +175,6 @@ class Route
 
 	/**
 	 * Returns the named parameter value.
-	 *
-	 * @param  string $name    Parameter name
-	 * @param  mixed  $default Default value
-	 * @return mixed
 	 */
 	public function getParameter(string $name, mixed $default = null): mixed
 	{
@@ -222,9 +183,6 @@ class Route
 
 	/**
 	 * Adds a prefix to the route.
-	 *
-	 * @param  string                   $prefix Route prefix
-	 * @return \mako\http\routing\Route
 	 */
 	public function prefix(string $prefix): Route
 	{
@@ -238,9 +196,6 @@ class Route
 
 	/**
 	 * Sets the custom patterns.
-	 *
-	 * @param  array                    $patterns Array of patterns
-	 * @return \mako\http\routing\Route
 	 */
 	public function patterns(array $patterns): Route
 	{
@@ -251,9 +206,6 @@ class Route
 
 	/**
 	 * Adds a set of middleware.
-	 *
-	 * @param  array|string             $middleware Middleware
-	 * @return \mako\http\routing\Route
 	 */
 	public function middleware(array|string $middleware): Route
 	{
@@ -264,9 +216,6 @@ class Route
 
 	/**
 	 * Adds a set of constraints.
-	 *
-	 * @param  array|string             $constraint Constraint
-	 * @return \mako\http\routing\Route
 	 */
 	public function constraint(array|string $constraint): Route
 	{
@@ -277,9 +226,6 @@ class Route
 
 	/**
 	 * Returns TRUE if the route allows the specified method or FALSE if not.
-	 *
-	 * @param  string $method Method
-	 * @return bool
 	 */
 	public function allowsMethod(string $method): bool
 	{
@@ -288,8 +234,6 @@ class Route
 
 	/**
 	 * Returns TRUE if the route has a trailing slash and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function hasTrailingSlash(): bool
 	{
@@ -298,8 +242,6 @@ class Route
 
 	/**
 	 * Returns the regex needed to match the route.
-	 *
-	 * @return string
 	 */
 	public function getRegex(): string
 	{

--- a/src/mako/http/routing/Router.php
+++ b/src/mako/http/routing/Router.php
@@ -36,23 +36,16 @@ class Router
 
 	/**
 	 * Constraints.
-	 *
-	 * @var array
 	 */
-	protected $constraints = [];
+	protected array $constraints = [];
 
 	/**
 	 * Global constraints.
-	 *
-	 * @var array
 	 */
-	protected $globalConstraints = [];
+	protected array $globalConstraints = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\http\routing\Routes $routes    Routes
-	 * @param \mako\syringe\Container   $container Container
 	 */
 	public function __construct(
 		protected Routes $routes,
@@ -62,10 +55,6 @@ class Router
 
 	/**
 	 * Registers constraint.
-	 *
-	 * @param  string                    $name       Constraint name or class name
-	 * @param  string|null               $constraint Constraint class name
-	 * @return \mako\http\routing\Router
 	 */
 	public function registerConstraint(string $name, ?string $constraint = null): Router
 	{
@@ -76,9 +65,6 @@ class Router
 
 	/**
 	 * Sets the chosen constraint as global.
-	 *
-	 * @param  array                     $constraint Array of constraint names
-	 * @return \mako\http\routing\Router
 	 */
 	public function setConstraintAsGlobal(array $constraint): Router
 	{
@@ -89,10 +75,6 @@ class Router
 
 	/**
 	 * Returns TRUE if the route matches the request path and FALSE if not.
-	 *
-	 * @param  \mako\http\routing\Route $route Route
-	 * @param  string                   $path  Request path
-	 * @return bool
 	 */
 	protected function matches(Route $route, string $path): bool
 	{
@@ -118,9 +100,6 @@ class Router
 
 	/**
 	 * Constraint factory.
-	 *
-	 * @param  string                                             $constraint Constraint
-	 * @return \mako\http\routing\constraints\ConstraintInterface
 	 */
 	protected function constraintFactory(string $constraint): ConstraintInterface
 	{
@@ -138,9 +117,6 @@ class Router
 
 	/**
 	 * Returns TRUE if all the route constraints are satisfied and FALSE if not.
-	 *
-	 * @param  \mako\http\routing\Route $route Route
-	 * @return bool
 	 */
 	protected function constraintsAreSatisfied(Route $route): bool
 	{
@@ -157,9 +133,6 @@ class Router
 
 	/**
 	 * Returns a route with a closure action that redirects to the correct URL.
-	 *
-	 * @param  string                   $requestPath The requested path
-	 * @return \mako\http\routing\Route
 	 */
 	protected function redirectRoute(string $requestPath): Route
 	{
@@ -180,9 +153,6 @@ class Router
 
 	/**
 	 * Returns an array of all allowed request methods for the requested route.
-	 *
-	 * @param  string $requestPath The requested path
-	 * @return array
 	 */
 	protected function getAllowedMethodsForMatchingRoutes(string $requestPath): array
 	{
@@ -201,9 +171,6 @@ class Router
 
 	/**
 	 * Returns a route with a closure action that sets the allow header.
-	 *
-	 * @param  string                   $requestPath The requested path
-	 * @return \mako\http\routing\Route
 	 */
 	protected function optionsRoute(string $requestPath): Route
 	{
@@ -217,9 +184,6 @@ class Router
 
 	/**
 	 * Returns a route that throws a method not allowed exception.
-	 *
-	 * @param  array                    $allowedMethods Allowed methods
-	 * @return \mako\http\routing\Route
 	 */
 	protected function methodNotAllowedRoute(array $allowedMethods): Route
 	{
@@ -231,8 +195,6 @@ class Router
 
 	/**
 	 * Returns a route that throws a not found exception.
-	 *
-	 * @return \mako\http\routing\Route
 	 */
 	protected function notFoundRoute(): Route
 	{
@@ -244,9 +206,6 @@ class Router
 
 	/**
 	 * Matches and returns the appropriate route along with its parameters.
-	 *
-	 * @param  \mako\http\Request       $request Request
-	 * @return \mako\http\routing\Route
 	 */
 	public function route(Request $request): Route
 	{

--- a/src/mako/http/routing/Routes.php
+++ b/src/mako/http/routing/Routes.php
@@ -23,36 +23,26 @@ class Routes
 
 	/**
 	 * Route groups.
-	 *
-	 * @var array
 	 */
-	protected $groups = [];
+	protected array $groups = [];
 
 	/**
 	 * Registered routes.
-	 *
-	 * @var array
 	 */
-	protected $routes = [];
+	protected array $routes = [];
 
 	/**
 	 * Routes grouped by request method.
-	 *
-	 * @var array
 	 */
-	protected $groupedRoutes = [];
+	protected array $groupedRoutes = [];
 
 	/**
 	 * Named routes.
-	 *
-	 * @var array
 	 */
-	protected $namedRoutes = [];
+	protected array $namedRoutes = [];
 
 	/**
 	 * Returns the registered routes.
-	 *
-	 * @return array
 	 */
 	public function getRoutes(): array
 	{
@@ -61,9 +51,6 @@ class Routes
 
 	/**
 	 * Returns the registered routes that accept the request method.
-	 *
-	 * @param  string $method Request method
-	 * @return array
 	 */
 	public function getRoutesByMethod(string $method): array
 	{
@@ -72,9 +59,6 @@ class Routes
 
 	/**
 	 * Returns TRUE if the named route exists and FALSE if not.
-	 *
-	 * @param  string $name Route name
-	 * @return bool
 	 */
 	public function hasNamedRoute(string $name): bool
 	{
@@ -83,9 +67,6 @@ class Routes
 
 	/**
 	 * Returns the named route.
-	 *
-	 * @param  string                   $name Route name
-	 * @return \mako\http\routing\Route
 	 */
 	public function getNamedRoute(string $name): Route
 	{
@@ -99,9 +80,6 @@ class Routes
 
 	/**
 	 * Adds a grouped set of routes to the colleciton.
-	 *
-	 * @param array    $options Group options
-	 * @param \Closure $routes  Route closure
 	 */
 	public function group(array $options, Closure $routes): void
 	{
@@ -114,12 +92,6 @@ class Routes
 
 	/**
 	 * Registers a route.
-	 *
-	 * @param  array                    $methods HTTP methods
-	 * @param  string                   $route   Route
-	 * @param  array|\Closure|string    $action  Route action
-	 * @param  string|null              $name    Route name
-	 * @return \mako\http\routing\Route
 	 */
 	protected function registerRoute(array $methods, string $route, array|Closure|string $action, ?string $name = null): Route
 	{
@@ -153,11 +125,6 @@ class Routes
 
 	/**
 	 * Adds a route that responds to GET requests to the collection.
-	 *
-	 * @param  string                   $route  Route
-	 * @param  array|\Closure|string    $action Route action
-	 * @param  string|null              $name   Route name
-	 * @return \mako\http\routing\Route
 	 */
 	public function get(string $route, array|Closure|string $action, ?string $name = null): Route
 	{
@@ -166,11 +133,6 @@ class Routes
 
 	/**
 	 * Adds a route that responds to POST requests to the collection.
-	 *
-	 * @param  string                   $route  Route
-	 * @param  array|\Closure|string    $action Route action
-	 * @param  string|null              $name   Route name
-	 * @return \mako\http\routing\Route
 	 */
 	public function post(string $route, array|Closure|string $action, ?string $name = null): Route
 	{
@@ -179,11 +141,6 @@ class Routes
 
 	/**
 	 * Adds a route that responds to PUT requests to the collection.
-	 *
-	 * @param  string                   $route  Route
-	 * @param  array|\Closure|string    $action Route action
-	 * @param  string|null              $name   Route name
-	 * @return \mako\http\routing\Route
 	 */
 	public function put(string $route, array|Closure|string $action, ?string $name = null): Route
 	{
@@ -192,11 +149,6 @@ class Routes
 
 	/**
 	 * Adds a route that responds to PATCH requests to the collection.
-	 *
-	 * @param  string                   $route  Route
-	 * @param  array|\Closure|string    $action Route action
-	 * @param  string|null              $name   Route name
-	 * @return \mako\http\routing\Route
 	 */
 	public function patch(string $route, array|Closure|string $action, ?string $name = null): Route
 	{
@@ -205,11 +157,6 @@ class Routes
 
 	/**
 	 * Adds a route that responds to DELETE requests to the collection.
-	 *
-	 * @param  string                   $route  Route
-	 * @param  array|\Closure|string    $action Route action
-	 * @param  string|null              $name   Route name
-	 * @return \mako\http\routing\Route
 	 */
 	public function delete(string $route, array|Closure|string $action, ?string $name = null): Route
 	{
@@ -218,11 +165,6 @@ class Routes
 
 	/**
 	 * Adds a route that responts to all HTTP methods to the collection.
-	 *
-	 * @param  string                   $route  Route
-	 * @param  array|\Closure|string    $action Route action
-	 * @param  string|null              $name   Route name
-	 * @return \mako\http\routing\Route
 	 */
 	public function all(string $route, array|Closure|string $action, ?string $name = null): Route
 	{
@@ -231,12 +173,6 @@ class Routes
 
 	/**
 	 * Adds a route that respodns to the chosen HTTP methods to the collection.
-	 *
-	 * @param  array                    $methods Array of HTTP methods the route should respond to
-	 * @param  string                   $route   Route
-	 * @param  array|\Closure|string    $action  Route action
-	 * @param  string|null              $name    Route name
-	 * @return \mako\http\routing\Route
 	 */
 	public function register(array $methods, string $route, array|Closure|string $action, ?string $name = null): Route
 	{

--- a/src/mako/http/routing/URLBuilder.php
+++ b/src/mako/http/routing/URLBuilder.php
@@ -21,32 +21,21 @@ class URLBuilder
 {
 	/**
 	 * Base URL.
-	 *
-	 * @var string
 	 */
-	protected $baseURL;
+	protected string $baseURL;
 
 	/**
 	 * Script name.
-	 *
-	 * @var string
 	 */
-	protected $scriptName;
+	protected string $scriptName;
 
 	/**
 	 * Language prefix.
-	 *
-	 * @var string
 	 */
-	protected $languagePrefix;
+	protected string $languagePrefix = '';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\http\Request        $request   Request instance
-	 * @param \mako\http\routing\Routes $routes    Route collection
-	 * @param bool                      $cleanURLs Create "clean" URLs?
-	 * @param string|null               $baseURL   Base URL
 	 */
 	public function __construct(
 		protected Request $request,
@@ -67,9 +56,6 @@ class URLBuilder
 
 	/**
 	 * Returns TRUE if the pattern matches the current route and FALSE if not.
-	 *
-	 * @param  string $pattern Pattern to match
-	 * @return bool
 	 */
 	public function matches(string $pattern): bool
 	{
@@ -78,8 +64,6 @@ class URLBuilder
 
 	/**
 	 * Returns the base URL of the application.
-	 *
-	 * @return string
 	 */
 	public function base(): string
 	{
@@ -88,12 +72,6 @@ class URLBuilder
 
 	/**
 	 * Returns the URL of the specified path.
-	 *
-	 * @param  string      $path        Path
-	 * @param  array       $queryParams Associative array used to build URL-encoded query string
-	 * @param  string      $separator   Argument separator
-	 * @param  bool|string $language    Request language
-	 * @return string
 	 */
 	public function to(string $path, array $queryParams = [], string $separator = '&', bool|string $language = true): string
 	{
@@ -109,13 +87,6 @@ class URLBuilder
 
 	/**
 	 * Returns the URL of a named route.
-	 *
-	 * @param  string      $routeName   Route name
-	 * @param  array       $routeParams Route parameters
-	 * @param  array       $queryParams Associative array used to build URL-encoded query string
-	 * @param  string      $separator   Argument separator
-	 * @param  bool|string $language    Request language
-	 * @return string
 	 */
 	public function toRoute(string $routeName, array $routeParams = [], array $queryParams = [], string $separator = '&', bool|string $language = true): string
 	{
@@ -141,11 +112,6 @@ class URLBuilder
 
 	/**
 	 * Returns the current URL of the request.
-	 *
-	 * @param  array|null  $queryParams Associative array used to build URL-encoded query string
-	 * @param  string      $separator   Argument separator
-	 * @param  bool|string $language    Request language
-	 * @return string
 	 */
 	public function current(?array $queryParams = [], string $separator = '&', bool|string $language = true): string
 	{
@@ -156,12 +122,6 @@ class URLBuilder
 
 	/**
 	 * Returns the URL of the specified route.
-	 *
-	 * @param  string $route       URL segments
-	 * @param  string $language    Request language
-	 * @param  array  $queryParams Associative array used to build URL-encoded query string
-	 * @param  string $separator   Argument separator
-	 * @return string
 	 */
 	public function toLanguage(string $route, string $language, array $queryParams = [], string $separator = '&'): string
 	{
@@ -170,13 +130,6 @@ class URLBuilder
 
 	/**
 	 * Returns the URL of a named route.
-	 *
-	 * @param  string $routeName   Route name
-	 * @param  string $language    Request language
-	 * @param  array  $routeParams Route parameters
-	 * @param  array  $queryParams Associative array used to build URL-encoded query string
-	 * @param  string $separator   Argument separator
-	 * @return string
 	 */
 	public function toRouteLanguage(string $routeName, string $language, array $routeParams = [], array $queryParams = [], string $separator = '&'): string
 	{
@@ -185,11 +138,6 @@ class URLBuilder
 
 	/**
 	 * Returns the current URL of the request.
-	 *
-	 * @param  string     $language    Request language
-	 * @param  array|null $queryParams Query parameters
-	 * @param  string     $separator   Argument separator
-	 * @return string
 	 */
 	public function currentLanguage(string $language, ?array $queryParams = [], string $separator = '&'): string
 	{

--- a/src/mako/http/routing/attributes/Constraint.php
+++ b/src/mako/http/routing/attributes/Constraint.php
@@ -17,8 +17,6 @@ class Constraint
 {
     /**
      * Constructor.
-     *
-     * @param array|string $constraint Constraint
      */
     public function __construct(
         protected array|string $constraint
@@ -27,8 +25,6 @@ class Constraint
 
     /**
      * Returns an array of constraints.
-     *
-     * @return array
      */
     public function getConstraints(): array
     {

--- a/src/mako/http/routing/attributes/Middleware.php
+++ b/src/mako/http/routing/attributes/Middleware.php
@@ -17,8 +17,6 @@ class Middleware
 {
     /**
      * Constructor.
-     *
-     * @param array|string $middleware Middleware
      */
     public function __construct(
         protected array|string $middleware
@@ -27,8 +25,6 @@ class Middleware
 
     /**
      * Returns an array of middleware.
-     *
-     * @return array
      */
     public function getMiddleware(): array
     {

--- a/src/mako/http/routing/constraints/ConstraintInterface.php
+++ b/src/mako/http/routing/constraints/ConstraintInterface.php
@@ -14,8 +14,6 @@ interface ConstraintInterface
 {
 	/**
 	 * Returns TRUE if the constraint is satisfied and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isSatisfied(): bool;
 }

--- a/src/mako/http/routing/middleware/AccessControl.php
+++ b/src/mako/http/routing/middleware/AccessControl.php
@@ -21,39 +21,31 @@ abstract class AccessControl implements MiddlewareInterface
 {
 	/**
 	 * Allow credentials?
-	 *
-	 * @var bool
 	 */
-	protected $allowCredentials = false;
+	protected bool $allowCredentials = false;
 
 	/**
 	 * Allow all domains?
-	 *
-	 * @var bool
 	 */
-	protected $allowAllDomains = false;
+	protected bool $allowAllDomains = false;
 
 	/**
 	 * Allowed domains.
-	 *
-	 * @var array
 	 */
-	protected $allowedDomains = [];
+	protected array $allowedDomains = [];
 
 	/**
-	 * @var array
+	 * Allowed headers.
 	 */
-	protected $allowedHeaders = [];
+	protected array $allowedHeaders = [];
 
 	/**
-	 * @var array
+	 * Allowed methods.
 	 */
-	protected $allowedMethods = [];
+	protected array $allowedMethods = [];
 
 	/**
 	 * Returns TRUE if we allows credentials and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	protected function allowsCredentials(): bool
 	{
@@ -62,8 +54,6 @@ abstract class AccessControl implements MiddlewareInterface
 
 	/**
 	 * Returns TRUE if we allow all domains and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	protected function allowsAllDomains(): bool
 	{
@@ -72,9 +62,6 @@ abstract class AccessControl implements MiddlewareInterface
 
 	/**
 	 * Returns the request origin.
-	 *
-	 * @param  \mako\http\Request $request Request instance
-	 * @return string|null
 	 */
 	protected function getOrigin(Request $request): ?string
 	{
@@ -83,8 +70,6 @@ abstract class AccessControl implements MiddlewareInterface
 
 	/**
 	 * Returns the allowed domains.
-	 *
-	 * @return array
 	 */
 	protected function getAllowedDomains(): array
 	{
@@ -93,9 +78,6 @@ abstract class AccessControl implements MiddlewareInterface
 
 	/**
 	 * Returns TRUE if the domain is allowed and FALSE if not.
-	 *
-	 * @param  string $domain Domain
-	 * @return bool
 	 */
 	protected function isDomainAllowed(string $domain): bool
 	{
@@ -104,8 +86,6 @@ abstract class AccessControl implements MiddlewareInterface
 
 	/**
 	 * Returns the allowed headers.
-	 *
-	 * @return array
 	 */
 	protected function getAllowedHeaders(): array
 	{
@@ -114,8 +94,6 @@ abstract class AccessControl implements MiddlewareInterface
 
 	/**
 	 * Returns the allowed methods.
-	 *
-	 * @return array
 	 */
 	protected function getAllowedMethods(): array
 	{

--- a/src/mako/http/routing/middleware/ContentSecurityPolicy.php
+++ b/src/mako/http/routing/middleware/ContentSecurityPolicy.php
@@ -26,7 +26,7 @@ class ContentSecurityPolicy implements MiddlewareInterface
 	/**
 	 * Report to.
 	 */
-	protected array|null $reportTo = null;
+	protected array $reportTo = [];
 
 	/**
 	 * Should we only report content security policy violations?
@@ -46,7 +46,7 @@ class ContentSecurityPolicy implements MiddlewareInterface
 	/**
 	 * Content security policy nonce.
 	 */
-	protected string|null $nonce = null;
+	protected string $nonce;
 
 	/**
 	 * Content security policy nonce view variable name.
@@ -89,7 +89,7 @@ class ContentSecurityPolicy implements MiddlewareInterface
 	 */
 	protected function getNonce(): string
 	{
-		if($this->nonce === null)
+		if(empty($this->nonce))
 		{
 			$this->nonce = $this->generateNonce();
 		}
@@ -157,14 +157,14 @@ class ContentSecurityPolicy implements MiddlewareInterface
 	{
 		$headers = $response->getHeaders();
 
-		if($this->reportTo !== null)
+		if(!empty($this->reportTo))
 		{
 			$headers->add('Report-To', $this->buildReportToValue());
 		}
 
 		$headers->add($this->reportOnly ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy', $this->buildValue());
 
-		if($this->nonce !== null)
+		if(!empty($this->nonce))
 		{
 			$this->assignNonceViewVariable();
 		}

--- a/src/mako/http/routing/middleware/ContentSecurityPolicy.php
+++ b/src/mako/http/routing/middleware/ContentSecurityPolicy.php
@@ -25,24 +25,18 @@ class ContentSecurityPolicy implements MiddlewareInterface
 {
 	/**
 	 * Report to.
-	 *
-	 * @var array|null
 	 */
-	protected $reportTo;
+	protected array|null $reportTo = null;
 
 	/**
 	 * Should we only report content security policy violations?
-	 *
-	 * @var bool
 	 */
-	protected $reportOnly = false;
+	protected bool $reportOnly = false;
 
 	/**
 	 * Content security policy directives.
-	 *
-	 * @var array
 	 */
-	protected $directives =
+	protected array $directives =
 	[
 		'base-uri'    => ['self'],
 		'default-src' => ['self'],
@@ -51,22 +45,16 @@ class ContentSecurityPolicy implements MiddlewareInterface
 
 	/**
 	 * Content security policy nonce.
-	 *
-	 * @var string|null
 	 */
-	protected $nonce;
+	protected string|null $nonce = null;
 
 	/**
 	 * Content security policy nonce view variable name.
-	 *
-	 * @var string
 	 */
-	protected $nonceVariableName = '_csp_nonce_';
+	protected string $nonceVariableName = '_csp_nonce_';
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\syringe\Container $container Container
 	 */
 	public function __construct(
 		protected Container $container
@@ -75,8 +63,6 @@ class ContentSecurityPolicy implements MiddlewareInterface
 
 	/**
 	 * Builds the "Report-To" header value.
-	 *
-	 * @return string
 	 */
 	protected function buildReportToValue(): string
 	{
@@ -92,8 +78,6 @@ class ContentSecurityPolicy implements MiddlewareInterface
 
 	/**
 	 * Generates a random content security policy nonce.
-	 *
-	 * @return string
 	 */
 	protected function generateNonce(): string
 	{
@@ -102,8 +86,6 @@ class ContentSecurityPolicy implements MiddlewareInterface
 
 	/**
 	 * Returns the content security policy nonce.
-	 *
-	 * @return string
 	 */
 	protected function getNonce(): string
 	{
@@ -117,8 +99,6 @@ class ContentSecurityPolicy implements MiddlewareInterface
 
 	/**
 	 * Builds the "Content-Security-Policy" header value.
-	 *
-	 * @return string
 	 */
 	protected function buildValue(): string
 	{

--- a/src/mako/http/routing/middleware/MiddlewareInterface.php
+++ b/src/mako/http/routing/middleware/MiddlewareInterface.php
@@ -18,11 +18,6 @@ interface MiddlewareInterface
 {
 	/**
 	 * Executes the middleware.
-	 *
-	 * @param  \mako\http\Request  $request  Request
-	 * @param  \mako\http\Response $response Response
-	 * @param  \Closure            $next     Next layer
-	 * @return \mako\http\Response
 	 */
 	public function execute(Request $request, Response $response, Closure $next): Response;
 }

--- a/src/mako/http/routing/middleware/SecurityHeaders.php
+++ b/src/mako/http/routing/middleware/SecurityHeaders.php
@@ -18,10 +18,8 @@ class SecurityHeaders implements MiddlewareInterface
 {
 	/**
 	 * Security headers.
-	 *
-	 * @var array
 	 */
-	protected $headers =
+	protected array $headers =
 	[
 		'X-Content-Type-Options' => 'nosniff',
 		'X-Frame-Options'        => 'sameorigin',
@@ -30,8 +28,6 @@ class SecurityHeaders implements MiddlewareInterface
 
 	/**
 	 * Returns an array containing the security headers we want to set.
-	 *
-	 * @return array
 	 */
 	protected function getHeaders(): array
 	{

--- a/src/mako/http/routing/traits/ControllerHelperTrait.php
+++ b/src/mako/http/routing/traits/ControllerHelperTrait.php
@@ -23,9 +23,6 @@ trait ControllerHelperTrait
 
 	/**
 	 * Returns a file response container.
-	 *
-	 * @param  string                           $file File path
-	 * @return \mako\http\response\senders\File
 	 */
 	protected function fileResponse(string $file): File
 	{
@@ -34,13 +31,6 @@ trait ControllerHelperTrait
 
 	/**
 	 * Returns a redirect response container.
-	 *
-	 * @param  string                               $location    Location
-	 * @param  array                                $routeParams Route parameters
-	 * @param  array                                $queryParams Associative array used to build URL-encoded query string
-	 * @param  string                               $separator   Argument separator
-	 * @param  bool|string                          $language    Request language
-	 * @return \mako\http\response\senders\Redirect
 	 */
 	protected function redirectResponse(string $location, array $routeParams = [], array $queryParams = [], string $separator = '&', bool|string $language = true): Redirect
 	{
@@ -54,11 +44,6 @@ trait ControllerHelperTrait
 
 	/**
 	 * Returns a stream response container.
-	 *
-	 * @param  \Closure                           $stream      Stream
-	 * @param  string|null                        $contentType Content type
-	 * @param  string|null                        $charset     Character set
-	 * @return \mako\http\response\senders\Stream
 	 */
 	protected function streamResponse(Closure $stream, ?string $contentType = null, ?string $charset = null): Stream
 	{
@@ -67,12 +52,6 @@ trait ControllerHelperTrait
 
 	/**
 	 * Returns a JSON response builder.
-	 *
-	 * @param  mixed                             $data    Data
-	 * @param  int                               $options JSON encode coptions
-	 * @param  int|null                          $status  Status code
-	 * @param  string|null                       $charset Character set
-	 * @return \mako\http\response\builders\JSON
 	 */
 	protected function jsonResponse(mixed $data, int $options = 0, ?int $status = null, ?string $charset = null): JSON
 	{

--- a/src/mako/http/traits/ContentNegotiationTrait.php
+++ b/src/mako/http/traits/ContentNegotiationTrait.php
@@ -20,10 +20,6 @@ trait ContentNegotiationTrait
 {
 	/**
 	 * Does the client expect the provided mime type?
-	 *
-	 * @param  array       $mimeTypes Mime types
-	 * @param  string|null $suffix    Mime type suffix
-	 * @return bool
 	 */
 	protected function expectsType(array $mimeTypes, ?string $suffix = null): bool
 	{
@@ -39,8 +35,6 @@ trait ContentNegotiationTrait
 
 	/**
 	 * Does the client expect JSON?
-	 *
-	 * @return bool
 	 */
 	protected function expectsJson(): bool
 	{
@@ -49,8 +43,6 @@ trait ContentNegotiationTrait
 
 	/**
 	 * Does the client expect XML?
-	 *
-	 * @return bool
 	 */
 	protected function expectsXml(): bool
 	{
@@ -59,10 +51,6 @@ trait ContentNegotiationTrait
 
 	/**
 	 * Should we respond with the provided mime type?
-	 *
-	 * @param  array       $mimeTypes Mime types
-	 * @param  string|null $suffix    Mime type suffix
-	 * @return bool
 	 */
 	protected function respondWithType(array $mimeTypes, ?string $suffix = null): bool
 	{
@@ -78,8 +66,6 @@ trait ContentNegotiationTrait
 
 	/**
 	 * Should we respond with JSON?
-	 *
-	 * @return bool
 	 */
 	protected function respondWithJson(): bool
 	{
@@ -88,8 +74,6 @@ trait ContentNegotiationTrait
 
 	/**
 	 * Should we respond with XML?
-	 *
-	 * @return bool
 	 */
 	protected function respondWithXml(): bool
 	{

--- a/src/mako/i18n/I18n.php
+++ b/src/mako/i18n/I18n.php
@@ -41,23 +41,16 @@ class I18n
 
 	/**
 	 * Loaded language strings.
-	 *
-	 * @var array
 	 */
-	protected $strings = [];
+	protected array $strings = [];
 
 	/**
 	 * Loaded language inflections.
-	 *
-	 * @var array
 	 */
-	protected $inflections = [];
+	protected array $inflections = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\i18n\loaders\LoaderInterface $loader   Loader instance
-	 * @param string                             $language Default language pack name
 	 */
 	public function __construct(
 		protected LoaderInterface $loader,
@@ -67,8 +60,6 @@ class I18n
 
 	/**
 	 * Returns the language loader.
-	 *
-	 * @return \mako\i18n\loaders\LoaderInterface
 	 */
 	public function getLoader(): LoaderInterface
 	{
@@ -77,8 +68,6 @@ class I18n
 
 	/**
 	 * Gets the current language.
-	 *
-	 * @return string
 	 */
 	public function getLanguage(): string
 	{
@@ -87,8 +76,6 @@ class I18n
 
 	/**
 	 * Sets the current language.
-	 *
-	 * @param string $language Name of the language pack
 	 */
 	public function setLanguage(string $language): void
 	{
@@ -97,8 +84,6 @@ class I18n
 
 	/**
 	 * Loads inflection closure and rules.
-	 *
-	 * @param string $language Name of the language pack
 	 */
 	protected function loadInflection(string $language): void
 	{
@@ -107,11 +92,6 @@ class I18n
 
 	/**
 	 * Returns the plural form of a noun.
-	 *
-	 * @param  string      $word     Noun to pluralize
-	 * @param  int|null    $count    Number of nouns
-	 * @param  string|null $language Language rules to use for pluralization
-	 * @return string
 	 */
 	public function pluralize(string $word, ?int $count = null, ?string $language = null): string
 	{
@@ -134,12 +114,6 @@ class I18n
 
 	/**
 	 * Format number according to locale or desired format.
-	 *
-	 * @param  float       $number             Number to format
-	 * @param  int         $decimals           Number of decimals
-	 * @param  string|null $decimalPoint       Decimal point
-	 * @param  string|null $thousandsSeparator Thousands separator
-	 * @return string
 	 */
 	public function number(float $number, int $decimals = 0, ?string $decimalPoint = null, ?string $thousandsSeparator = null): string
 	{
@@ -161,9 +135,6 @@ class I18n
 
 	/**
 	 * Parses the language key.
-	 *
-	 * @param  string $key Language key
-	 * @return array
 	 */
 	protected function parseKey(string $key): array
 	{
@@ -172,9 +143,6 @@ class I18n
 
 	/**
 	 * Loads all strings for the language.
-	 *
-	 * @param string $language Name of the language pack
-	 * @param string $file     File from which we are loading the strings
 	 */
 	protected function loadStrings(string $language, string $file): void
 	{
@@ -183,10 +151,6 @@ class I18n
 
 	/**
 	 * Returns all strings from the chosen language file.
-	 *
-	 * @param  string $language Name of the language pack
-	 * @param  string $file     File from which we are getting the strings
-	 * @return array
 	 */
 	protected function getStrings(string $language, string $file): array
 	{
@@ -200,10 +164,6 @@ class I18n
 
 	/**
 	 * Returns TRUE if the string exists and FALSE if not.
-	 *
-	 * @param  string      $key      String to translate
-	 * @param  string|null $language Name of the language pack
-	 * @return bool
 	 */
 	public function has(string $key, ?string $language = null): bool
 	{
@@ -221,9 +181,6 @@ class I18n
 
 	/**
 	 * Pluralize words between pluralization tags.
-	 *
-	 * @param  string $string String to parse
-	 * @return string
 	 */
 	protected function parsePluralizationTags(string $string): string
 	{
@@ -232,9 +189,6 @@ class I18n
 
 	/**
 	 * Format numbers between number tags.
-	 *
-	 * @param  string $string String to parse
-	 * @return string
 	 */
 	protected function parseNumberTags(string $string): string
 	{
@@ -243,9 +197,6 @@ class I18n
 
 	/**
 	 * Parses tags.
-	 *
-	 * @param  string $string String to parse
-	 * @return string
 	 */
 	protected function parseTags(string $string): string
 	{
@@ -264,11 +215,6 @@ class I18n
 
 	/**
 	 * Returns the chosen string from the current language.
-	 *
-	 * @param  string      $key      String to translate
-	 * @param  array       $vars     Array of values to replace in the translated text
-	 * @param  string|null $language Name of the language pack
-	 * @return string
 	 */
 	public function get(string $key, array $vars = [], ?string $language = null): string
 	{

--- a/src/mako/i18n/loaders/Loader.php
+++ b/src/mako/i18n/loaders/Loader.php
@@ -22,9 +22,6 @@ class Loader implements LoaderInterface
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\file\FileSystem $fileSystem File system instance
-	 * @param string                $path       Default path
 	 */
 	public function __construct(
 		protected FileSystem $fileSystem,

--- a/src/mako/i18n/loaders/LoaderInterface.php
+++ b/src/mako/i18n/loaders/LoaderInterface.php
@@ -14,18 +14,11 @@ interface LoaderInterface
 {
 	/**
 	 * Returns the inflection rules or NULL if they don't exist.
-	 *
-	 * @param  string     $language Name of the language pack
-	 * @return array|null
 	 */
 	public function loadInflection(string $language): ?array;
 
 	/**
 	 * Loads and returns language strings.
-	 *
-	 * @param  string $language Name of the language pack
-	 * @param  string $file     File we want to load
-	 * @return array
 	 */
 	public function loadStrings(string $language, string $file): array;
 }

--- a/src/mako/logger/Logger.php
+++ b/src/mako/logger/Logger.php
@@ -15,17 +15,10 @@ use Stringable;
  */
 class Logger implements LoggerInterface
 {
-	/**
-	 * Global logger context.
-	 *
-	 * @var array
-	 */
-	protected $context = [];
+	protected array $context = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \Psr\Log\LoggerInterface $logger Logger instance
 	 */
 	public function __construct(
 		protected LoggerInterface $logger
@@ -34,8 +27,6 @@ class Logger implements LoggerInterface
 
 	/**
 	 * Returns the underlying logger instance.
-	 *
-	 * @return \Psr\Log\LoggerInterface
 	 */
 	public function getLogger(): LoggerInterface
 	{
@@ -45,7 +36,6 @@ class Logger implements LoggerInterface
 	/**
 	 * Sets the global logger context.
 	 *
-	 * @param  array $context Context
 	 * @return $this
 	 */
 	public function setContext(array $context)
@@ -57,8 +47,6 @@ class Logger implements LoggerInterface
 
 	/**
 	 * Returns the global logger context.
-	 *
-	 * @return array
 	 */
 	public function getContext(): array
 	{

--- a/src/mako/logger/Logger.php
+++ b/src/mako/logger/Logger.php
@@ -38,7 +38,7 @@ class Logger implements LoggerInterface
 	 *
 	 * @return $this
 	 */
-	public function setContext(array $context)
+	public function setContext(array $context): static
 	{
 		$this->context = $context;
 

--- a/src/mako/onion/Onion.php
+++ b/src/mako/onion/Onion.php
@@ -22,24 +22,16 @@ class Onion
 {
 	/**
 	 * Middleware layers.
-	 *
-	 * @var array
 	 */
-	protected $layers = [];
+	protected array $layers = [];
 
 	/**
 	 * Middleware parameters.
-	 *
-	 * @var array
 	 */
-	protected $parameters = [];
+	protected array $parameters = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\syringe\Container $container         Container
-	 * @param string                  $method            Method to call on the decoracted class
-	 * @param string|null             $expectedInterface Expected middleware interface
 	 */
 	public function __construct(
 		protected Container $container = new Container,
@@ -50,11 +42,6 @@ class Onion
 
 	/**
 	 * Add a new middleware layer.
-	 *
-	 * @param  string     $class      Class
-	 * @param  array|null $parameters Middleware parameters
-	 * @param  bool       $inner      Add an inner layer?
-	 * @return int
 	 */
 	public function addLayer(string $class, ?array $parameters = null, bool $inner = true): int
 	{
@@ -65,10 +52,6 @@ class Onion
 
 	/**
 	 * Add a inner layer to the middleware stack.
-	 *
-	 * @param  string     $class      Class
-	 * @param  array|null $parameters Middleware parameters
-	 * @return int
 	 */
 	public function addInnerLayer(string $class, ?array $parameters = null): int
 	{
@@ -77,10 +60,6 @@ class Onion
 
 	/**
 	 * Add an outer layer to the middleware stack.
-	 *
-	 * @param  string     $class      Class
-	 * @param  array|null $parameters Middleware parameters
-	 * @return int
 	 */
 	public function addOuterLayer(string $class, ?array $parameters = null): int
 	{
@@ -89,9 +68,6 @@ class Onion
 
 	/**
 	 * Builds the core closure.
-	 *
-	 * @param  object   $object The object that we're decorating
-	 * @return \Closure
 	 */
 	protected function buildCoreClosure(object $object): Closure
 	{
@@ -105,10 +81,6 @@ class Onion
 
 	/**
 	 * Builds a layer closure.
-	 *
-	 * @param  object   $layer Middleware object
-	 * @param  \Closure $next  The next middleware layer
-	 * @return \Closure
 	 */
 	protected function buildLayerClosure(object $layer, Closure $next): Closure
 	{
@@ -117,10 +89,6 @@ class Onion
 
 	/**
 	 * Returns the parameters of the requested middleware.
-	 *
-	 * @param  array  $parameters Parameters array
-	 * @param  string $middleware Middleware name
-	 * @return array
 	 */
 	protected function mergeParameters(array $parameters, string $middleware): array
 	{
@@ -129,10 +97,6 @@ class Onion
 
 	/**
 	 * Middleware factory.
-	 *
-	 * @param  string $middleware Middleware class name
-	 * @param  array  $parameters Middleware parameters
-	 * @return object
 	 */
 	protected function middlewareFactory(string $middleware, array $parameters): object
 	{
@@ -158,11 +122,6 @@ class Onion
 
 	/**
 	 * Executes the middleware stack.
-	 *
-	 * @param  object $object               The object that we're decorating
-	 * @param  array  $parameters           Parameters
-	 * @param  array  $middlewareParameters Middleware parameters
-	 * @return mixed
 	 */
 	public function peel(object $object, array $parameters = [], array $middlewareParameters = []): mixed
 	{

--- a/src/mako/pagination/Pagination.php
+++ b/src/mako/pagination/Pagination.php
@@ -23,10 +23,8 @@ class Pagination implements PaginationInterface
 {
 	/**
 	 * Options.
-	 *
-	 * @var array
 	 */
-	protected $options =
+	protected array $options =
 	[
 		'page_key'       => 'page',
 		'max_page_links' => 5,
@@ -34,52 +32,38 @@ class Pagination implements PaginationInterface
 
 	/**
 	 * Number of pages.
-	 *
-	 * @var int
 	 */
-	protected $pages;
+	protected int $pages;
 
 	/**
 	 * Offset.
-	 *
-	 * @var int
 	 */
-	protected $offset;
+	protected int $offset;
 
 	/**
 	 * Request instance.
-	 *
-	 * @var \mako\http\Request|null
 	 */
-	protected $request;
+	protected Request|null $request = null;
 
 	/**
 	 * Query parameter cache.
-	 *
-	 * @var array
 	 */
-	protected $params;
+	protected array|null $params = null;
 
 	/**
 	 * URL builder instance.
-	 *
-	 * @var \mako\http\routing\URLBuilder|null
 	 */
-	protected $urlBuilder;
+	protected URLBuilder|null $urlBuilder = null;
 
 	/**
 	 * View factory instance.
-	 *
-	 * @var \mako\view\ViewFactory|null
 	 */
-	protected $viewFactory;
+	protected ViewFactory|null $viewFactory = null;
 
 	/**
 	 * Pagination.
-	 *
-	 * @var array
 	 */
-	protected $pagination = [];
+	protected array $pagination = [];
 
 	/**
 	 * {@inheritDoc}
@@ -160,8 +144,6 @@ class Pagination implements PaginationInterface
 
 	/**
 	 * Sets the request instance.
-	 *
-	 * @param \mako\http\Request $request Request
 	 */
 	public function setRequest(Request $request): void
 	{
@@ -170,8 +152,6 @@ class Pagination implements PaginationInterface
 
 	/**
 	 * Sets the URL builder instance.
-	 *
-	 * @param \mako\http\routing\URLBuilder $urlBuilder URL builder instance
 	 */
 	public function setURLBuilder(URLBuilder $urlBuilder): void
 	{
@@ -180,8 +160,6 @@ class Pagination implements PaginationInterface
 
 	/**
 	 * Sets the view factory builder instance.
-	 *
-	 * @param \mako\view\ViewFactory $viewFactory View factory instance
 	 */
 	public function setViewFactory(ViewFactory $viewFactory): void
 	{
@@ -190,9 +168,6 @@ class Pagination implements PaginationInterface
 
 	/**
 	 * Builds a url to the desired page.
-	 *
-	 * @param  int    $page Page
-	 * @return string
 	 */
 	protected function buildPageUrl(int $page): string
 	{
@@ -234,8 +209,6 @@ class Pagination implements PaginationInterface
 
 	/**
 	 * Returns data which can be serialized by json_encode().
-	 *
-	 * @return mixed
 	 */
 	public function jsonSerialize(): mixed
 	{
@@ -252,8 +225,6 @@ class Pagination implements PaginationInterface
 
 	/**
 	 * Builds and returns the pagination array.
-	 *
-	 * @return array
 	 */
 	public function pagination(): array
 	{
@@ -317,9 +288,6 @@ class Pagination implements PaginationInterface
 
 	/**
 	 * Renders and returns the pagination partial.
-	 *
-	 * @param  string $view Pagination view
-	 * @return string
 	 */
 	public function render(string $view): string
 	{

--- a/src/mako/pagination/PaginationFactory.php
+++ b/src/mako/pagination/PaginationFactory.php
@@ -20,23 +20,16 @@ class PaginationFactory implements PaginationFactoryInterface
 {
 	/**
 	 * URL builder instance.
-	 *
-	 * @var \mako\http\routing\URLBuilder|null
 	 */
-	protected $urlBuilder;
+	protected URLBuilder|null $urlBuilder = null;
 
 	/**
 	 * View factory instance.
-	 *
-	 * @var \mako\view\ViewFactory|null
 	 */
-	protected $viewFactory;
+	protected ViewFactory|null $viewFactory = null;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\http\Request $request Request
-	 * @param array              $options Options
 	 */
 	public function __construct(
 		protected Request $request,
@@ -46,8 +39,6 @@ class PaginationFactory implements PaginationFactoryInterface
 
 	/**
 	 * Sets the URL builder instance.
-	 *
-	 * @param \mako\http\routing\URLBuilder $urlBuilder URL builder instance
 	 */
 	public function setURLBuilder(URLBuilder $urlBuilder): void
 	{
@@ -56,8 +47,6 @@ class PaginationFactory implements PaginationFactoryInterface
 
 	/**
 	 * Sets the view factory builder instance.
-	 *
-	 * @param \mako\view\ViewFactory $viewFactory View factory instance
 	 */
 	public function setViewFactory(ViewFactory $viewFactory): void
 	{

--- a/src/mako/pagination/PaginationFactoryInterface.php
+++ b/src/mako/pagination/PaginationFactoryInterface.php
@@ -14,11 +14,6 @@ interface PaginationFactoryInterface
 {
 	/**
 	 * Creates and returns a pagination instance.
-	 *
-	 * @param  int                                  $items        Number of items
-	 * @param  int|null                             $itemsPerPage Number of items per page
-	 * @param  array                                $options      Pagination options
-	 * @return \mako\pagination\PaginationInterface
 	 */
 	public function create(int $items, ?int $itemsPerPage = null, array $options = []): PaginationInterface;
 }

--- a/src/mako/pagination/PaginationInterface.php
+++ b/src/mako/pagination/PaginationInterface.php
@@ -16,75 +16,51 @@ interface PaginationInterface extends JsonSerializable
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param int   $items        Number of items
-	 * @param int   $itemsPerPage Number of items per page
-	 * @param int   $currentPage  The current page
-	 * @param array $options      Pagination options
 	 */
 	public function __construct(int $items, int $itemsPerPage, int $currentPage, array $options = []);
 
 	/**
 	 * Returns the number of items.
-	 *
-	 * @return int
 	 */
 	public function items(): int;
 
 	/**
 	 * Returns the number of items per page.
-	 *
-	 * @return int
 	 */
 	public function itemsPerPage(): int;
 
 	/**
 	 * Returns the current page.
-	 *
-	 * @return int
 	 */
 	public function currentPage(): int;
 
 	/**
 	 * Returns the number pages.
-	 *
-	 * @return int
 	 */
 	public function numberOfPages(): int;
 
 	/**
 	 * Returns TRUE if we're on a valid page and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isValidPage(): bool;
 
 	/**
 	 * Returns the limit.
-	 *
-	 * @return int
 	 */
 	public function limit(): int;
 
 	/**
 	 * Returns the offset.
-	 *
-	 * @return int
 	 */
 	public function offset(): int;
 
 	/**
 	 * Returns an array representation of the pagination object.
-	 *
-	 * @return array
 	 */
 	public function toArray(): array;
 
 	/**
 	 * Returns a json representation of the pagination object.
-	 *
-	 * @param  int    $options JSON encode options
-	 * @return string
 	 */
 	public function toJson(int $options = 0): string;
 }

--- a/src/mako/pixl/Image.php
+++ b/src/mako/pixl/Image.php
@@ -101,9 +101,6 @@ class Image
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string                                   $image     Path to image file
-	 * @param \mako\pixl\processors\ProcessorInterface $processor Processor instance
 	 */
 	public function __construct(
 		protected $image,
@@ -124,11 +121,8 @@ class Image
 
 	/**
 	 * Makes sure that the quality is between 1 and 100.
-	 *
-	 * @param  int $quality Image quality
-	 * @return int
 	 */
-	protected function normalizeImageQuality($quality)
+	protected function normalizeImageQuality(int $quality): int
 	{
 		return max(min((int) $quality, 100), 1);
 	}
@@ -151,41 +145,32 @@ class Image
 
 	/**
 	 * Returns the image width in pixels.
-	 *
-	 * @return int
 	 */
-	public function getWidth()
+	public function getWidth(): int
 	{
 		return $this->processor->getWidth();
 	}
 
 	/**
 	 * Returns the image height in pixels.
-	 *
-	 * @return int
 	 */
-	public function getHeight()
+	public function getHeight(): int
 	{
 		return $this->processor->getHeight();
 	}
 
 	/**
 	 * Returns an array containing the image dimensions in pixels.
-	 *
-	 * @return array
 	 */
-	public function getDimensions()
+	public function getDimensions(): array
 	{
 		return $this->processor->getDimensions();
 	}
 
 	/**
 	 * Rotates the image using the given angle in degrees.
-	 *
-	 * @param  int              $degrees Degrees to rotate the image
-	 * @return \mako\pixl\Image
 	 */
-	public function rotate($degrees): Image
+	public function rotate(int $degrees): Image
 	{
 		$this->processor->rotate($degrees);
 
@@ -194,13 +179,8 @@ class Image
 
 	/**
 	 * Resizes the image to the chosen size.
-	 *
-	 * @param  int              $width       Width of the image
-	 * @param  int              $height      Height of the image
-	 * @param  int              $aspectRatio Aspect ratio
-	 * @return \mako\pixl\Image
 	 */
-	public function resize($width, $height = null, $aspectRatio = Image::RESIZE_IGNORE): Image
+	public function resize(int $width, ?int $height = null, int $aspectRatio = Image::RESIZE_IGNORE): Image
 	{
 		$this->processor->resize($width, $height, $aspectRatio);
 
@@ -209,14 +189,8 @@ class Image
 
 	/**
 	 * Crops the image.
-	 *
-	 * @param  int              $width  Width of the crop
-	 * @param  int              $height Height of the crop
-	 * @param  int              $x      The X coordinate of the cropped region's top left corner
-	 * @param  int              $y      The Y coordinate of the cropped region's top left corner
-	 * @return \mako\pixl\Image
 	 */
-	public function crop($width, $height, $x, $y): Image
+	public function crop(int $width, int $height, int $x, int $y): Image
 	{
 		$this->processor->crop($width, $height, $x, $y);
 
@@ -225,11 +199,8 @@ class Image
 
 	/**
 	 * Flips the image.
-	 *
-	 * @param  int              $direction Direction to flip the image
-	 * @return \mako\pixl\Image
 	 */
-	public function flip($direction = Image::FLIP_HORIZONTAL): Image
+	public function flip(int $direction = Image::FLIP_HORIZONTAL): Image
 	{
 		$this->processor->flip($direction);
 
@@ -238,13 +209,8 @@ class Image
 
 	/**
 	 * Adds a watermark to the image.
-	 *
-	 * @param  string           $file     Path to the image file
-	 * @param  int              $position Position of the watermark
-	 * @param  int              $opacity  Opacity of the watermark in percent
-	 * @return \mako\pixl\Image
 	 */
-	public function watermark($file, $position = Image::WATERMARK_TOP_LEFT, $opacity = 100): Image
+	public function watermark(string $file, int $position = Image::WATERMARK_TOP_LEFT, int $opacity = 100): Image
 	{
 		// Check if the image exists
 
@@ -266,11 +232,8 @@ class Image
 
 	/**
 	 * Adjust image brightness.
-	 *
-	 * @param  int              $level Brightness level (-100 to 100)
-	 * @return \mako\pixl\Image
 	 */
-	public function brightness($level = 50): Image
+	public function brightness(int $level = 50): Image
 	{
 		// Normalize brighness level
 
@@ -285,8 +248,6 @@ class Image
 
 	/**
 	 * Converts image to greyscale.
-	 *
-	 * @return \mako\pixl\Image
 	 */
 	public function greyscale(): Image
 	{
@@ -297,8 +258,6 @@ class Image
 
 	/**
 	 * Converts image to sepia.
-	 *
-	 * @return \mako\pixl\Image
 	 */
 	public function sepia(): Image
 	{
@@ -309,8 +268,6 @@ class Image
 
 	/**
 	 * Converts image to bitonal.
-	 *
-	 * @return \mako\pixl\Image
 	 */
 	public function bitonal(): Image
 	{
@@ -321,11 +278,8 @@ class Image
 
 	/**
 	 * Colorizes the image.
-	 *
-	 * @param  string           $color Hex code for the color
-	 * @return \mako\pixl\Image
 	 */
-	public function colorize($color): Image
+	public function colorize(string $color): Image
 	{
 		$this->processor->colorize($color);
 
@@ -344,11 +298,8 @@ class Image
 
 	/**
 	 * Pixelates the image.
-	 *
-	 * @param  int              $pixelSize Pixel size
-	 * @return \mako\pixl\Image
 	 */
-	public function pixelate($pixelSize = 10): Image
+	public function pixelate(int $pixelSize = 10): Image
 	{
 		$this->processor->pixelate($pixelSize);
 
@@ -357,8 +308,6 @@ class Image
 
 	/**
 	 * Negates the image.
-	 *
-	 * @return \mako\pixl\Image
 	 */
 	public function negate(): Image
 	{
@@ -369,12 +318,8 @@ class Image
 
 	/**
 	 * Adds a border to the image.
-	 *
-	 * @param  string           $color     Hex code for the color
-	 * @param  int              $thickness Thickness of the frame in pixels
-	 * @return \mako\pixl\Image
 	 */
-	public function border($color = '#000', $thickness = 5): Image
+	public function border(string $color = '#000', int $thickness = 5): Image
 	{
 		$this->processor->border($color, $thickness);
 
@@ -383,23 +328,16 @@ class Image
 
 	/**
 	 * Returns a string containing the image.
-	 *
-	 * @param  string $type    Image type
-	 * @param  int    $quality Image quality 1-100
-	 * @return string
 	 */
-	public function getImageBlob($type = null, $quality = 95)
+	public function getImageBlob(?string $type = null, int $quality = 95): string
 	{
 		return $this->processor->getImageBlob($type, $this->normalizeImageQuality($quality));
 	}
 
 	/**
 	 * Saves image to file.
-	 *
-	 * @param string $file    Path to the image file
-	 * @param int    $quality Image quality 1-100
 	 */
-	public function save($file = null, $quality = 95): void
+	public function save(?string $file = null, int $quality = 95): void
 	{
 		$file ??= $this->image;
 

--- a/src/mako/pixl/processors/GD.php
+++ b/src/mako/pixl/processors/GD.php
@@ -66,31 +66,23 @@ class GD implements ProcessorInterface
 
 	/**
 	 * Image resource.
-	 *
-	 * @var \GdImage|null
 	 */
-	protected $image;
+	protected GdImage|null $image = null;
 
 	/**
 	 * Image resource.
-	 *
-	 * @var \GdImage|null
 	 */
-	protected $snapshot;
+	protected GdImage|null $snapshot = null;
 
 	/**
 	 * Image info.
-	 *
-	 * @var array
 	 */
-	protected $imageInfo;
+	protected array $imageInfo = [];
 
 	/**
 	 * Do we have the imagefilter function?
-	 *
-	 * @var bool
 	 */
-	protected $hasFilters;
+	protected bool $hasFilters;
 
 	/**
 	 * Constructor.
@@ -112,11 +104,8 @@ class GD implements ProcessorInterface
 
 	/**
 	 * Collects information about the image.
-	 *
-	 * @param  string $file Path to image file
-	 * @return array
 	 */
-	protected function getImageInfo($file)
+	protected function getImageInfo(string $file): array
 	{
 		$imageInfo = getimagesize($file);
 
@@ -130,12 +119,8 @@ class GD implements ProcessorInterface
 
 	/**
 	 * Creates an image resource that we can work with.
-	 *
-	 * @param  string   $image     Path to image file
-	 * @param  array    $imageInfo Image info
-	 * @return \GdImage
 	 */
-	protected function createImageResource($image, $imageInfo): GdImage
+	protected function createImageResource(string $image, array $imageInfo): GdImage
 	{
 		return match($imageInfo[2])
 		{
@@ -148,11 +133,8 @@ class GD implements ProcessorInterface
 
 	/**
 	 * Converts HEX value to an RGB array.
-	 *
-	 * @param  string $hex HEX value
-	 * @return array
 	 */
-	protected function hexToRgb($hex)
+	protected function hexToRgb(string $hex): array
 	{
 		$hex = str_replace('#', '', $hex);
 
@@ -180,7 +162,7 @@ class GD implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function open($image): void
+	public function open(string $image): void
 	{
 		$this->imageInfo = $this->getImageInfo($image);
 
@@ -218,7 +200,7 @@ class GD implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getWidth()
+	public function getWidth(): int
 	{
 		return imagesx($this->image);
 	}
@@ -226,7 +208,7 @@ class GD implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getHeight()
+	public function getHeight(): int
 	{
 		return imagesy($this->image);
 	}
@@ -234,7 +216,7 @@ class GD implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getDimensions()
+	public function getDimensions(): array
 	{
 		return ['width' => $this->getWidth(), 'height' => $this->getHeight()];
 	}
@@ -242,7 +224,7 @@ class GD implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function rotate($degrees): void
+	public function rotate(int $degrees): void
 	{
 		$width  = imagesx($this->image);
 		$height = imagesy($this->image);
@@ -295,7 +277,7 @@ class GD implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function crop($width, $height, $x, $y): void
+	public function crop(int $width, int $height, int $x, int $y): void
 	{
 		$oldWidth  = imagesx($this->image);
 		$oldHeight = imagesy($this->image);
@@ -318,7 +300,7 @@ class GD implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function flip($direction = Image::FLIP_HORIZONTAL): void
+	public function flip(int $direction = Image::FLIP_HORIZONTAL): void
 	{
 		$width  = imagesx($this->image);
 		$height = imagesy($this->image);
@@ -358,7 +340,7 @@ class GD implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function watermark($file, $position = Image::WATERMARK_TOP_LEFT, $opacity = 100): void
+	public function watermark(string $file, int $position = Image::WATERMARK_TOP_LEFT, int $opacity = 100): void
 	{
 		$watermark = $this->createImageResource($file, $this->getImageInfo($file));
 
@@ -413,7 +395,7 @@ class GD implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function brightness($level = 50): void
+	public function brightness(int $level = 50): void
 	{
 		$level *= 2.5;
 
@@ -585,7 +567,7 @@ class GD implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function colorize($color): void
+	public function colorize(string $color): void
 	{
 		$rgb = $this->hexToRgb($color);
 
@@ -643,7 +625,7 @@ class GD implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function pixelate($pixelSize = 10): void
+	public function pixelate(int $pixelSize = 10): void
 	{
 		if($this->hasFilters)
 		{
@@ -695,7 +677,7 @@ class GD implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function border($color = '#000', $thickness = 5): void
+	public function border(string $color = '#000', int $thickness = 5): void
 	{
 		$width  = imagesx($this->image);
 		$height = imagesy($this->image);
@@ -716,7 +698,7 @@ class GD implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getImageBlob($type = null, $quality = 95)
+	public function getImageBlob(?string $type = null, int $quality = 95): string
 	{
 		$type ??= $this->imageInfo['mime'];
 
@@ -752,7 +734,7 @@ class GD implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function save($file, $quality = 95): void
+	public function save(string $file, int $quality = 95): void
 	{
 		// Get the file extension
 

--- a/src/mako/pixl/processors/ImageMagick.php
+++ b/src/mako/pixl/processors/ImageMagick.php
@@ -26,17 +26,13 @@ class ImageMagick implements ProcessorInterface
 
 	/**
 	 * Imagick instance.
-	 *
-	 * @var \Imagick
 	 */
-	protected $image;
+	protected Imagick|null $image = null;
 
 	/**
 	 * Imagick instance.
-	 *
-	 * @var \Imagick|null
 	 */
-	protected $snapshot;
+	protected Imagick|null $snapshot = null;
 
 	/**
 	 * Destructor.
@@ -56,11 +52,8 @@ class ImageMagick implements ProcessorInterface
 
 	/**
 	 * Add the hash character (#) if its missing.
-	 *
-	 * @param  string $hex HEX value
-	 * @return string
 	 */
-	public function normalizeHex($hex)
+	public function normalizeHex(string $hex): string
 	{
 		if(preg_match('/^(#?[a-f0-9]{3}){1,2}$/i', $hex) !== 1)
 		{
@@ -73,7 +66,7 @@ class ImageMagick implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function open($image): void
+	public function open(string $image): void
 	{
 		$this->image = new Imagick($image);
 	}
@@ -104,7 +97,7 @@ class ImageMagick implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getWidth()
+	public function getWidth(): int
 	{
 		return $this->image->getImageWidth();
 	}
@@ -112,7 +105,7 @@ class ImageMagick implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getHeight()
+	public function getHeight(): int
 	{
 		return $this->image->getImageHeight();
 	}
@@ -120,7 +113,7 @@ class ImageMagick implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getDimensions()
+	public function getDimensions(): array
 	{
 		return ['width' => $this->getWidth(), 'height' => $this->getHeight()];
 	}
@@ -128,7 +121,7 @@ class ImageMagick implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function rotate($degrees): void
+	public function rotate(int $degrees): void
 	{
 		$this->image->rotateImage(new ImagickPixel('none'), $degrees);
 	}
@@ -149,7 +142,7 @@ class ImageMagick implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function crop($width, $height, $x, $y): void
+	public function crop(int $width, int $height, int $x, int $y): void
 	{
 		$this->image->cropImage($width, $height, $x, $y);
 	}
@@ -157,7 +150,7 @@ class ImageMagick implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function flip($direction = Image::FLIP_HORIZONTAL): void
+	public function flip(int $direction = Image::FLIP_HORIZONTAL): void
 	{
 		if($direction ===  Image::FLIP_VERTICAL)
 		{
@@ -176,7 +169,7 @@ class ImageMagick implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function watermark($file, $position = Image::WATERMARK_TOP_LEFT, $opacity = 100): void
+	public function watermark(string $file, int $position = Image::WATERMARK_TOP_LEFT, int $opacity = 100): void
 	{
 		$watermark = new Imagick($file);
 
@@ -221,7 +214,7 @@ class ImageMagick implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function brightness($level = 50): void
+	public function brightness(int $level = 50): void
 	{
 		$this->image->modulateImage(100 + $level, 100, 100);
 	}
@@ -253,7 +246,7 @@ class ImageMagick implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function colorize($color): void
+	public function colorize(string $color): void
 	{
 		$this->image->colorizeImage($this->normalizeHex($color), 1.0);
 	}
@@ -269,7 +262,7 @@ class ImageMagick implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function pixelate($pixelSize = 10): void
+	public function pixelate(int $pixelSize = 10): void
 	{
 		$width = $this->image->getImageWidth();
 
@@ -291,7 +284,7 @@ class ImageMagick implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function border($color = '#000', $thickness = 5): void
+	public function border(string $color = '#000', int $thickness = 5): void
 	{
 		$this->image->shaveImage($thickness, $thickness);
 
@@ -301,7 +294,7 @@ class ImageMagick implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getImageBlob($type = null, $quality = 95)
+	public function getImageBlob(?string $type = null, int $quality = 95): string
 	{
 		if($type !== null)
 		{
@@ -323,7 +316,7 @@ class ImageMagick implements ProcessorInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function save($file, $quality = 95): void
+	public function save(string $file, int $quality = 95): void
 	{
 		// Set image quality
 

--- a/src/mako/pixl/processors/ProcessorInterface.php
+++ b/src/mako/pixl/processors/ProcessorInterface.php
@@ -16,10 +16,8 @@ interface ProcessorInterface
 {
 	/**
 	 * Opens the image we want to work with.
-	 *
-	 * @param string $image Path to image file
 	 */
-	public function open($image);
+	public function open(string $image);
 
 	/**
 	 * Creates a snapshot of the image resource.
@@ -33,135 +31,98 @@ interface ProcessorInterface
 
 	/**
 	 * Returns the image width in pixels.
-	 *
-	 * @return int
 	 */
-	public function getWidth();
+	public function getWidth(): int;
 
 	/**
 	 * Returns the image height in pixels.
-	 *
-	 * @return int
 	 */
-	public function getHeight();
+	public function getHeight(): int;
 
 	/**
 	 * Returns an array containing the image dimensions in pixels.
-	 *
-	 * @return array
 	 */
-	public function getDimensions();
+	public function getDimensions(): array;
 
 	/**
 	 * Rotates the image using the given angle in degrees.
-	 *
-	 * @param int $degrees Degrees to rotate the image
 	 */
-	public function rotate($degrees);
+	public function rotate(int $degrees);
 
 	/**
 	 * Resizes the image to the chosen size.
-	 *
-	 * @param int      $width       Width of the image
-	 * @param int|null $height      Height of the image
-	 * @param int      $aspectRatio Aspect ratio
 	 */
 	public function resize(int $width, ?int $height = null, int $aspectRatio = Image::RESIZE_IGNORE);
 
 	/**
 	 * Crops the image.
-	 *
-	 * @param int $width  Width of the crop
-	 * @param int $height Height of the crop
-	 * @param int $x      The X coordinate of the cropped region's top left corner
-	 * @param int $y      The Y coordinate of the cropped region's top left corner
 	 */
-	public function crop($width, $height, $x, $y);
+	public function crop(int $width, int $height, int $x, int $y): void;
 
 	/**
 	 * Flips the image.
-	 *
-	 * @param int $direction Direction to flip the image
 	 */
-	public function flip($direction = Image::FLIP_HORIZONTAL);
+	public function flip(int $direction = Image::FLIP_HORIZONTAL): void;
 
 	/**
 	 * Adds a watermark to the image.
-	 *
-	 * @param string $file     Path to the image file
-	 * @param int    $position Position of the watermark
-	 * @param int    $opacity  Opacity of the watermark in percent
 	 */
-	public function watermark($file, $position = Image::WATERMARK_TOP_LEFT, $opacity = 100);
+	public function watermark(string $file, int $position = Image::WATERMARK_TOP_LEFT, int $opacity = 100): void;
 
 	/**
 	 * Adjust image brightness.
-	 *
-	 * @param int $level Brightness level (-100 to 100)
 	 */
-	public function brightness($level = 50);
+	public function brightness(int $level = 50);
 
 	/**
 	 * Converts image to greyscale.
 	 */
-	public function greyscale();
+	public function greyscale(): void;
 
 	/**
 	 * Converts image to sepia.
 	 */
-	public function sepia();
+	public function sepia(): void;
 
 	/**
 	 * Converts image to bitonal.
 	 */
-	public function bitonal();
+	public function bitonal(): void;
 
 	/**
 	 * Colorize the image.
 	 *
 	 * @param string $color Hex value
 	 */
-	public function colorize($color);
+	public function colorize(string $color): void;
 
 	/**
 	 * Sharpens the image.
 	 */
-	public function sharpen();
+	public function sharpen(): void;
 
 	/**
 	 * Pixelates the image.
-	 *
-	 * @param int $pixelSize Pixel size
 	 */
-	public function pixelate($pixelSize = 10);
+	public function pixelate(int $pixelSize = 10);
 
 	/**
 	 * Negates the image.
 	 */
-	public function negate();
+	public function negate(): void;
 
 	/**
 	 * Adds a border to the image.
-	 *
-	 * @param string $color     Hex code for the color
-	 * @param int    $thickness Thickness of the frame in pixels
 	 */
-	public function border($color = '#000', $thickness = 5);
+	public function border(string $color = '#000', int $thickness = 5): void;
 
 	/**
 	 * Returns a string containing the image.
-	 *
-	 * @param  string $type    Image type
-	 * @param  int    $quality Image quality 1-100
-	 * @return string
 	 */
-	public function getImageBlob($type = null, $quality = 95);
+	public function getImageBlob(?string $type = null, int $quality = 95): string;
 
 	/**
 	 * Saves image to file.
-	 *
-	 * @param string $file    Path to the image file
-	 * @param int    $quality Image quality 1-100
 	 */
-	public function save($file, $quality = 95);
+	public function save(string $file, int $quality = 95): void;
 }

--- a/src/mako/pixl/processors/ProcessorInterface.php
+++ b/src/mako/pixl/processors/ProcessorInterface.php
@@ -91,8 +91,6 @@ interface ProcessorInterface
 
 	/**
 	 * Colorize the image.
-	 *
-	 * @param string $color Hex value
 	 */
 	public function colorize(string $color): void;
 

--- a/src/mako/pixl/processors/traits/CalculateNewDimensionsTrait.php
+++ b/src/mako/pixl/processors/traits/CalculateNewDimensionsTrait.php
@@ -19,13 +19,6 @@ trait CalculateNewDimensionsTrait
 {
 	/**
 	 * Calculates new image dimensions.
-	 *
-	 * @param  int      $width       Desired image width
-	 * @param  int|null $height      Desired image height
-	 * @param  int      $oldWidth    Old image width
-	 * @param  int      $oldHeight   Old image height
-	 * @param  int      $aspectRatio Aspect ratio
-	 * @return array
 	 */
 	protected function calculateNewDimensions(int $width, ?int $height, int $oldWidth, int $oldHeight, int $aspectRatio): array
 	{

--- a/src/mako/reactor/Command.php
+++ b/src/mako/reactor/Command.php
@@ -21,12 +21,12 @@ abstract class Command implements CommandInterface
 	/**
 	 * Command.
 	 */
-	protected string|null $command = null;
+	protected string $command;
 
 	/**
 	 * Command description.
 	 */
-	protected string|null $description = null;
+	protected string $description;
 
 	/**
 	 * Constructor.

--- a/src/mako/reactor/Command.php
+++ b/src/mako/reactor/Command.php
@@ -20,23 +20,16 @@ abstract class Command implements CommandInterface
 
 	/**
 	 * Command.
-	 *
-	 * @var string|null
 	 */
-	protected $command;
+	protected string|null $command = null;
 
 	/**
 	 * Command description.
-	 *
-	 * @var string|null
 	 */
-	protected $description;
+	protected string|null $description = null;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\input\Input   $input  Input
-	 * @param \mako\cli\output\Output $output Output
 	 */
 	public function __construct(
 		protected Input $input,

--- a/src/mako/reactor/CommandInterface.php
+++ b/src/mako/reactor/CommandInterface.php
@@ -28,22 +28,16 @@ interface CommandInterface
 
 	/**
 	 * Returns the command.
-	 *
-	 * @return string|null
 	 */
 	public function getCommand(): ?string;
 
 	/**
 	 * Returns the command description.
-	 *
-	 * @return string
 	 */
 	public function getDescription(): string;
 
 	/**
 	 * Returns the command arguments.
-	 *
-	 * @return array
 	 */
 	public function getArguments(): array;
 }

--- a/src/mako/reactor/Dispatcher.php
+++ b/src/mako/reactor/Dispatcher.php
@@ -19,8 +19,6 @@ class Dispatcher
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\syringe\Container $container Container
 	 */
 	public function __construct(
 		protected Container $container
@@ -29,9 +27,6 @@ class Dispatcher
 
 	/**
 	 * Resolves the command.
-	 *
-	 * @param  string                         $command Command class
-	 * @return \mako\reactor\CommandInterface
 	 */
 	protected function resolve(string $command): CommandInterface
 	{
@@ -40,9 +35,6 @@ class Dispatcher
 
 	/**
 	 * Returns arguments where null values have been removed.
-	 *
-	 * @param  array $arguments
-	 * @return array
 	 */
 	protected function filterArguments(array $arguments): array
 	{
@@ -51,10 +43,6 @@ class Dispatcher
 
 	/**
 	 * Executes the command.
-	 *
-	 * @param  \mako\reactor\CommandInterface $command   Command instance
-	 * @param  array                          $arguments Command arguments
-	 * @return mixed
 	 */
 	protected function execute(CommandInterface $command, array $arguments): mixed
 	{
@@ -63,10 +51,6 @@ class Dispatcher
 
 	/**
 	 * Dispatches the command.
-	 *
-	 * @param  string $command   Command class
-	 * @param  array  $arguments Command arguments
-	 * @return int
 	 */
 	public function dispatch(string $command, array $arguments): int
 	{

--- a/src/mako/reactor/Reactor.php
+++ b/src/mako/reactor/Reactor.php
@@ -34,32 +34,21 @@ class Reactor
 
 	/**
 	 * Dispatcher.
-	 *
-	 * @var \mako\reactor\Dispatcher
 	 */
-	protected $dispatcher;
+	protected Dispatcher $dispatcher;
 
 	/**
 	 * Commands.
-	 *
-	 * @var array
 	 */
-	protected $commands = [];
+	protected array $commands = [];
 
 	/**
 	 * Logo.
-	 *
-	 * @var string
 	 */
-	protected $logo;
+	protected string|null $logo = null;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\cli\input\Input         $input      Input
-	 * @param \mako\cli\output\Output       $output     Output
-	 * @param \mako\syringe\Container       $container  Container
-	 * @param \mako\reactor\Dispatcher|null $dispatcher Command dispatcher
 	 */
 	public function __construct(
 		protected Input $input,
@@ -73,8 +62,6 @@ class Reactor
 
 	/**
 	 * Returns the input.
-	 *
-	 * @return \mako\cli\input\Input
 	 */
 	public function getInput(): Input
 	{
@@ -83,8 +70,6 @@ class Reactor
 
 	/**
 	 * Returns the output.
-	 *
-	 * @return \mako\cli\output\Output
 	 */
 	public function getOutput(): Output
 	{
@@ -93,9 +78,6 @@ class Reactor
 
 	/**
 	 * Registers a command.
-	 *
-	 * @param string $command Command
-	 * @param string $class   Command class
 	 */
 	public function registerCommand(string $command, string $class): void
 	{
@@ -104,8 +86,6 @@ class Reactor
 
 	/**
 	 * Sets the reactor logo.
-	 *
-	 * @param string $logo ASCII logo
 	 */
 	public function setLogo(string $logo): void
 	{
@@ -136,10 +116,6 @@ class Reactor
 
 	/**
 	 * Draws information table.
-	 *
-	 * @param string $heading Table heading
-	 * @param array  $headers Table headers
-	 * @param array  $rows    Table rows
 	 */
 	protected function drawTable(string $heading, array $headers, array $rows): void
 	{
@@ -161,9 +137,6 @@ class Reactor
 
 	/**
 	 * Draws an argument table.
-	 *
-	 * @param string $heading   Table heading
-	 * @param array  $arguments Arguments
 	 */
 	protected function drawArgumentTable(string $heading, array $arguments): void
 	{
@@ -189,7 +162,7 @@ class Reactor
 	{
 		// Display basic reactor information
 
-		if(!empty($this->logo))
+		if($this->logo !== null)
 		{
 			$this->output->writeLn($this->logo);
 
@@ -213,9 +186,6 @@ class Reactor
 
 	/**
 	 * Instantiates command without calling the constructor.
-	 *
-	 * @param  string                         $class Class name
-	 * @return \mako\reactor\CommandInterface
 	 */
 	protected function instantiateCommandWithoutConstructor(string $class): CommandInterface
 	{
@@ -224,8 +194,6 @@ class Reactor
 
 	/**
 	 * Returns an array of command information.
-	 *
-	 * @return array
 	 */
 	protected function getCommands(): array
 	{
@@ -255,8 +223,6 @@ class Reactor
 
 	/**
 	 * Displays reactor info and lists all available commands.
-	 *
-	 * @return int
 	 */
 	protected function displayReactorInfoAndCommandList(): int
 	{
@@ -269,9 +235,6 @@ class Reactor
 
 	/**
 	 * Returns TRUE if the command exists and FALSE if not.
-	 *
-	 * @param  string $command Command
-	 * @return bool
 	 */
 	protected function commandExists(string $command): bool
 	{
@@ -280,9 +243,6 @@ class Reactor
 
 	/**
 	 * Displays error message for unknown commands.
-	 *
-	 * @param  string $command Command
-	 * @return int
 	 */
 	protected function unknownCommand(string $command): int
 	{
@@ -302,9 +262,6 @@ class Reactor
 
 	/**
 	 * Displays information about the chosen command.
-	 *
-	 * @param  string $command Command
-	 * @return int
 	 */
 	protected function displayCommandHelp(string $command): int
 	{
@@ -331,9 +288,6 @@ class Reactor
 
 	/**
 	 * Registers the command arguments and dispatches the command.
-	 *
-	 * @param  string $command
-	 * @return int
 	 */
 	protected function registerCommandArgumentsAndDispatch(string $command): int
 	{
@@ -350,8 +304,6 @@ class Reactor
 
 	/**
 	 * Run the reactor.
-	 *
-	 * @return int
 	 */
 	public function run(): int
 	{

--- a/src/mako/reactor/traits/CommandHelperTrait.php
+++ b/src/mako/reactor/traits/CommandHelperTrait.php
@@ -32,9 +32,6 @@ trait CommandHelperTrait
 
 	/**
 	 * Writes n newlines to output.
-	 *
-	 * @param int $lines  Number of newlines to write
-	 * @param int $writer Output writer
 	 */
 	protected function nl(int $lines = 1, int $writer = Output::STANDARD): void
 	{
@@ -43,9 +40,6 @@ trait CommandHelperTrait
 
 	/**
 	 * Writes string to output.
-	 *
-	 * @param string $string String to write
-	 * @param int    $writer Output writer
 	 */
 	protected function write(string $string, int $writer = Output::STANDARD): void
 	{
@@ -54,8 +48,6 @@ trait CommandHelperTrait
 
 	/**
 	 * Writes string to output using the error writer.
-	 *
-	 * @param string $string String to write
 	 */
 	protected function error(string $string): void
 	{
@@ -72,10 +64,6 @@ trait CommandHelperTrait
 
 	/**
 	 * Draws an alert.
-	 *
-	 * @param string $message  Message
-	 * @param string $template Alert template
-	 * @param int    $writer   Output writer
 	 */
 	protected function alert(string $message, string $template = Alert::DEFAULT, int $writer = Output::STANDARD): void
 	{
@@ -84,8 +72,6 @@ trait CommandHelperTrait
 
 	/**
 	 * Rings the terminal bell n times.
-	 *
-	 * @param int $times Number of times to ring the bell
 	 */
 	protected function bell(int $times = 1): void
 	{
@@ -94,8 +80,6 @@ trait CommandHelperTrait
 
 	/**
 	 * Counts down from n.
-	 *
-	 * @param int $from Number of seconds to count down
 	 */
 	protected function countdown(int $from = 5): void
 	{
@@ -104,11 +88,6 @@ trait CommandHelperTrait
 
 	/**
 	 * Draws a progress bar and returns a progress bar instance.
-	 *
-	 * @param  int                                  $items                Total number of items
-	 * @param  float                                $minTimeBetweenRedraw Minimum time between redraw in seconds
-	 * @param  string|null                          $prefix               Progress bar prefix
-	 * @return \mako\cli\output\helpers\ProgressBar
 	 */
 	protected function progressBar(int $items, float $minTimeBetweenRedraw = 0.1, ?string $prefix = null): ProgressBar
 	{
@@ -132,10 +111,6 @@ trait CommandHelperTrait
 
 	/**
 	 * Draws a table.
-	 *
-	 * @param array $columnNames Array of column names
-	 * @param array $rows        Array of rows
-	 * @param int   $writer      Output writer
 	 */
 	protected function table(array $columnNames, array $rows, int $writer = Output::STANDARD): void
 	{
@@ -144,10 +119,6 @@ trait CommandHelperTrait
 
 	/**
 	 * Draws an ordered list.
-	 *
-	 * @param array  $items  Items
-	 * @param string $marker Item marker
-	 * @param int    $writer Output writer
 	 */
 	protected function ol(array $items, string $marker = '<yellow>%s</yellow>.', int $writer = Output::STANDARD): void
 	{
@@ -156,10 +127,6 @@ trait CommandHelperTrait
 
 	/**
 	 * Draws an unordered list.
-	 *
-	 * @param array  $items  Items
-	 * @param string $marker Item marker
-	 * @param int    $writer Output writer
 	 */
 	protected function ul(array $items, string $marker = '<yellow>*</yellow>', int $writer = Output::STANDARD): void
 	{
@@ -168,10 +135,6 @@ trait CommandHelperTrait
 
 	/**
 	 * Writes question to output and returns boolesn value corresponding to the chosen value.
-	 *
-	 * @param  string $question Question to ask
-	 * @param  string $default  Default answer
-	 * @return bool
 	 */
 	protected function confirm(string $question, string $default = 'n')
 	{
@@ -180,10 +143,6 @@ trait CommandHelperTrait
 
 	/**
 	 * Writes question to output and returns user input.
-	 *
-	 * @param  string $question Question to ask
-	 * @param  mixed  $default  Default if no input is entered
-	 * @return mixed
 	 */
 	protected function question(string $question, mixed $default = null): mixed
 	{
@@ -192,10 +151,6 @@ trait CommandHelperTrait
 
 	/**
 	 * Prints out a list of options and returns the array key of the chosen value.
-	 *
-	 * @param  string $question Question to ask
-	 * @param  array  $options  Numeric array of options to choose from
-	 * @return int
 	 */
 	protected function select(string $question, array $options): int
 	{
@@ -204,11 +159,6 @@ trait CommandHelperTrait
 
 	/**
 	 * Writes question to output and returns hidden user input.
-	 *
-	 * @param  string $question Question to ask
-	 * @param  mixed  $default  Default if no input is entered
-	 * @param  bool   $fallback Fall back to non-hidden input?
-	 * @return mixed
 	 */
 	protected function secret(string $question, mixed $default = null, bool $fallback = false): mixed
 	{

--- a/src/mako/reactor/traits/FireTrait.php
+++ b/src/mako/reactor/traits/FireTrait.php
@@ -26,8 +26,6 @@ trait FireTrait
 {
 	/**
 	 * Returns path to the reactor executable.
-	 *
-	 * @return string
 	 */
 	protected function buildReactorPath(): string
 	{
@@ -36,11 +34,6 @@ trait FireTrait
 
 	/**
 	 * Returns command that we're going to execute.
-	 *
-	 * @param  string $command         Command
-	 * @param  bool   $background      Is it a background process?
-	 * @param  bool   $sameEnvironment Run command using the same environment?
-	 * @return string
 	 */
 	protected function buildCommand(string $command, bool $background = false, bool $sameEnvironment = true): string
 	{
@@ -71,11 +64,6 @@ trait FireTrait
 
 	/**
 	 * Runs command as a separate process and feeds output to handler.
-	 *
-	 * @param  string        $command         Command
-	 * @param  \Closure|null $handler         Output handler
-	 * @param  bool          $sameEnvironment Run command using the same environment?
-	 * @return int
 	 */
 	protected function fire(string $command, ?Closure $handler = null, bool $sameEnvironment = true): int
 	{
@@ -96,9 +84,6 @@ trait FireTrait
 
 	/**
 	 * Starts command as a background process.
-	 *
-	 * @param string $command         Command
-	 * @param bool   $sameEnvironment Run command using the same environment?
 	 */
 	protected function fireAndForget(string $command, bool $sameEnvironment = true): void
 	{

--- a/src/mako/redis/Connection.php
+++ b/src/mako/redis/Connection.php
@@ -40,45 +40,31 @@ class Connection
 
 	/**
 	 * Connection name.
-	 *
-	 * @var string|null
 	 */
-	protected $name;
+	protected string|null $name;
 
 	/**
 	 * Is the connection persistent?
-	 *
-	 * @var bool
 	 */
-	protected $isPersistent;
+	protected bool $isPersistent;
 
 	/**
 	 * Connection timeout.
-	 *
-	 * @var int
 	 */
-	protected $connectionTimeout;
+	protected int $connectionTimeout;
 
 	/**
 	 * Read/write timeout.
-	 *
-	 * @var int
 	 */
-	protected $readWriteTimeout;
+	protected int $readWriteTimeout;
 
 	/**
 	 * TCP nodelay.
-	 *
-	 * @var bool
 	 */
-	protected $tcpNodelay;
+	protected bool $tcpNodelay;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string $host    Redis host
-	 * @param int    $port    Redis port
-	 * @param array  $options Connection options
 	 */
 	public function __construct(string $host, int $port = 6379, array $options = [])
 	{
@@ -112,8 +98,6 @@ class Connection
 
 	/**
 	 * Returns the connection options.
-	 *
-	 * @return array
 	 */
 	public function getOptions(): array
 	{
@@ -130,8 +114,6 @@ class Connection
 	/**
 	 * Creates a connection to the server.
 	 *
-	 * @param  string   $host Redis host
-	 * @param  int      $port Redis port
 	 * @return resource
 	 */
 	protected function createConnection(string $host, int $port)
@@ -161,9 +143,6 @@ class Connection
 
 	/**
 	 * Appends the read error reason to the error message if possible.
-	 *
-	 * @param  string $message Error message
-	 * @return string
 	 */
 	protected function appendReadErrorReason($message): string
 	{
@@ -177,8 +156,6 @@ class Connection
 
 	/**
 	 * Gets line from the server.
-	 *
-	 * @return string
 	 */
 	public function readLine(): string
 	{
@@ -194,9 +171,6 @@ class Connection
 
 	/**
 	 * Reads n bytes from the server.
-	 *
-	 * @param  int    $bytes Number of bytes to read
-	 * @return string
 	 */
 	public function read(int $bytes): string
 	{
@@ -224,9 +198,6 @@ class Connection
 
 	/**
 	 * Writes data to the server.
-	 *
-	 * @param  string $data Data to write
-	 * @return int
 	 */
 	public function write(string $data): int
 	{

--- a/src/mako/redis/ConnectionManager.php
+++ b/src/mako/redis/ConnectionManager.php
@@ -23,9 +23,6 @@ class ConnectionManager extends BaseConnectionManager
 {
 	/**
 	 * Connects to the chosen redis configuration and returns the connection.
-	 *
-	 * @param  string            $connection Connection name
-	 * @return \mako\redis\Redis
 	 */
 	protected function connect(string $connection): Redis
 	{

--- a/src/mako/redis/Message.php
+++ b/src/mako/redis/Message.php
@@ -19,36 +19,26 @@ class Message implements Stringable
 {
 	/**
 	 * Message type.
-	 *
-	 * @var string
 	 */
-	protected $type;
+	protected string $type;
 
 	/**
 	 * Message channel.
-	 *
-	 * @var string|null
 	 */
-	protected $channel = null;
+	protected string|null $channel = null;
 
 	/**
 	 * Channel pattern.
-	 *
-	 * @var string|null
 	 */
-	protected $pattern = null;
+	protected string|null $pattern = null;
 
 	/**
 	 * Message body.
-	 *
-	 * @var string|null
 	 */
-	protected $body = null;
+	protected string|null $body = null;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array $response Response
 	 */
 	public function __construct(array $response)
 	{
@@ -57,8 +47,6 @@ class Message implements Stringable
 
 	/**
 	 * Parses the message response.
-	 *
-	 * @param array $response Response
 	 */
 	protected function parseResponse(array $response): void
 	{
@@ -93,8 +81,6 @@ class Message implements Stringable
 
 	/**
 	 * Returns the message type.
-	 *
-	 * @return string
 	 */
 	public function getType(): string
 	{
@@ -103,8 +89,6 @@ class Message implements Stringable
 
 	/**
 	 * Returns the message channel.
-	 *
-	 * @return string|null
 	 */
 	public function getChannel(): ?string
 	{
@@ -113,8 +97,6 @@ class Message implements Stringable
 
 	/**
 	 * Returns the channel pattern.
-	 *
-	 * @return string|null
 	 */
 	public function getPattern(): ?string
 	{
@@ -123,8 +105,6 @@ class Message implements Stringable
 
 	/**
 	 * Returns the message body.
-	 *
-	 * @return string|null
 	 */
 	public function getBody(): ?string
 	{
@@ -133,8 +113,6 @@ class Message implements Stringable
 
 	/**
 	 * Returns the message body.
-	 *
-	 * @return string
 	 */
 	public function __toString(): string
 	{

--- a/src/mako/redis/Redis.php
+++ b/src/mako/redis/Redis.php
@@ -331,72 +331,51 @@ class Redis
 
 	/**
 	 * RESP version the connection was created with.
-	 *
-	 * @var int
 	 */
-	protected $resp = Redis::RESP2;
+	protected int $resp = Redis::RESP2;
 
 	/**
 	 * Redis username.
-	 *
-	 * @var string
 	 */
-	protected $username;
+	protected string|null $username = null;
 
 	/**
 	 * Redis password.
-	 *
-	 * @var string
 	 */
-	protected $password;
+	protected string|null $password = null;
 
 	/**
 	 * Redis database.
-	 *
-	 * @var int
 	 */
-	protected $database;
+	protected int|null $database = null;
 
 	/**
 	 * Is pipelining enabled?
-	 *
-	 * @var bool
 	 */
-	protected $pipelined = false;
+	protected bool $pipelined = false;
 
 	/**
 	 * Pipelined commands.
-	 *
-	 * @var array
 	 */
-	protected $commands = [];
+	protected array $commands = [];
 
 	/**
 	 * Cluster clients.
-	 *
-	 * @var array
 	 */
-	protected $clusterClients = [];
+	protected array $clusterClients = [];
 
 	/**
 	 * Last command.
-	 *
-	 * @var string
 	 */
-	protected $lastCommand;
+	protected string $lastCommand;
 
 	/**
 	 * Response attributes.
-	 *
-	 * @var array
 	 */
-	protected $attributes = [];
+	protected array $attributes = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\redis\Connection $connection Redis connection
-	 * @param array                  $options    Options
 	 */
 	final public function __construct(
 		protected Connection $connection,
@@ -434,8 +413,6 @@ class Redis
 
 	/**
 	 * Returns the RESP version the connection was created with.
-	 *
-	 * @return int
 	 */
 	public function getRespVersion(): int
 	{
@@ -444,8 +421,6 @@ class Redis
 
 	/**
 	 * Returns the connection.
-	 *
-	 * @return \mako\redis\Connection
 	 */
 	public function getConnection(): Connection
 	{
@@ -454,8 +429,6 @@ class Redis
 
 	/**
 	 * Returns the cluster clients.
-	 *
-	 * @return array
 	 */
 	public function getClusterClients(): array
 	{
@@ -464,8 +437,6 @@ class Redis
 
 	/**
 	 * Returns the response attributes from the last call.
-	 *
-	 * @return array
 	 */
 	public function getAttributes(): array
 	{
@@ -474,9 +445,6 @@ class Redis
 
 	/**
 	 * Creates a cluster client.
-	 *
-	 * @param  string            $server Server string
-	 * @return \mako\redis\Redis
 	 */
 	protected function createClusterClient(string $server): Redis
 	{
@@ -493,9 +461,6 @@ class Redis
 
 	/**
 	 * Gets a cluster client.
-	 *
-	 * @param  string            $serverInfo Cluster slot and server string
-	 * @return \mako\redis\Redis
 	 */
 	protected function getClusterClient(string $serverInfo): Redis
 	{
@@ -511,9 +476,6 @@ class Redis
 
 	/**
 	 * Handles a simple string response.
-	 *
-	 * @param  string $response Redis response
-	 * @return string
 	 */
 	protected function handleSimpleStringResponse(string $response): string
 	{
@@ -522,9 +484,6 @@ class Redis
 
 	/**
 	 * Handles a blob string response.
-	 *
-	 * @param  string      $response Redis response
-	 * @return string|null
 	 */
 	protected function handleBlobStringResponse(string $response): ?string
 	{
@@ -560,9 +519,6 @@ class Redis
 
 	/**
 	 * Handles a verbatim string response.
-	 *
-	 * @param  string $response Redis response
-	 * @return string
 	 */
 	protected function handleVerbatimStringResponse(string $response): string
 	{
@@ -573,9 +529,6 @@ class Redis
 
 	/**
 	 * Handles a number response.
-	 *
-	 * @param  string $response Redis response
-	 * @return int
 	 */
 	protected function handleNumberResponse(string $response): int
 	{
@@ -584,9 +537,6 @@ class Redis
 
 	/**
 	 * Handles a double response.
-	 *
-	 * @param  string $response Redis response
-	 * @return float
 	 */
 	protected function handleDoubleResponse(string $response): float
 	{
@@ -607,9 +557,6 @@ class Redis
 
 	/**
 	 * Handles a big number response.
-	 *
-	 * @param  string $response Redis response
-	 * @return string
 	 */
 	protected function handleBigNumberResponse(string $response): string
 	{
@@ -618,9 +565,6 @@ class Redis
 
 	/**
 	 * Handles a boolean response.
-	 *
-	 * @param  string $response Redis response
-	 * @return bool
 	 */
 	protected function handleBooleanResponse(string $response): bool
 	{
@@ -634,9 +578,6 @@ class Redis
 
 	/**
 	 * Handles a array response.
-	 *
-	 * @param  string     $response Redis response
-	 * @return array|null
 	 */
 	protected function handleArrayResponse(string $response): ?array
 	{
@@ -682,9 +623,6 @@ class Redis
 
 	/**
 	 * Handles a map response.
-	 *
-	 * @param  string $response Redis response
-	 * @return array
 	 */
 	protected function handleMapResponse(string $response): array
 	{
@@ -725,9 +663,6 @@ class Redis
 
 	/**
 	 * Handles a set response.
-	 *
-	 * @param  string $response Redis response
-	 * @return array
 	 */
 	protected function handleSetResponse(string $response): array
 	{
@@ -736,9 +671,6 @@ class Redis
 
 	/**
 	 * Handles an attribute response.
-	 *
-	 * @param  string $response Redis response
-	 * @return mixed
 	 */
 	protected function handleAttributeResponse(string $response): mixed
 	{
@@ -762,9 +694,6 @@ class Redis
 
 	/**
 	 * Handles a push response.
-	 *
-	 * @param  string $response Redis response
-	 * @return array
 	 */
 	protected function handlePushResponse(string $response): array
 	{
@@ -773,9 +702,6 @@ class Redis
 
 	/**
 	 * Handles simple error responses.
-	 *
-	 * @param  string $response Redis response
-	 * @return mixed
 	 */
 	protected function handleSimpleErrorResponse(string $response): mixed
 	{
@@ -792,8 +718,6 @@ class Redis
 
 	/**
 	 * Handles blob error responses.
-	 *
-	 * @param string $response Redis response
 	 */
 	protected function handleBlobErrorResponse(string $response): void
 	{
@@ -806,8 +730,6 @@ class Redis
 
 	/**
 	 * Returns response from redis server.
-	 *
-	 * @return mixed
 	 */
 	protected function getResponse(): mixed
 	{
@@ -837,10 +759,6 @@ class Redis
 
 	/**
 	 * Builds command.
-	 *
-	 * @param  string $name      Camel cased or snake cased command name
-	 * @param  array  $arguments Command arguments
-	 * @return string
 	 */
 	protected function buildCommand(string $name, array $arguments = []): string
 	{
@@ -874,8 +792,6 @@ class Redis
 
 	/**
 	 * Sends command to server.
-	 *
-	 * @param string $command Command
 	 */
 	protected function sendCommand(string $command): void
 	{
@@ -886,9 +802,6 @@ class Redis
 
 	/**
 	 * Executes raw Redis commands and returns the response.
-	 *
-	 * @param  string $command Command
-	 * @return mixed
 	 */
 	protected function sendCommandAndGetResponse(string $command): mixed
 	{
@@ -899,12 +812,6 @@ class Redis
 
 	/**
 	 * Subscribes to the chosen channels.
-	 *
-	 * @param array    $channels    Channels
-	 * @param \Closure $subscriber  Subscriber
-	 * @param array    $accept      Message types to accept
-	 * @param string   $subscribe   Subscribe command
-	 * @param string   $unsubscribe Unsubscribe command
 	 */
 	protected function subscribe(array $channels, Closure $subscriber, array $accept, string $subscribe, string $unsubscribe): void
 	{
@@ -930,10 +837,6 @@ class Redis
 
 	/**
 	 * Subscribes to the chosen channels.
-	 *
-	 * @param array    $channels   Channels
-	 * @param \Closure $subscriber Subscriber
-	 * @param array    $accept     Message types to accept
 	 */
 	public function subscribeTo(array $channels, Closure $subscriber, array $accept = ['message']): void
 	{
@@ -942,10 +845,6 @@ class Redis
 
 	/**
 	 * Subscribes to the chosen channels.
-	 *
-	 * @param array    $channels   Channels
-	 * @param \Closure $subscriber Subscriber
-	 * @param array    $accept     Message types to accept
 	 */
 	public function subscribeToPattern(array $channels, Closure $subscriber, array $accept = ['pmessage']): void
 	{
@@ -954,8 +853,6 @@ class Redis
 
 	/**
 	 * Monitors the redis server.
-	 *
-	 * @param \Closure $monitor Monitor closure
 	 */
 	public function monitor(Closure $monitor): void
 	{
@@ -974,9 +871,6 @@ class Redis
 
 	/**
 	 * Pipeline commands.
-	 *
-	 * @param  \Closure $pipeline Pipelined commands
-	 * @return array
 	 */
 	public function pipeline(Closure $pipeline): array
 	{
@@ -1019,10 +913,6 @@ class Redis
 	/**
 	 * Sends command to Redis server and returns response
 	 * or appends command to the pipeline and returns the client.
-	 *
-	 * @param  string $name      Method name
-	 * @param  array  $arguments Method arguments
-	 * @return mixed
 	 */
 	public function __call(string $name, array $arguments): mixed
 	{

--- a/src/mako/security/Key.php
+++ b/src/mako/security/Key.php
@@ -20,9 +20,6 @@ class Key
 {
 	/**
 	 * Converts a binary key into its hexadecimal representation.
-	 *
-	 * @param  string $key Binary key
-	 * @return string
 	 */
 	public static function encode(string $key): string
 	{
@@ -31,9 +28,6 @@ class Key
 
 	/**
 	 * Converts a hexadecimal key into its binary representation.
-	 *
-	 * @param  string $key Encoded key
-	 * @return string
 	 */
 	public static function decode(string $key): string
 	{
@@ -46,10 +40,7 @@ class Key
 	}
 
 	/**
-	 * Generates a key.
-	 *
-	 * @param  int    $length Key length
-	 * @return string
+	 * Generates a binary key.
 	 */
 	public static function generate(int $length = 32): string
 	{
@@ -58,9 +49,6 @@ class Key
 
 	/**
 	 * Generates a hex encoded key.
-	 *
-	 * @param  int    $length Key length
-	 * @return string
 	 */
 	public static function generateEncoded(int $length = 32): string
 	{

--- a/src/mako/security/Signer.php
+++ b/src/mako/security/Signer.php
@@ -41,9 +41,6 @@ class Signer
 
 	/**
 	 * Returns a signed string.
-	 *
-	 * @param  string $string The string you want to sign
-	 * @return string
 	 */
 	public function sign(string $string): string
 	{
@@ -53,7 +50,6 @@ class Signer
 	/**
 	 * Returns the original string if the signature is valid or FALSE if not.
 	 *
-	 * @param  string       $string The string you want to validate
 	 * @return false|string
 	 */
 	public function validate(string $string)

--- a/src/mako/security/Signer.php
+++ b/src/mako/security/Signer.php
@@ -25,8 +25,6 @@ class Signer
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string $secret Secret used to sign and validate strings
 	 */
 	public function __construct(
 		protected string $secret
@@ -35,9 +33,6 @@ class Signer
 
 	/**
 	 * Returns the signature.
-	 *
-	 * @param  string $string The string you want to sign
-	 * @return string
 	 */
 	protected function getSignature(string $string): string
 	{

--- a/src/mako/security/crypto/Crypto.php
+++ b/src/mako/security/crypto/Crypto.php
@@ -17,7 +17,7 @@ use mako\security\Signer;
 class Crypto
 {
 	/**
-	 * Constructor.                             $signer  signer instance.
+	 * Constructor.
 	 */
 	public function __construct(
 		protected EncrypterInterface $adapter,

--- a/src/mako/security/crypto/Crypto.php
+++ b/src/mako/security/crypto/Crypto.php
@@ -17,10 +17,7 @@ use mako\security\Signer;
 class Crypto
 {
 	/**
-	 * Constructor.
-	 *
-	 * @param \mako\security\crypto\encrypters\EncrypterInterface $adapter Crypto adapter
-	 * @param \mako\security\Signer                               $signer  signer instance
+	 * Constructor.                             $signer  signer instance.
 	 */
 	public function __construct(
 		protected EncrypterInterface $adapter,
@@ -30,9 +27,6 @@ class Crypto
 
 	/**
 	 * Encrypts string.
-	 *
-	 * @param  string $string String to encrypt
-	 * @return string
 	 */
 	public function encrypt(string $string): string
 	{
@@ -42,7 +36,6 @@ class Crypto
 	/**
 	 * Decrypts string.
 	 *
-	 * @param  string       $string String to decrypt
 	 * @return false|string
 	 */
 	public function decrypt(string $string)

--- a/src/mako/security/crypto/CryptoManager.php
+++ b/src/mako/security/crypto/CryptoManager.php
@@ -27,9 +27,6 @@ class CryptoManager extends AdapterManager
 {
 	/**
 	 * OpenSSL encrypter factory.
-	 *
-	 * @param  array                                    $configuration Configuration
-	 * @return \mako\security\crypto\encrypters\OpenSSL
 	 */
 	protected function opensslFactory(array $configuration): OpenSSL
 	{
@@ -38,9 +35,6 @@ class CryptoManager extends AdapterManager
 
 	/**
 	 * Returns a crypto instance.
-	 *
-	 * @param  string                       $configuration Configuration name
-	 * @return \mako\security\crypto\Crypto
 	 */
 	protected function instantiate(string $configuration): Crypto
 	{
@@ -56,9 +50,6 @@ class CryptoManager extends AdapterManager
 
 	/**
 	 * Returns an instance of the chosen encrypter. Alias of CryptoManager::getInstance().
-	 *
-	 * @param  string|null                                         $configuration Configuration name
-	 * @return \mako\security\crypto\encrypters\EncrypterInterface
 	 */
 	public function getEncrypter(?string $configuration = null): EncrypterInterface
 	{

--- a/src/mako/security/crypto/encrypters/Encrypter.php
+++ b/src/mako/security/crypto/encrypters/Encrypter.php
@@ -30,11 +30,6 @@ abstract class Encrypter
 
 	/**
 	 * Generate a PBKDF2 key derivation of a supplied key.
-	 *
-	 * @param  string $key     The key to derive
-	 * @param  string $salt    The salt
-	 * @param  int    $keySize The desired key size
-	 * @return string
 	 */
 	protected function deriveKey(string $key, string $salt, int $keySize): string
 	{

--- a/src/mako/security/crypto/encrypters/EncrypterInterface.php
+++ b/src/mako/security/crypto/encrypters/EncrypterInterface.php
@@ -14,16 +14,12 @@ interface EncrypterInterface
 {
 	/**
 	 * Encrypts string.
-	 *
-	 * @param  string $string String to encrypt
-	 * @return string
 	 */
 	public function encrypt(string $string): string;
 
 	/**
 	 * Decrypts string.
 	 *
-	 * @param  string       $string String to decrypt
 	 * @return false|string
 	 */
 	public function decrypt(string $string);

--- a/src/mako/security/crypto/encrypters/OpenSSL.php
+++ b/src/mako/security/crypto/encrypters/OpenSSL.php
@@ -22,16 +22,11 @@ class OpenSSL extends Encrypter implements EncrypterInterface
 {
 	/**
 	 * Initialization vector size.
-	 *
-	 * @var int
 	 */
-	protected $ivSize;
+	protected int $ivSize;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string $key    Encryption key
-	 * @param string $cipher The cipher method to use for encryption
 	 */
 	public function __construct(
 		protected string $key,

--- a/src/mako/security/password/Hasher.php
+++ b/src/mako/security/password/Hasher.php
@@ -21,15 +21,11 @@ abstract class Hasher implements HasherInterface
 {
 	/**
 	 * Algorithm options.
-	 *
-	 * @var array
 	 */
-	protected $options;
+	protected array $options;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array $options algorithm options
 	 */
 	public function __construct(array $options = [])
 	{
@@ -38,9 +34,6 @@ abstract class Hasher implements HasherInterface
 
 	/**
 	 * Normalizes the algorithm options.
-	 *
-	 * @param  array $options Algorithm options
-	 * @return array
 	 */
 	protected function normalizeOptions(array $options): array
 	{
@@ -49,8 +42,6 @@ abstract class Hasher implements HasherInterface
 
 	/**
 	 * Returns the algorithm type.
-	 *
-	 * @return string|null
 	 */
 	abstract protected function getAlgorithm(): ?string;
 

--- a/src/mako/security/password/HasherInterface.php
+++ b/src/mako/security/password/HasherInterface.php
@@ -14,26 +14,16 @@ interface HasherInterface
 {
 	/**
 	 * Creates a password hash.
-	 *
-	 * @param  string $password Password
-	 * @return string
 	 */
 	public function create(string $password): string;
 
 	/**
 	 * Verifies that the password matches the hash.
-	 *
-	 * @param  string $password Password
-	 * @param  string $hash     Hash
-	 * @return bool
 	 */
 	public function verify(string $password, string $hash): bool;
 
 	/**
 	 * Returns TRUE if the password needs rehashing and FALSE if not.
-	 *
-	 * @param  string $hash Hash
-	 * @return bool
 	 */
 	public function needsRehash(string $hash): bool;
 }

--- a/src/mako/session/Session.php
+++ b/src/mako/session/Session.php
@@ -59,7 +59,7 @@ class Session
 	/**
 	 * Session id.
 	 */
-	protected string|null $sessionId = null;
+	protected string $sessionId;
 
 	/**
 	 * Session data.
@@ -67,14 +67,14 @@ class Session
 	protected array $sessionData = [];
 
 	/**
+	 * Session token.
+	 */
+	protected string $token;
+
+	/**
 	 * Flashdata.
 	 */
 	protected array $flashData = [];
-
-	/**
-	 * Session token.
-	 */
-	protected string|null $token = null;
 
 	/**
 	 * Constructor.

--- a/src/mako/session/Session.php
+++ b/src/mako/session/Session.php
@@ -36,17 +36,13 @@ class Session
 
 	/**
 	 * Has the session been destroyed?
-	 *
-	 * @var bool
 	 */
-	protected $destroyed = false;
+	protected bool $destroyed = false;
 
 	/**
 	 * Session options.
-	 *
-	 * @var array
 	 */
-	protected $options =
+	protected array $options =
 	[
 		'name'           => 'mako_session',
 		'data_ttl'       => 1800,
@@ -62,40 +58,26 @@ class Session
 
 	/**
 	 * Session id.
-	 *
-	 * @var string
 	 */
-	protected $sessionId;
+	protected string|null $sessionId = null;
 
 	/**
 	 * Session data.
-	 *
-	 * @var array
 	 */
-	protected $sessionData = [];
+	protected array $sessionData = [];
 
 	/**
 	 * Flashdata.
-	 *
-	 * @var array
 	 */
-	protected $flashData = [];
+	protected array $flashData = [];
 
 	/**
 	 * Session token.
-	 *
-	 * @var string
 	 */
-	protected $token;
+	protected string|null $token = null;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\http\Request                  $request    Request instance
-	 * @param \mako\http\Response                 $response   Response instance
-	 * @param \mako\session\stores\StoreInterface $store      Session store instance
-	 * @param array                               $options    Session options
-	 * @param bool                                $autoCommit Should the session data be commited automatically?
 	 */
 	public function __construct(
 		protected Request $request,
@@ -130,12 +112,7 @@ class Session
 	{
 		// Get the session id from the cookie or generate a new one if it doesn't exist.
 
-		$this->sessionId = $this->request->getCookies()->getSigned($this->options['name'], false);
-
-		if($this->sessionId === false)
-		{
-			$this->sessionId = $this->generateId();
-		}
+		$this->sessionId = $this->request->getCookies()->getSigned($this->options['name'], false) ?: $this->generateId();
 
 		// Create a new / update the existing session cookie
 
@@ -201,8 +178,6 @@ class Session
 
 	/**
 	 * Generates a session id.
-	 *
-	 * @return string
 	 */
 	protected function generateId(): string
 	{
@@ -232,8 +207,6 @@ class Session
 
 	/**
 	 * Returns the session id.
-	 *
-	 * @return string
 	 */
 	public function getId(): string
 	{
@@ -242,9 +215,6 @@ class Session
 
 	/**
 	 * Regenerate the session id and returns it.
-	 *
-	 * @param  bool   $keepOld Keep the session data associated with the old session id?
-	 * @return string
 	 */
 	public function regenerateId(bool $keepOld = false): string
 	{
@@ -268,8 +238,6 @@ class Session
 
 	/**
 	 * Returns all the seesion data.
-	 *
-	 * @return array
 	 */
 	public function getData(): array
 	{
@@ -278,9 +246,6 @@ class Session
 
 	/**
 	 * Store a value in the session.
-	 *
-	 * @param string $key   Session key
-	 * @param mixed  $value Session data
 	 */
 	public function put(string $key, mixed $value): void
 	{
@@ -289,9 +254,6 @@ class Session
 
 	/**
 	 * Returns TRUE if key exists in the session and FALSE if not.
-	 *
-	 * @param  string $key Session key
-	 * @return bool
 	 */
 	public function has(string $key): bool
 	{
@@ -300,10 +262,6 @@ class Session
 
 	/**
 	 * Returns a value from the session.
-	 *
-	 * @param  string $key     Session key
-	 * @param  mixed  $default Default value
-	 * @return mixed
 	 */
 	public function get(string $key, mixed $default = null): mixed
 	{
@@ -312,11 +270,6 @@ class Session
 
 	/**
 	 * Gets a value from the session and replaces it.
-	 *
-	 * @param  string $key     Session key
-	 * @param  mixed  $value   Session data
-	 * @param  mixed  $default Default value
-	 * @return mixed
 	 */
 	public function getAndPut(string $key, mixed $value, mixed $default = null): mixed
 	{
@@ -329,10 +282,6 @@ class Session
 
 	/**
 	 * Gets a value from the session and removes it.
-	 *
-	 * @param  string $key     Session key
-	 * @param  mixed  $default Default value
-	 * @return mixed
 	 */
 	public function getAndRemove(string $key, mixed $default = null): mixed
 	{
@@ -345,8 +294,6 @@ class Session
 
 	/**
 	 * Removes a value from the session.
-	 *
-	 * @param string $key Session key
 	 */
 	public function remove(string $key): void
 	{
@@ -355,9 +302,6 @@ class Session
 
 	/**
 	 * Store a flash value in the session.
-	 *
-	 * @param string $key   Flash key
-	 * @param mixed  $value Flash data
 	 */
 	public function putFlash(string $key, mixed $value): void
 	{
@@ -366,9 +310,6 @@ class Session
 
 	/**
 	 * Returns TRUE if key exists in the session and FALSE if not.
-	 *
-	 * @param  string $key Session key
-	 * @return bool
 	 */
 	public function hasFlash(string $key): bool
 	{
@@ -377,10 +318,6 @@ class Session
 
 	/**
 	 * Returns a flash value from the session.
-	 *
-	 * @param  string $key     Session key
-	 * @param  mixed  $default Default value
-	 * @return mixed
 	 */
 	public function getFlash(string $key, mixed $default = null): mixed
 	{
@@ -389,8 +326,6 @@ class Session
 
 	/**
 	 * Removes a value from the session.
-	 *
-	 * @param string $key Session key
 	 */
 	public function removeFlash(string $key): void
 	{
@@ -399,8 +334,6 @@ class Session
 
 	/**
 	 * Extends the lifetime of the flash data by one request.
-	 *
-	 * @param array $keys Keys to preserve
 	 */
 	public function reflash(array $keys = []): void
 	{
@@ -413,8 +346,6 @@ class Session
 
 	/**
 	 * Returns the session token.
-	 *
-	 * @return string
 	 */
 	public function getToken(): string
 	{
@@ -423,8 +354,6 @@ class Session
 
 	/**
 	 * Generates a new session token and returns it.
-	 *
-	 * @return string
 	 */
 	public function regenerateToken(): string
 	{
@@ -433,9 +362,6 @@ class Session
 
 	/**
 	 * Validates the provided token.
-	 *
-	 * @param  string $token Token to validate
-	 * @return bool
 	 */
 	public function validateToken(string $token): bool
 	{
@@ -444,8 +370,6 @@ class Session
 
 	/**
 	 * Returns random security token.
-	 *
-	 * @return string
 	 */
 	public function generateOneTimeToken(): string
 	{
@@ -467,9 +391,6 @@ class Session
 
 	/**
 	 * Validates security token.
-	 *
-	 * @param  string $token Security token
-	 * @return bool
 	 */
 	public function validateOneTimeToken(string $token): bool
 	{

--- a/src/mako/session/stores/Database.php
+++ b/src/mako/session/stores/Database.php
@@ -21,10 +21,6 @@ class Database implements StoreInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\database\connections\Connection $connection     Database connection
-	 * @param string                                $table          Database table
-	 * @param array|bool                            $classWhitelist Class whitelist
 	 */
 	public function __construct(
 		protected Connection $connection,
@@ -35,8 +31,6 @@ class Database implements StoreInterface
 
 	/**
 	 * Returns a query builder instance.
-	 *
-	 * @return \mako\database\query\Query
 	 */
 	protected function table(): Query
 	{

--- a/src/mako/session/stores/File.php
+++ b/src/mako/session/stores/File.php
@@ -21,10 +21,6 @@ class File implements StoreInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\file\FileSystem $fileSystem     File system instance
-	 * @param string                $sessionPath    Session path
-	 * @param array|bool            $classWhitelist Class whitelist
 	 */
 	public function __construct(
 		protected FileSystem $fileSystem,
@@ -35,9 +31,6 @@ class File implements StoreInterface
 
 	/**
 	 * Returns the path to the session file.
-	 *
-	 * @param  string $sessionId Session id
-	 * @return string
 	 */
 	protected function sessionFile(string $sessionId): string
 	{

--- a/src/mako/session/stores/Redis.php
+++ b/src/mako/session/stores/Redis.php
@@ -19,9 +19,6 @@ class Redis implements StoreInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\redis\Redis $redis          Redis client
-	 * @param array|bool        $classWhitelist Class whitelist
 	 */
 	public function __construct(
 		protected RedisClient $redis,

--- a/src/mako/session/stores/StoreInterface.php
+++ b/src/mako/session/stores/StoreInterface.php
@@ -14,32 +14,21 @@ interface StoreInterface
 {
 	/**
 	 * Writes session data.
-	 *
-	 * @param string $sessionId   Session id
-	 * @param array  $sessionData Session data
-	 * @param int    $dataTTL     TTL in seconds
 	 */
 	public function write(string $sessionId, array $sessionData, int $dataTTL): void;
 
 	/**
 	 * Reads and returns session data.
-	 *
-	 * @param  string $sessionId Session id
-	 * @return array
 	 */
 	public function read(string $sessionId): array;
 
 	/**
 	 * Destroys the session data assiciated with the provided id.
-	 *
-	 * @param string $sessionId Session id
 	 */
 	public function delete(string $sessionId): void;
 
 	/**
 	 * Garbage collector that deletes expired session data.
-	 *
-	 * @param int $dataTTL Data TTL in seconds
 	 */
 	public function gc(int $dataTTL): void;
 }

--- a/src/mako/syringe/Container.php
+++ b/src/mako/syringe/Container.php
@@ -32,44 +32,31 @@ class Container
 {
 	/**
 	 * Registered type hints.
-	 *
-	 * @var array
 	 */
-	protected $hints = [];
+	protected array $hints = [];
 
 	/**
 	 * Aliases.
-	 *
-	 * @var array
 	 */
-	protected $aliases = [];
+	protected array $aliases = [];
 
 	/**
 	 * Singleton instances.
-	 *
-	 * @var array
 	 */
-	protected $instances = [];
+	protected array $instances = [];
 
 	/**
 	 * Contextual dependencies.
-	 *
-	 * @var array
 	 */
-	protected $contextualDependencies = [];
+	protected array $contextualDependencies = [];
 
 	/**
 	 * Instance replacers.
-	 *
-	 * @var array
 	 */
-	protected $replacers = [];
+	protected array $replacers = [];
 
 	/**
 	 * Parse the hint parameter.
-	 *
-	 * @param  array|string $hint Type hint or array contaning both type hint and alias
-	 * @return string
 	 */
 	protected function parseHint(array|string $hint): string
 	{
@@ -85,10 +72,6 @@ class Container
 
 	/**
 	 * Register a type hint.
-	 *
-	 * @param array|string    $hint      Type hint or array contaning both type hint and alias
-	 * @param \Closure|string $class     Class name or closure
-	 * @param bool            $singleton Should we return the same instance every time?
 	 */
 	public function register(array|string $hint, Closure|string $class, bool $singleton = false): void
 	{
@@ -97,9 +80,6 @@ class Container
 
 	/**
 	 * Register a type hint and return the same instance every time.
-	 *
-	 * @param array|string    $hint  Type hint or array contaning both type hint and alias
-	 * @param \Closure|string $class Class name or closure
 	 */
 	public function registerSingleton(array|string $hint, Closure|string $class): void
 	{
@@ -108,9 +88,6 @@ class Container
 
 	/**
 	 * Register a singleton instance.
-	 *
-	 * @param array|string $hint     Type hint or array contaning both type hint and alias
-	 * @param object       $instance Class instance
 	 */
 	public function registerInstance(array|string $hint, object $instance): void
 	{
@@ -119,10 +96,6 @@ class Container
 
 	/**
 	 * Registers a contextual dependency.
-	 *
-	 * @param array|string $dependent      Class name or an array containing a class and method name
-	 * @param string       $interface      Interface name
-	 * @param string       $implementation Implementation name
 	 */
 	public function registerContextualDependency(array|string $dependent, string $interface, string $implementation): void
 	{
@@ -136,9 +109,6 @@ class Container
 
 	/**
 	 * Return the name based on its alias. If no alias exists then we'll just return the value we received.
-	 *
-	 * @param  string $alias Alias
-	 * @return string
 	 */
 	protected function resolveAlias(string $alias): string
 	{
@@ -147,8 +117,6 @@ class Container
 
 	/**
 	 * Replaces previously resolved instances.
-	 *
-	 * @param string $hint Type hint
 	 */
 	protected function replaceInstances(string $hint): void
 	{
@@ -165,10 +133,6 @@ class Container
 
 	/**
 	 * Registers replacers.
-	 *
-	 * @param string      $hint      Type hint
-	 * @param callable    $replacer  Instance replacer
-	 * @param string|null $eventName Event name
 	 */
 	public function onReplace(string $hint, callable $replacer, ?string $eventName = null): void
 	{
@@ -179,10 +143,6 @@ class Container
 
 	/**
 	 * Replaces a registered type hint.
-	 *
-	 * @param string          $hint      Type hint
-	 * @param \Closure|string $class     Class name or closure
-	 * @param bool            $singleton Are we replacing a singleton?
 	 */
 	public function replace(string $hint, Closure|string $class, bool $singleton = false): void
 	{
@@ -205,9 +165,6 @@ class Container
 
 	/**
 	 * Replaces a registered singleton type hint.
-	 *
-	 * @param string          $hint  Type hint
-	 * @param \Closure|string $class Class name or closure
 	 */
 	public function replaceSingleton(string $hint, Closure|string $class): void
 	{
@@ -216,9 +173,6 @@ class Container
 
 	/**
 	 * Replaces a singleton instance.
-	 *
-	 * @param string $hint     Type hint
-	 * @param object $instance Class instance
 	 */
 	public function replaceInstance(string $hint, object $instance): void
 	{
@@ -236,9 +190,6 @@ class Container
 
 	/**
 	 * Resolves a type hint.
-	 *
-	 * @param  string          $hint Type hint
-	 * @return \Closure|string
 	 */
 	protected function resolveHint(string $hint): Closure|string
 	{
@@ -247,10 +198,6 @@ class Container
 
 	/**
 	 * Resolves a contextual dependency.
-	 *
-	 * @param  string $dependent Class name or class name and method name separated by a double colon
-	 * @param  string $interface Interface
-	 * @return string
 	 */
 	protected function resolveContextualDependency(string $dependent, string $interface): string
 	{
@@ -259,10 +206,6 @@ class Container
 
 	/**
 	 * Merges the provided parameters with the reflection parameters.
-	 *
-	 * @param  array $reflectionParameters Reflection parameters
-	 * @param  array $providedParameters   Provided parameters
-	 * @return array
 	 */
 	protected function mergeParameters(array $reflectionParameters, array $providedParameters): array
 	{
@@ -291,9 +234,6 @@ class Container
 
 	/**
 	 * Returns the name of the declaring function.
-	 *
-	 * @param  \ReflectionParameter $parameter ReflectionParameter instance
-	 * @return string
 	 */
 	protected function getDeclaringFunction(ReflectionParameter $parameter): string
 	{
@@ -314,11 +254,6 @@ class Container
 
 	/**
 	 * Resolve a parameter.
-	 *
-	 * @param  \ReflectionParameter  $parameter ReflectionParameter instance
-	 * @param  \ReflectionClass|null $class     ReflectionClass instance
-	 * @param  string|null           $method    Metod name
-	 * @return mixed
 	 */
 	protected function resolveParameter(ReflectionParameter $parameter, ?ReflectionClass $class = null, ?string $method = null): mixed
 	{
@@ -371,12 +306,6 @@ class Container
 
 	/**
 	 * Resolve parameters.
-	 *
-	 * @param  array                 $reflectionParameters Reflection parameters
-	 * @param  array                 $providedParameters   Provided Parameters
-	 * @param  \ReflectionClass|null $class                ReflectionClass instance
-	 * @param  string|null           $method               Method name
-	 * @return array
 	 */
 	protected function resolveParameters(array $reflectionParameters, array $providedParameters, ?ReflectionClass $class = null, ?string $method = null): array
 	{
@@ -406,9 +335,6 @@ class Container
 
 	/**
 	 * Checks if a class is container aware.
-	 *
-	 * @param  object $class Class instance
-	 * @return bool
 	 */
 	protected function isContainerAware(object $class): bool
 	{
@@ -419,10 +345,6 @@ class Container
 
 	/**
 	 * Creates a class instance using a factory closure.
-	 *
-	 * @param  \Closure $factory    Class name or closure
-	 * @param  array    $parameters Constructor parameters
-	 * @return object
 	 */
 	protected function closureFactory(Closure $factory, array $parameters): object
 	{
@@ -433,10 +355,6 @@ class Container
 
 	/**
 	 * Creates a class instance using reflection.
-	 *
-	 * @param  string $class      Class name
-	 * @param  array  $parameters Constructor parameters
-	 * @return object
 	 */
 	protected function reflectionFactory(string $class, array $parameters): object
 	{
@@ -467,10 +385,6 @@ class Container
 
 	/**
 	 * Creates a class instance.
-	 *
-	 * @param  \Closure|string $class      Class name or closure
-	 * @param  array           $parameters Constructor parameters
-	 * @return object
 	 */
 	public function factory(Closure|string $class, array $parameters = []): object
 	{
@@ -499,9 +413,6 @@ class Container
 
 	/**
 	 * Returns TRUE if the class is registered in the container and FALSE if not.
-	 *
-	 * @param  string $class Class name
-	 * @return bool
 	 */
 	public function has(string $class): bool
 	{
@@ -512,9 +423,6 @@ class Container
 
 	/**
 	 * Returns TRUE if there's an instance of the class in the container and FALSE if not.
-	 *
-	 * @param  string $class Class name
-	 * @return bool
 	 */
 	public function hasInstanceOf(string $class): bool
 	{
@@ -523,9 +431,6 @@ class Container
 
 	/**
 	 * Returns TRUE if a class has been registered as a singleton and FALSE if not.
-	 *
-	 * @param  string $class Class name
-	 * @return bool
 	 */
 	public function isSingleton(string $class): bool
 	{
@@ -536,11 +441,6 @@ class Container
 
 	/**
 	 * Returns a class instance.
-	 *
-	 * @param  string $class         Class name
-	 * @param  array  $parameters    Constructor parameters
-	 * @param  bool   $reuseInstance Reuse existing instance?
-	 * @return object
 	 */
 	public function get(string $class, array $parameters = [], bool $reuseInstance = true): object
 	{
@@ -571,10 +471,6 @@ class Container
 
 	/**
 	 * Returns a fresh class instance even if the class is registered as a singleton.
-	 *
-	 * @param  string $class      Class name
-	 * @param  array  $parameters Constructor parameters
-	 * @return object
 	 */
 	public function getFresh(string $class, array $parameters = []): object
 	{
@@ -583,10 +479,6 @@ class Container
 
 	/**
 	 * Execute a callable and inject its dependencies.
-	 *
-	 * @param  callable $callable   Callable
-	 * @param  array    $parameters Parameters
-	 * @return mixed
 	 */
 	public function call(callable $callable, array $parameters = []): mixed
 	{

--- a/src/mako/syringe/traits/ContainerAwareTrait.php
+++ b/src/mako/syringe/traits/ContainerAwareTrait.php
@@ -47,22 +47,16 @@ trait ContainerAwareTrait
 {
 	/**
 	 * Container.
-	 *
-	 * @var \mako\syringe\Container
 	 */
-	protected $container;
+	protected Container $container;
 
 	/**
 	 * Array of resolved objects and/or references to resolved objects.
-	 *
-	 * @var array
 	 */
-	protected $resolved = [];
+	protected array $__resolved__ = [];
 
 	/**
 	 * Sets the container instance.
-	 *
-	 * @param \mako\syringe\Container $container Container
 	 */
 	public function setContainer(Container $container): void
 	{
@@ -71,15 +65,12 @@ trait ContainerAwareTrait
 
 	/**
 	 * Resolves item from the container using overloading.
-	 *
-	 * @param  string $key Key
-	 * @return mixed
 	 */
 	public function __get(string $key): mixed
 	{
-		if(isset($this->resolved[$key]))
+		if(isset($this->__resolved__[$key]))
 		{
-			return $this->resolved[$key];
+			return $this->__resolved__[$key];
 		}
 
 		if($this->container->has($key) === false)
@@ -94,6 +85,6 @@ trait ContainerAwareTrait
 			return $resolved;
 		}
 
-		return $this->resolved[$key] = $resolved;
+		return $this->__resolved__[$key] = $resolved;
 	}
 }

--- a/src/mako/utility/Arr.php
+++ b/src/mako/utility/Arr.php
@@ -32,10 +32,6 @@ class Arr
 {
 	/**
 	 * Sets an array value using "dot notation".
-	 *
-	 * @param array  &$array Array you want to modify
-	 * @param string $path   Array path
-	 * @param mixed  $value  Value to set
 	 */
 	public static function set(array &$array, string $path, mixed $value): void
 	{
@@ -58,10 +54,6 @@ class Arr
 
 	/**
 	 * Appends an array value using "dot notation".
-	 *
-	 * @param array  &$array Array you want to modify
-	 * @param string $path   Array path
-	 * @param mixed  $value  Value to append
 	 */
 	public static function append(array &$array, string $path, mixed $value): void
 	{
@@ -84,10 +76,6 @@ class Arr
 
 	/**
 	 * Search for an array value using "dot notation". Returns TRUE if the array key exists and FALSE if not.
-	 *
-	 * @param  array  $array Array we're goint to search
-	 * @param  string $path  Array path
-	 * @return bool
 	 */
 	public static function has(array $array, string $path): bool
 	{
@@ -108,11 +96,6 @@ class Arr
 
 	/**
 	 * Returns value from array using "dot notation".
-	 *
-	 * @param  array  $array   Array we're going to search
-	 * @param  string $path    Array path
-	 * @param  mixed  $default Default return value
-	 * @return mixed
 	 */
 	public static function get(array $array, string $path, mixed $default = null): mixed
 	{
@@ -133,10 +116,6 @@ class Arr
 
 	/**
 	 * Deletes an array value using "dot notation".
-	 *
-	 * @param  array  &$array Array you want to modify
-	 * @param  string $path   Array path
-	 * @return bool
 	 */
 	public static function delete(array &$array, string $path): bool
 	{
@@ -161,9 +140,6 @@ class Arr
 
 	/**
 	 * Returns a random value from an array.
-	 *
-	 * @param  array $array Array you want to pick a random value from
-	 * @return mixed
 	 */
 	public static function random(array $array): mixed
 	{
@@ -172,9 +148,6 @@ class Arr
 
 	/**
 	 * Returns TRUE if the array is associative and FALSE if not.
-	 *
-	 * @param  array $array Array to check
-	 * @return bool
 	 */
 	public static function isAssoc(array $array): bool
 	{
@@ -183,10 +156,6 @@ class Arr
 
 	/**
 	 * Returns the values from a single column of the input array, identified by the key.
-	 *
-	 * @param  array  $array Array to pluck from
-	 * @param  string $key   Array key
-	 * @return array
 	 */
 	public static function pluck(array $array, string $key): array
 	{
@@ -202,10 +171,6 @@ class Arr
 
 	/**
 	 * Expands a wildcard key to an array of "dot notation" keys.
-	 *
-	 * @param  array  $array Array
-	 * @param  string $key   Wildcard key
-	 * @return array
 	 */
 	public static function expandKey(array $array, string $key): array
 	{
@@ -251,9 +216,6 @@ class Arr
 
 	/**
 	 * Converts arrays to objects.
-	 *
-	 * @param  array        $array Array to convert
-	 * @return array|object
 	 */
 	public static function toObject(array $array): array|object
     {

--- a/src/mako/utility/Collection.php
+++ b/src/mako/utility/Collection.php
@@ -74,7 +74,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	 *
 	 * @return $this
 	 */
-	public function resetKeys()
+	public function resetKeys(): static
 	{
 		$this->items = array_values($this->items);
 
@@ -86,7 +86,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	 *
 	 * @return $this
 	 */
-	public function put(int|string $key, mixed $value)
+	public function put(int|string $key, mixed $value): static
 	{
 		$this->items[$key] = $value;
 
@@ -119,7 +119,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	 *
 	 * @return $this
 	 */
-	public function remove(int|string $key)
+	public function remove(int|string $key): static
 	{
 		unset($this->items[$key]);
 
@@ -131,7 +131,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	 *
 	 * @return $this
 	 */
-	public function clear()
+	public function clear(): static
 	{
 		$this->items = [];
 
@@ -278,7 +278,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	 *
 	 * @return $this
 	 */
-	public function sort(callable $comparator, bool $maintainIndexAssociation = true)
+	public function sort(callable $comparator, bool $maintainIndexAssociation = true): static
 	{
 		if($maintainIndexAssociation)
 		{
@@ -308,12 +308,11 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	}
 
 	/**
-	 * Shuffles the items in the collection and returns
-	 * TRUE on success and FALSE on failure.
+	 * Shuffles the items in the collection.
 	 *
 	 * @return $this
 	 */
-	public function shuffle()
+	public function shuffle(): static
 	{
 		shuffle($this->items);
 
@@ -325,7 +324,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	 *
 	 * @return $this
 	 */
-	public function each(callable $callable)
+	public function each(callable $callable): static
 	{
 		$reflection = new ReflectionFunction($callable);
 

--- a/src/mako/utility/Collection.php
+++ b/src/mako/utility/Collection.php
@@ -47,8 +47,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array $items Collection items
 	 */
 	final public function __construct(
 		protected array $items = []
@@ -57,8 +55,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Returns all the items in the collection.
-	 *
-	 * @return array
 	 */
 	public function getItems(): array
 	{
@@ -67,8 +63,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Returns all the values in the collection.
-	 *
-	 * @return array
 	 */
 	public function getValues(): array
 	{
@@ -90,8 +84,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	/**
 	 * Adds a new item to the collection.
 	 *
-	 * @param  int|string $key   Key
-	 * @param  mixed      $value Value
 	 * @return $this
 	 */
 	public function put(int|string $key, mixed $value)
@@ -103,9 +95,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Returns TRUE if the item key exists and FALSE if not.
-	 *
-	 * @param  int|string $key Key
-	 * @return bool
 	 */
 	public function has(int|string $key): bool
 	{
@@ -114,10 +103,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Returns an item from the collection.
-	 *
-	 * @param  int|string $key     Key
-	 * @param  mixed      $default Default value
-	 * @return mixed
 	 */
 	public function get(int|string $key, mixed $default = null): mixed
 	{
@@ -132,7 +117,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	/**
 	 * Removes an item from the collection.
 	 *
-	 * @param  int|string $key Key
 	 * @return $this
 	 */
 	public function remove(int|string $key)
@@ -156,9 +140,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Checks whether or not an offset exists.
-	 *
-	 * @param  mixed $offset The offset to check for
-	 * @return bool
 	 */
 	public function offsetExists(mixed $offset): bool
 	{
@@ -167,9 +148,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Returns the value at the specified offset.
-	 *
-	 * @param  mixed $offset The offset to retrieve
-	 * @return mixed
 	 */
 	public function offsetGet(mixed $offset): mixed
 	{
@@ -183,9 +161,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Assigns a value to the specified offset.
-	 *
-	 * @param mixed $offset The offset to assign the value to
-	 * @param mixed $value  The value to set
 	 */
 	public function offsetSet(mixed $offset, mixed $value): void
 	{
@@ -201,8 +176,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Unsets an offset.
-	 *
-	 * @param mixed $offset The offset to unset
 	 */
 	public function offsetUnset(mixed $offset): void
 	{
@@ -211,8 +184,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Returns the numner of items in the collection.
-	 *
-	 * @return int
 	 */
 	public function count(): int
 	{
@@ -221,8 +192,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Retruns an array iterator object.
-	 *
-	 * @return \ArrayIterator
 	 */
 	public function getIterator(): ArrayIterator
 	{
@@ -231,8 +200,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Returns TRUE if the collection is empty and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function isEmpty(): bool
 	{
@@ -242,9 +209,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	/**
 	 * Prepends the passed item to the front of the collection
 	 * and returns the new number of elements in the collection.
-	 *
-	 * @param  mixed $item Collection item
-	 * @return int
 	 */
 	public function unshift(mixed $item): int
 	{
@@ -254,8 +218,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	/**
 	 * Shifts the first value of the collection off and returns it,
 	 * shortening the collection by one element.
-	 *
-	 * @return mixed
 	 */
 	public function shift(): mixed
 	{
@@ -265,9 +227,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	/**
 	 * Pushes the passed variable onto the end of the collection
 	 * and returns the new number of elements in the collection.
-	 *
-	 * @param  mixed $item Collection item
-	 * @return int
 	 */
 	public function push(mixed $item): int
 	{
@@ -277,8 +236,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	/**
 	 * Pops and returns the last value of the collection,
 	 * shortening the collection by one element.
-	 *
-	 * @return mixed
 	 */
 	public function pop(): mixed
 	{
@@ -287,8 +244,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Returns the first item of the collection or NULL if the collection is empty.
-	 *
-	 * @return mixed
 	 */
 	public function first(): mixed
 	{
@@ -304,8 +259,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Returns the last item of the collection or NULL if the collection is empty.
-	 *
-	 * @return mixed
 	 */
 	public function last(): mixed
 	{
@@ -323,8 +276,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	 * Sorts the collection using the specified comparator callable
 	 * and returns TRUE on success and FALSE on failure.
 	 *
-	 * @param  callable $comparator               Comparator callable
-	 * @param  bool     $maintainIndexAssociation Maintain index association?
 	 * @return $this
 	 */
 	public function sort(callable $comparator, bool $maintainIndexAssociation = true)
@@ -343,9 +294,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Chunks the collection into a collection containing $size sized collections.
-	 *
-	 * @param  int    $size Chunk size
-	 * @return static
 	 */
 	public function chunk(int $size): static
 	{
@@ -375,7 +323,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	/**
 	 * Applies the callable on all items in the collection.
 	 *
-	 * @param  callable $callable Callable
 	 * @return $this
 	 */
 	public function each(callable $callable)
@@ -404,9 +351,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 	/**
 	 * Returns a new collection where the callable has
 	 * been applied to all the items.
-	 *
-	 * @param  callable $callable Callable
-	 * @return static
 	 */
 	public function map(callable $callable): static
 	{
@@ -419,9 +363,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Returns a new filtered collection.
-	 *
-	 * @param  callable|null $callable Filter
-	 * @return static
 	 */
 	public function filter(?callable $callable = null): static
 	{
@@ -435,9 +376,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Returns a new collection where all items not in the provided list have been removed.
-	 *
-	 * @param  array  $keys Keys
-	 * @return static
 	 */
 	public function with(array $keys): static
 	{
@@ -446,9 +384,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Returns a new collection where all items in the provided list have been removed.
-	 *
-	 * @param  array  $keys Keys
-	 * @return static
 	 */
 	public function without(array $keys): static
 	{
@@ -457,9 +392,6 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
 	/**
 	 * Merges two collections.
-	 *
-	 * @param  \mako\utility\Collection $collection Collection to merge
-	 * @return static
 	 */
 	public function merge(Collection $collection): static
 	{

--- a/src/mako/utility/HTML.php
+++ b/src/mako/utility/HTML.php
@@ -21,8 +21,6 @@ class HTML
 
 	/**
 	 * Constructor.
-	 *
-	 * @param bool $xhtml Should we return HXML?
 	 */
 	public function __construct(
 		protected bool $xhtml = false
@@ -31,9 +29,6 @@ class HTML
 
 	/**
 	 * Takes an array of attributes and turns it into a string.
-	 *
-	 * @param  array  $attributes Array of tags
-	 * @return string
 	 */
 	protected function attributes(array $attributes): string
 	{
@@ -54,11 +49,6 @@ class HTML
 
 	/**
 	 * Creates a HTML5 tag.
-	 *
-	 * @param  string      $name       Tag name
-	 * @param  array       $attributes Tag attributes
-	 * @param  string|null $content    Tag content
-	 * @return string
 	 */
 	public function tag(string $name, array $attributes = [], ?string $content = null): string
 	{
@@ -67,11 +57,6 @@ class HTML
 
 	/**
 	 * Helper method for building media tags.
-	 *
-	 * @param  string       $type       Tag type
-	 * @param  array|string $files      File or array of files
-	 * @param  array        $attributes Tag attributes
-	 * @return string
 	 */
 	protected function buildMedia(string $type, array|string $files, array $attributes): string
 	{
@@ -87,10 +72,6 @@ class HTML
 
 	/**
 	 * Creates audio tag with support for multiple sources.
-	 *
-	 * @param  array|string $files      File or array of files
-	 * @param  array        $attributes Tag attributes
-	 * @return string
 	 */
 	public function audio(array|string $files, array $attributes = []): string
 	{
@@ -99,10 +80,6 @@ class HTML
 
 	/**
 	 * Creates video tag with support for multiple sources.
-	 *
-	 * @param  array|string $files      File or array of files
-	 * @param  array        $attributes Tag attributes
-	 * @return string
 	 */
 	public function video(array|string $files, array $attributes = []): string
 	{
@@ -111,11 +88,6 @@ class HTML
 
 	/**
 	 * Helper method for building list tags.
-	 *
-	 * @param  string $type       Tag type
-	 * @param  array  $items      List items
-	 * @param  array  $attributes Tag attributes
-	 * @return string
 	 */
 	protected function buildList(string $type, array $items, array $attributes): string
 	{
@@ -138,10 +110,6 @@ class HTML
 
 	/**
 	 * Builds an un-ordered list.
-	 *
-	 * @param  array  $items      List items
-	 * @param  array  $attributes List attributes
-	 * @return string
 	 */
 	public function ul(array $items, array $attributes = []): string
 	{
@@ -150,10 +118,6 @@ class HTML
 
 	/**
 	 * Builds am ordered list.
-	 *
-	 * @param  array  $items      List items
-	 * @param  array  $attributes List attributes
-	 * @return string
 	 */
 	public function ol(array $items, array $attributes = []): string
 	{

--- a/src/mako/utility/Humanizer.php
+++ b/src/mako/utility/Humanizer.php
@@ -24,8 +24,6 @@ class Humanizer
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\i18n\I18n|null $i18n I18n instance
 	 */
 	public function __construct(
 		protected ?I18n $i18n = null
@@ -34,10 +32,6 @@ class Humanizer
 
 	/**
 	 * Returns a human friendly file size.
-	 *
-	 * @param  float|int $size   File size in bytes
-	 * @param  bool      $binary True to use binary suffixes and FALSE to use decimal suffixes
-	 * @return string
 	 */
 	public function fileSize(float|int $size, bool $binary = true): string
 	{
@@ -64,10 +58,6 @@ class Humanizer
 
 	/**
 	 * Returns a human friendly representation of the date.
-	 *
-	 * @param  \DateTimeInterface $dateTime   DateTime object
-	 * @param  string             $dateFormat Default date format
-	 * @return string
 	 */
 	public function day(DateTimeInterface $dateTime, string $dateFormat = 'Y-m-d, H:i'): string
 	{
@@ -91,11 +81,6 @@ class Humanizer
 
 	/**
 	 * Returns a human friendly representation of the time.
-	 *
-	 * @param  \DateTimeInterface $dateTime    DateTime object
-	 * @param  string             $dateFormat  Default date format
-	 * @param  string             $clockFormat Default clock format
-	 * @return string
 	 */
 	public function time(DateTimeInterface $dateTime, string $dateFormat = 'Y-m-d, H:i', string $clockFormat = ', H:i'): string
 	{

--- a/src/mako/utility/Num.php
+++ b/src/mako/utility/Num.php
@@ -20,9 +20,6 @@ class Num
 {
 	/**
 	 * Converts arabic numerals (1-3999) to roman numerals.
-	 *
-	 * @param  int    $int Arabic numeral to convert
-	 * @return string
 	 */
 	public static function arabic2roman(int $int): string
 	{
@@ -76,9 +73,6 @@ class Num
 
 	/**
 	 * Converts roman numerals (I-MMMCMXCIX) to arabic numerals.
-	 *
-	 * @param  string $str Roman numeral to convert
-	 * @return int
 	 */
 	public static function roman2arabic(string $str): int
 	{

--- a/src/mako/utility/Retry.php
+++ b/src/mako/utility/Retry.php
@@ -32,12 +32,6 @@ class Retry
 
 	/**
 	 * Constructor.
-	 *
-	 * @param callable      $callable        The callable
-	 * @param int           $attempts        The number of attempts
-	 * @param int           $wait            The time we want to want to wait between each attempt in microseconds
-	 * @param bool          $exponentialWait Should the time between each attempt increase exponentially?
-	 * @param callable|null $decider         Callable that decides whether or not we should retry
 	 */
 	public function __construct(
 		callable $callable,
@@ -54,9 +48,6 @@ class Retry
 
 	/**
 	 * Sets the number of attempts.
-	 *
-	 * @param  int                 $attempts The maximum number of attempts
-	 * @return \mako\utility\Retry
 	 */
 	public function setAttempts(int $attempts): Retry
 	{
@@ -67,9 +58,6 @@ class Retry
 
 	/**
 	 * Sets the time we want to want to wait between each attempt in microseconds.
-	 *
-	 * @param  int                 $wait The time we want to want to wait between each attempt in microseconds
-	 * @return \mako\utility\Retry
 	 */
 	public function setWait(int $wait): Retry
 	{
@@ -80,8 +68,6 @@ class Retry
 
 	/**
 	 * Enables exponential waiting.
-	 *
-	 * @return \mako\utility\Retry
 	 */
 	public function exponentialWait(): Retry
 	{
@@ -92,9 +78,6 @@ class Retry
 
 	/**
 	 * Sets the decider that decides whether or not we should retry.
-	 *
-	 * @param  callable            $decider Callable that decides whether or not we should retry
-	 * @return \mako\utility\Retry
 	 */
 	public function setDecider(callable $decider): Retry
 	{
@@ -105,9 +88,6 @@ class Retry
 
 	/**
 	 * Returns the number of microseconds we should wait for.
-	 *
-	 * @param  int $attempts Number of attempts
-	 * @return int
 	 */
 	protected function calculateWait(int $attempts): int
 	{
@@ -121,8 +101,6 @@ class Retry
 
 	/**
 	 * Executes and returns the return value of the callable.
-	 *
-	 * @return mixed
 	 */
 	public function execute(): mixed
 	{
@@ -149,8 +127,6 @@ class Retry
 
 	/**
 	 * Executes and returns the return value of the callable.
-	 *
-	 * @return mixed
 	 */
 	public function __invoke(): mixed
 	{

--- a/src/mako/utility/Str.php
+++ b/src/mako/utility/Str.php
@@ -67,10 +67,8 @@ class Str
 
 	/**
 	 * Pluralization rules.
-	 *
-	 * @var array
 	 */
-	protected static $pluralizationRules =
+	protected static array $pluralizationRules =
 	[
 		'/(quiz)$/i'                     => '$1zes',
 		'/([m|l])ouse$/i'                => '$1ice',
@@ -94,10 +92,8 @@ class Str
 
 	/**
 	 * Irregular nouns.
-	 *
-	 * @var array
 	 */
-	protected static $irregulars =
+	protected static array $irregulars =
 	[
 		'alias'       => 'aliases',
 		'audio'       => 'audio',
@@ -124,10 +120,6 @@ class Str
 
 	/**
 	 * Replaces newline with <br> or <br />.
-	 *
-	 * @param  string $string The input string
-	 * @param  bool   $xhtml  Should we return XHTML?
-	 * @return string
 	 */
 	public static function nl2br(string $string, bool $xhtml = false): string
 	{
@@ -136,9 +128,6 @@ class Str
 
 	/**
 	 * Replaces <br> and <br /> with newline.
-	 *
-	 * @param  string $string The input string
-	 * @return string
 	 */
 	public static function br2nl(string $string): string
 	{
@@ -147,10 +136,6 @@ class Str
 
 	/**
 	 * Returns the plural form of a noun (english only).
-	 *
-	 * @param  string   $noun  Noun to pluralize
-	 * @param  int|null $count Number of nouns
-	 * @return string
 	 */
 	public static function pluralize(string $noun, ?int $count = null): string
 	{
@@ -179,9 +164,6 @@ class Str
 
 	/**
 	 * Converts camel case to underscored.
-	 *
-	 * @param  string $string The input string
-	 * @return string
 	 */
 	public static function camelToSnake(string $string): string
 	{
@@ -190,10 +172,6 @@ class Str
 
 	/**
 	 * Converts underscored to camel case.
-	 *
-	 * @param  string $string The input string
-	 * @param  bool   $upper  Return upper case camelCase?
-	 * @return string
 	 */
 	public static function snakeToCamel(string $string, bool $upper = false): string
 	{
@@ -202,11 +180,6 @@ class Str
 
 	/**
 	 * Limits the number of characters in a string.
-	 *
-	 * @param  string $string     The input string
-	 * @param  int    $characters Number of characters to allow
-	 * @param  string $sufix      Sufix to add if number of characters is reduced
-	 * @return string
 	 */
 	public static function limitChars(string $string, int $characters = 100, string $sufix = '...'): string
 	{
@@ -215,11 +188,6 @@ class Str
 
 	/**
 	 * Limits the number of words in a string.
-	 *
-	 * @param  string $string The input string
-	 * @param  int    $words  Number of words to allow
-	 * @param  string $sufix  Sufix to add if number of words is reduced
-	 * @return string
 	 */
 	public static function limitWords(string $string, int $words = 100, string $sufix = '...'): string
 	{
@@ -235,9 +203,6 @@ class Str
 
 	/**
 	 * Creates a URL friendly string.
-	 *
-	 * @param  string $string The input string
-	 * @return string
 	 */
 	public static function slug(string $string): string
 	{
@@ -246,9 +211,6 @@ class Str
 
 	/**
 	 * Strips all non-ASCII characters.
-	 *
-	 * @param  string $string The input string
-	 * @return string
 	 */
 	public static function ascii(string $string): string
 	{
@@ -257,9 +219,6 @@ class Str
 
 	/**
 	 * Returns a alternator that will alternate between the defined strings.
-	 *
-	 * @param  array                        $strings Array of strings to alternate between
-	 * @return \mako\utility\str\Alternator
 	 */
 	public static function alternator(array $strings): Alternator
 	{
@@ -268,10 +227,6 @@ class Str
 
 	/**
 	 * Converts URLs in a text into clickable links.
-	 *
-	 * @param  string $string     Text to scan for links
-	 * @param  array  $attributes Anchor attributes
-	 * @return string
 	 */
 	public static function autolink(string $string, array $attributes = []): string
 	{
@@ -280,11 +235,6 @@ class Str
 
 	/**
 	 * Returns a masked string where only the last n characters are visible.
-	 *
-	 * @param  string $string  String to mask
-	 * @param  int    $visible Number of characters to show
-	 * @param  string $mask    Character used to replace remaining characters
-	 * @return string
 	 */
 	public static function mask(string $string, int $visible = 3, string $mask = '*'): string
 	{
@@ -300,11 +250,6 @@ class Str
 
 	/**
 	 * Increments a string by appending a number to it or increasing the number.
-	 *
-	 * @param  string $string    String to increment
-	 * @param  int    $start     Starting number
-	 * @param  string $separator Separator
-	 * @return string
 	 */
 	public static function increment(string $string, int $start = 1, string $separator = '_'): string
 	{
@@ -315,10 +260,6 @@ class Str
 
 	/**
 	 * Returns a random string of the selected type and length.
-	 *
-	 * @param  string $pool   Character pool to use
-	 * @param  int    $length Desired string length
-	 * @return string
 	 */
 	public static function random(string $pool = Str::ALNUM, int $length = 32): string
 	{

--- a/src/mako/utility/UUID.php
+++ b/src/mako/utility/UUID.php
@@ -70,9 +70,6 @@ class UUID
 
 	/**
 	 * Checks if a UUID is valid.
-	 *
-	 * @param  string $uuid The UUID to validate
-	 * @return bool
 	 */
 	public static function validate(string $uuid): bool
 	{
@@ -83,9 +80,6 @@ class UUID
 
 	/**
 	 * Converts a UUID from its hexadecimal representation to a binary string.
-	 *
-	 * @param  string $uuid UUID
-	 * @return string
 	 */
 	public static function toBinary(string $uuid): string
 	{
@@ -108,9 +102,6 @@ class UUID
 
 	/**
 	 * Converts a binary UUID to its hexadecimal representation.
-	 *
-	 * @param  string $bytes Binary representation of a UUID
-	 * @return string
 	 */
 	public static function toHexadecimal(string $bytes): string
 	{
@@ -124,10 +115,6 @@ class UUID
 
 	/**
 	 * Returns a V3 UUID.
-	 *
-	 * @param  string $namespace Namespace
-	 * @param  string $name      Name
-	 * @return string
 	 */
 	public static function v3(string $namespace, string $name): string
 	{
@@ -146,8 +133,6 @@ class UUID
 
 	/**
 	 * Returns a V4 UUID.
-	 *
-	 * @return string
 	 */
 	public static function v4(): string
 	{
@@ -162,10 +147,6 @@ class UUID
 
 	/**
 	 * Returns a V5 UUID.
-	 *
-	 * @param  string $namespace Namespace
-	 * @param  string $name      Name
-	 * @return string
 	 */
 	public static function v5(string $namespace, string $name): string
 	{
@@ -184,8 +165,6 @@ class UUID
 
 	/**
 	 * Returns a sequential (COMB) v4 UUID.
-	 *
-	 * @return string
 	 */
 	public static function sequential(): string
 	{

--- a/src/mako/utility/ip/IP.php
+++ b/src/mako/utility/ip/IP.php
@@ -16,10 +16,6 @@ class IP
 {
 	/**
 	 * Checks if an IP is in the specified range.
-	 *
-	 * @param  string $ip    IP address
-	 * @param  string $range Ip address or IP range
-	 * @return bool
 	 */
 	public static function inRange(string $ip, string $range): bool
 	{

--- a/src/mako/utility/ip/IPv4.php
+++ b/src/mako/utility/ip/IPv4.php
@@ -18,10 +18,6 @@ class IPv4
 {
 	/**
 	 * Checks if an IP is in the specified range.
-	 *
-	 * @param  string $ip    IP address
-	 * @param  string $range Ip address or IP range
-	 * @return bool
 	 */
 	public static function inRange(string $ip, string $range): bool
 	{

--- a/src/mako/utility/ip/IPv6.php
+++ b/src/mako/utility/ip/IPv6.php
@@ -21,10 +21,6 @@ class IPv6
 {
 	/**
 	 * Checks if an IP is in the specified range.
-	 *
-	 * @param  string $ip    IP address
-	 * @param  string $range Ip address or IP range
-	 * @return bool
 	 */
 	public static function inRange(string $ip, string $range): bool
 	{

--- a/src/mako/utility/str/Alternator.php
+++ b/src/mako/utility/str/Alternator.php
@@ -18,22 +18,16 @@ class Alternator implements Stringable
 {
 	/**
 	 * String count.
-	 *
-	 * @var int
 	 */
-	protected $stringCount;
+	protected int $stringCount;
 
 	/**
 	 * Counter.
-	 *
-	 * @var int
 	 */
-	protected $counter = 0;
+	protected int $counter = 0;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array $strings Strings
 	 */
 	public function __construct(
 		protected array $strings
@@ -44,8 +38,6 @@ class Alternator implements Stringable
 
 	/**
 	 * Returns a string.
-	 *
-	 * @return string
 	 */
 	public function __toString(): string
 	{
@@ -54,8 +46,6 @@ class Alternator implements Stringable
 
 	/**
 	 * Returns a string.
-	 *
-	 * @return string
 	 */
 	public function __invoke(): string
 	{

--- a/src/mako/validator/Validator.php
+++ b/src/mako/validator/Validator.php
@@ -99,17 +99,13 @@ class Validator
 
 	/**
 	 * Rule sets.
-	 *
-	 * @var array
 	 */
-	protected $ruleSets;
+	protected array $ruleSets;
 
 	/**
 	 * Rules.
-	 *
-	 * @var array
 	 */
-	protected $rules =
+	protected array $rules =
 	[
 		'after'                    => After::class,
 		'alpha_dash_unicode'       => AlphanumericDashUnicode::class,
@@ -177,32 +173,21 @@ class Validator
 
 	/**
 	 * Original field names.
-	 *
-	 * @var array
 	 */
-	protected $originalFieldNames;
+	protected array $originalFieldNames = [];
 
 	/**
 	 * Is the input valid?
-	 *
-	 * @var bool
 	 */
-	protected $isValid = true;
+	protected bool $isValid = true;
 
 	/**
 	 * Error messages.
-	 *
-	 * @var array
 	 */
-	protected $errors = [];
+	protected array $errors = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array                   $input     Input
-	 * @param array                   $ruleSets  Rule sets
-	 * @param \mako\i18n\I18n|null    $i18n      I18n
-	 * @param \mako\syringe\Container $container Container
 	 */
 	public function __construct(
 		protected array $input,
@@ -216,10 +201,6 @@ class Validator
 
 	/**
 	 * Registers a custom validation rule.
-	 *
-	 * @param  string                    $rule      Rule
-	 * @param  string                    $ruleClass Rule class
-	 * @return \mako\validator\Validator
 	 */
 	public function extend(string $rule, string $ruleClass): Validator
 	{
@@ -230,9 +211,6 @@ class Validator
 
 	/**
 	 * Returns TRUE if the field name has a wildcard and FALSE if not.
-	 *
-	 * @param  string $string Field name
-	 * @return bool
 	 */
 	protected function hasWilcard(string $string): bool
 	{
@@ -241,9 +219,6 @@ class Validator
 
 	/**
 	 * Saves original field name along with the expanded field name.
-	 *
-	 * @param array  $fields Expanded field names
-	 * @param string $field  Original field name
 	 */
 	protected function saveOriginalFieldNames(array $fields, string $field): void
 	{
@@ -255,9 +230,6 @@ class Validator
 
 	/**
 	 * Returns the original field name.
-	 *
-	 * @param  string $field Field name
-	 * @return string
 	 */
 	protected function getOriginalFieldName(string $field): string
 	{
@@ -266,9 +238,6 @@ class Validator
 
 	/**
 	 * Expands fields.
-	 *
-	 * @param  array $ruleSets Rule sets
-	 * @return array
 	 */
 	protected function expandFields(array $ruleSets): array
 	{
@@ -301,10 +270,6 @@ class Validator
 
 	/**
 	 * Adds validation rules to input field.
-	 *
-	 * @param  string                    $field   Input field
-	 * @param  array                     $ruleSet Rule set
-	 * @return \mako\validator\Validator
 	 */
 	public function addRules(string $field, array $ruleSet): Validator
 	{
@@ -315,11 +280,6 @@ class Validator
 
 	/**
 	 * Adds validation rules to input field if the condition is met.
-	 *
-	 * @param  string                    $field     Input field
-	 * @param  array                     $ruleSet   Rule set
-	 * @param  bool|\Closure             $condition Condition
-	 * @return \mako\validator\Validator
 	 */
 	public function addRulesIf(string $field, array $ruleSet, bool|Closure $condition): Validator
 	{
@@ -333,9 +293,6 @@ class Validator
 
 	/**
 	 * Parses the rule.
-	 *
-	 * @param  string $rule Rule
-	 * @return object
 	 */
 	protected function parseRule(string $rule): object
 	{
@@ -353,9 +310,6 @@ class Validator
 
 	/**
 	 * Returns the rule class name.
-	 *
-	 * @param  string $name Rule name
-	 * @return string
 	 */
 	protected function getRuleClassName(string $name): string
 	{
@@ -374,10 +328,6 @@ class Validator
 
 	/**
 	 * Creates a rule instance.
-	 *
-	 * @param  string                              $name       Rule name
-	 * @param  array                               $parameters Rule parameters
-	 * @return \mako\validator\rules\RuleInterface
 	 */
 	protected function ruleFactory(string $name, array $parameters): RuleInterface
 	{
@@ -386,9 +336,6 @@ class Validator
 
 	/**
 	 * Returns TRUE if the input field is considered empty and FALSE if not.
-	 *
-	 * @param  mixed $value Value
-	 * @return bool
 	 */
 	protected function isInputFieldEmpty(mixed $value): bool
 	{
@@ -397,11 +344,6 @@ class Validator
 
 	/**
 	 * Returns the error message.
-	 *
-	 * @param  \mako\validator\rules\RuleInterface $rule       Rule
-	 * @param  string                              $field      Field name
-	 * @param  object                              $parsedRule Parsed rule
-	 * @return string
 	 */
 	protected function getErrorMessage(RuleInterface $rule, string $field, object $parsedRule): string
 	{
@@ -417,10 +359,6 @@ class Validator
 
 	/**
 	 * Validates the field using the specified rule.
-	 *
-	 * @param  string $field Field name
-	 * @param  string $rule  Rule
-	 * @return bool
 	 */
 	protected function validateField(string $field, string $rule): bool
 	{
@@ -450,8 +388,6 @@ class Validator
 	/**
 	 * Processes all validation rules and returns an array containing
 	 * the validation status and potential error messages.
-	 *
-	 * @return array
 	 */
 	protected function process(): array
 	{
@@ -477,9 +413,6 @@ class Validator
 
 	/**
 	 * Returns TRUE if all rules passed and FALSE if validation failed.
-	 *
-	 * @param  array &$errors If $errors is provided, then it is filled with all the error messages
-	 * @return bool
 	 */
 	public function isValid(?array &$errors = null): bool
 	{
@@ -490,9 +423,6 @@ class Validator
 
 	/**
 	 * Returns false if all rules passed and true if validation failed.
-	 *
-	 * @param  array &$errors If $errors is provided, then it is filled with all the error messages
-	 * @return bool
 	 */
 	public function isInvalid(?array &$errors = null): bool
 	{
@@ -503,8 +433,6 @@ class Validator
 
 	/**
 	 * Validates the input and returns an array containing validated data.
-	 *
-	 * @return array
 	 */
 	public function getValidatedInput(): array
 	{
@@ -528,8 +456,6 @@ class Validator
 
 	/**
 	 * Returns the validation errors.
-	 *
-	 * @return array
 	 */
 	public function getErrors(): array
 	{

--- a/src/mako/validator/ValidatorFactory.php
+++ b/src/mako/validator/ValidatorFactory.php
@@ -17,16 +17,11 @@ class ValidatorFactory
 {
 	/**
 	 * Custom rules.
-	 *
-	 * @var array
 	 */
-	protected $rules = [];
+	protected array $rules = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\i18n\I18n|null         $i18n      I18n instance
-	 * @param \mako\syringe\Container|null $container Container
 	 */
 	public function __construct(
 		protected ?I18n $i18n = null,
@@ -36,10 +31,6 @@ class ValidatorFactory
 
 	/**
 	 * Registers a custom validation rule.
-	 *
-	 * @param  string                           $rule      Rule
-	 * @param  string                           $ruleClass Rule class
-	 * @return \mako\validator\ValidatorFactory
 	 */
 	public function extend(string $rule, string $ruleClass): ValidatorFactory
 	{
@@ -50,10 +41,6 @@ class ValidatorFactory
 
 	/**
 	 * Creates and returns a validator instance.
-	 *
-	 * @param  array                     $input    Array to validate
-	 * @param  array                     $ruleSets Array of validation rule sets
-	 * @return \mako\validator\Validator
 	 */
 	public function create(array $input, array $ruleSets = []): Validator
 	{

--- a/src/mako/validator/exceptions/ValidationException.php
+++ b/src/mako/validator/exceptions/ValidationException.php
@@ -23,18 +23,11 @@ class ValidationException extends ValidatorException
 {
 	/**
 	 * Input.
-	 *
-	 * @var \mako\validator\input\InputInterface|null
 	 */
-	protected $input;
+	protected InputInterface|null $input = null;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array           $errors   Validation errors
-	 * @param string          $message  Exception code
-	 * @param int             $code     Exception message
-	 * @param \Throwable|null $previous Previous exception
 	 */
 	public function __construct(
 		protected array $errors,
@@ -47,8 +40,6 @@ class ValidationException extends ValidatorException
 
 	/**
 	 * Returns the validation errors.
-	 *
-	 * @return array
 	 */
 	public function getErrors(): array
 	{
@@ -57,8 +48,6 @@ class ValidationException extends ValidatorException
 
 	/**
 	 * Returns the exception message along with the validation errors.
-	 *
-	 * @return string
 	 */
 	public function getMessageWithErrors(): string
 	{
@@ -71,8 +60,6 @@ class ValidationException extends ValidatorException
 
 	/**
 	 * Sets the input.
-	 *
-	 * @param \mako\validator\input\InputInterface $input Input
 	 */
 	public function setInput(InputInterface $input): void
 	{
@@ -81,8 +68,6 @@ class ValidationException extends ValidatorException
 
 	/**
 	 * Returns the input.
-	 *
-	 * @return \mako\validator\input\InputInterface|null
 	 */
 	public function getInput(): ?InputInterface
 	{

--- a/src/mako/validator/input/Input.php
+++ b/src/mako/validator/input/Input.php
@@ -16,24 +16,18 @@ abstract class Input implements InputInterface
 {
 	/**
 	 * Validation rules.
-	 *
-	 * @var array
 	 */
-	protected $rules;
+	protected array $rules = [];
 
 	/**
 	 * Error message.
-	 *
-	 * @var string|null
 	 */
-	protected $errorMessage;
+	protected string|null $errorMessage = null;
 
 	/**
 	 * Validation extensions.
-	 *
-	 * @var array
 	 */
-	protected $extensions = [];
+	protected array $extensions = [];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/input/InputInterface.php
+++ b/src/mako/validator/input/InputInterface.php
@@ -16,36 +16,26 @@ interface InputInterface
 {
 	/**
 	 * Returns the input to validate.
-	 *
-	 * @return array
 	 */
 	public function getInput(): array;
 
 	/**
 	 * Returns the validation rules.
-	 *
-	 * @return array
 	 */
 	public function getRules(): array;
 
 	/**
 	 * Returns an array of validator extensions.
-	 *
-	 * @return array
 	 */
 	public function getExtensions(): array;
 
 	/**
 	 * Adds conditional rules to the validator.
-	 *
-	 * @param \mako\validator\Validator $validator Validator
 	 */
 	public function addConditionalRules(Validator $validator): void;
 
 	/**
 	 * Returns the error message.
-	 *
-	 * @return string|null
 	 */
 	public function getErrorMessage(): ?string;
 }

--- a/src/mako/validator/input/http/Input.php
+++ b/src/mako/validator/input/http/Input.php
@@ -18,23 +18,16 @@ abstract class Input extends BaseInput implements InputInterface
 {
 	/**
 	 * Should we redirect the client if possible?
-	 *
-	 * @var bool
 	 */
-	protected $shouldRedirect = true;
+	protected bool $shouldRedirect = true;
 
 	/**
 	 * Should the old input be included?
-	 *
-	 * @var bool
 	 */
-	protected $shouldIncludeOldInput = true;
+	protected bool $shouldIncludeOldInput = true;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\http\Request            $request    Request
-	 * @param \mako\http\routing\URLBuilder $urlBuilder URL builder
 	 */
 	public function __construct(
 		protected Request $request,

--- a/src/mako/validator/input/http/InputInterface.php
+++ b/src/mako/validator/input/http/InputInterface.php
@@ -16,29 +16,21 @@ interface InputInterface extends BaseInputInterface
 {
 	/**
 	 * Should we redirect the client if possible?
-	 *
-	 * @return bool
 	 */
 	public function shouldRedirect(): bool;
 
 	/**
 	 * Returns the redirect URL.
-	 *
-	 * @return string
 	 */
 	public function getRedirectUrl(): string;
 
 	/**
 	 * Should the old input be included?
-	 *
-	 * @return bool
 	 */
 	public function shouldIncludeOldInput(): bool;
 
 	/**
 	 * Returns the old input.
-	 *
-	 * @return array
 	 */
 	public function getOldInput(): array;
 }

--- a/src/mako/validator/input/http/routing/middleware/InputValidation.php
+++ b/src/mako/validator/input/http/routing/middleware/InputValidation.php
@@ -36,87 +36,61 @@ class InputValidation implements MiddlewareInterface
 
 	/**
 	 * Default HTTP status code for invalid requests.
-	 *
-	 * @var int
 	 */
-	protected $httpStatusCode = 400;
+	protected int $httpStatusCode = 400;
 
 	/**
 	 * Headers and cookies to keep.
-	 *
-	 * @var array
 	 */
-	protected $keep = ['headers' => ['Access-Control-.*']];
+	protected array $keep = ['headers' => ['Access-Control-.*']];
 
 	/**
 	 * Session flash key for errors.
-	 *
-	 * @var string
 	 */
-	protected $errorsFlashKey = 'mako.errors';
+	protected string $errorsFlashKey = 'mako.errors';
 
 	/**
 	 * Session flash key for old input.
-	 *
-	 * @var string
 	 */
-	protected $oldInputFlashKey = 'mako.old';
+	protected string $oldInputFlashKey = 'mako.old';
 
 	/**
 	 * Errors view variable name.
-	 *
-	 * @var string
 	 */
-	protected $errorsVariableName = '_errors_';
+	protected string $errorsVariableName = '_errors_';
 
 	/**
 	 * Old input view variable name.
-	 *
-	 * @var string
 	 */
-	protected $oldInputVariableName = '_old_';
+	protected string $oldInputVariableName = '_old_';
 
 	/**
 	 * Default error message.
-	 *
-	 * @var string
 	 */
-	protected $defaultErrorMessage = 'Invalid input.';
+	protected string $defaultErrorMessage = 'Invalid input.';
 
 	/**
 	 * Keys that will be removed from the old input.
-	 *
-	 * @var array
 	 */
-	protected $dontInclude = ['password', 'password_confirmation'];
+	protected array $dontInclude = ['password', 'password_confirmation'];
 
 	/**
 	 * Request.
-	 *
-	 * @var \mako\http\Request
 	 */
-	protected $request;
+	protected Request $request;
 
 	/**
 	 * Response.
-	 *
-	 * @var \mako\http\Response
 	 */
-	protected $response;
+	protected Response $response;
 
 	/**
 	 * Input.
-	 *
-	 * @var \mako\validator\input\http\InputInterface|null
 	 */
-	protected $input;
+	protected InputInterface|null $input = null;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\http\routing\URLBuilder $urlBuilder  URL builder
-	 * @param \mako\session\Session|null    $session     Session
-	 * @param \mako\view\ViewFactory|null   $viewFactory View factory
 	 */
 	public function __construct(
 		protected URLBuilder $urlBuilder,
@@ -127,8 +101,6 @@ class InputValidation implements MiddlewareInterface
 
 	/**
 	 * Set the input.
-	 *
-	 * @param \mako\validator\input\http\InputInterface|null $input Input
 	 */
 	protected function setInput(?InputInterface $input): void
 	{
@@ -137,8 +109,6 @@ class InputValidation implements MiddlewareInterface
 
 	/**
 	 * Should we redirect the client if possible?
-	 *
-	 * @return bool
 	 */
 	protected function shouldRedirect(): bool
 	{
@@ -152,8 +122,6 @@ class InputValidation implements MiddlewareInterface
 
 	/**
 	 * Should the old input be included?
-	 *
-	 * @return bool
 	 */
 	protected function shouldIncludeOldInput(): bool
 	{
@@ -167,8 +135,6 @@ class InputValidation implements MiddlewareInterface
 
 	/**
 	 * Returns the old input.
-	 *
-	 * @return array
 	 */
 	protected function getOldInput(): array
 	{
@@ -186,8 +152,6 @@ class InputValidation implements MiddlewareInterface
 
 	/**
 	 * Returns the redirect URL.
-	 *
-	 * @return string
 	 */
 	protected function getRedirectUrl(): string
 	{
@@ -201,9 +165,6 @@ class InputValidation implements MiddlewareInterface
 
 	/**
 	 * Add errors to flash data and redirect.
-	 *
-	 * @param  \mako\validator\exceptions\ValidationException $exception Validation exception
-	 * @return \mako\http\Response
 	 */
 	protected function handleRedirect(ValidationException $exception): Response
 	{
@@ -221,8 +182,6 @@ class InputValidation implements MiddlewareInterface
 
 	/**
 	 * Returns the error message.
-	 *
-	 * @return string
 	 */
 	protected function getErrorMessage(): string
 	{
@@ -236,10 +195,6 @@ class InputValidation implements MiddlewareInterface
 
 	/**
 	 * Builds XML based on the exception.
-	 *
-	 * @param  \mako\validator\exceptions\ValidationException $exception Validation exception
-	 * @param  string                                         $charset   Character set
-	 * @return string
 	 */
 	protected function buildXmlFromException(ValidationException $exception, string $charset): string
 	{
@@ -259,9 +214,6 @@ class InputValidation implements MiddlewareInterface
 
 	/**
 	 * Output errors.
-	 *
-	 * @param  \mako\validator\exceptions\ValidationException $exception Validation exception
-	 * @return \mako\http\Response
 	 */
 	protected function handleOutput(ValidationException $exception): Response
 	{

--- a/src/mako/validator/input/http/routing/traits/InputValidationTrait.php
+++ b/src/mako/validator/input/http/routing/traits/InputValidationTrait.php
@@ -24,9 +24,6 @@ trait InputValidationTrait
 
 	/**
 	 * Returns an array containing validated request input.
-	 *
-	 * @param  array|string $inputOrRules Input class name or an array of validation rules
-	 * @return array
 	 */
 	protected function getValidatedInput(array|string $inputOrRules): array
 	{
@@ -40,9 +37,6 @@ trait InputValidationTrait
 
 	/**
 	 * Returns an array containing validated request files.
-	 *
-	 * @param  array|string $inputOrRules Input class name or an array of validation rules
-	 * @return array
 	 */
 	protected function getValidatedFiles(array|string $inputOrRules): array
 	{

--- a/src/mako/validator/input/traits/InputValidationTrait.php
+++ b/src/mako/validator/input/traits/InputValidationTrait.php
@@ -22,10 +22,6 @@ trait InputValidationTrait
 {
 	/**
 	 * Validates the input and returns an array containing the validated data.
-	 *
-	 * @param  array|string $input Input class name or input array
-	 * @param  array        $rules Validation rules
-	 * @return array
 	 */
 	protected function getValidatedInput(array|string $input, array $rules = []): array
 	{

--- a/src/mako/validator/rules/After.php
+++ b/src/mako/validator/rules/After.php
@@ -18,16 +18,11 @@ class After extends Rule implements RuleInterface
 {
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['format', 'date'];
+	protected array $i18nParameters = ['format', 'date'];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string $format Date format
-	 * @param string $date   Date
 	 */
 	public function __construct(
 		protected string $format,

--- a/src/mako/validator/rules/Alphanumeric.php
+++ b/src/mako/validator/rules/Alphanumeric.php
@@ -15,7 +15,6 @@ use function sprintf;
  */
 class Alphanumeric extends Rule implements RuleInterface
 {
-
 	/**
 	 * {@inheritDoc}
 	 */

--- a/src/mako/validator/rules/Before.php
+++ b/src/mako/validator/rules/Before.php
@@ -18,16 +18,11 @@ class Before extends Rule implements RuleInterface
 {
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['format', 'date'];
+	protected array $i18nParameters = ['format', 'date'];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string $format Date format
-	 * @param string $date   Date
 	 */
 	public function __construct(
 		protected string $format,

--- a/src/mako/validator/rules/Between.php
+++ b/src/mako/validator/rules/Between.php
@@ -16,9 +16,6 @@ class Between extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param mixed $minimum Minimum value
-	 * @param mixed $maximum Maximum value
 	 */
 	public function __construct(
 		protected mixed $minimum,
@@ -28,10 +25,8 @@ class Between extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['minimum', 'maximum'];
+	protected array $i18nParameters = ['minimum', 'maximum'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/Date.php
+++ b/src/mako/validator/rules/Date.php
@@ -18,8 +18,6 @@ class Date extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param string $format Date format
 	 */
 	public function __construct(
 		protected string $format
@@ -28,10 +26,8 @@ class Date extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['format'];
+	protected array $i18nParameters = ['format'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/Different.php
+++ b/src/mako/validator/rules/Different.php
@@ -18,8 +18,6 @@ class Different extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param string $field Field name
 	 */
 	public function __construct(
 		protected string $field
@@ -28,17 +26,13 @@ class Different extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['field'];
+	protected array $i18nParameters = ['field'];
 
 	/**
 	 * Parameters holding i18n field names.
-	 *
-	 * @var array
 	 */
-	protected $i18nFieldNameParameters = ['field'];
+	protected array $i18nFieldNameParameters = ['field'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/EmailDomain.php
+++ b/src/mako/validator/rules/EmailDomain.php
@@ -19,9 +19,6 @@ class EmailDomain extends Rule implements RuleInterface
 {
 	/**
 	 * Returns TRUE if the domain has a MX record and FALSE if not.
-	 *
-	 * @param  string $domain Domain
-	 * @return bool
 	 */
 	protected function hasMXRecord(string $domain): bool
 	{

--- a/src/mako/validator/rules/Enum.php
+++ b/src/mako/validator/rules/Enum.php
@@ -21,8 +21,6 @@ class Enum extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param string $enum Enum class
 	 */
 	public function __construct(
 		protected string $enum

--- a/src/mako/validator/rules/ExactLength.php
+++ b/src/mako/validator/rules/ExactLength.php
@@ -17,8 +17,6 @@ class ExactLength extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param int $length Length
 	 */
 	public function __construct(
 		protected int $length
@@ -27,10 +25,8 @@ class ExactLength extends Rule implements RuleInterface
 
 	/**
 	 * I18 parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['length'];
+	protected array $i18nParameters = ['length'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/GreaterThan.php
+++ b/src/mako/validator/rules/GreaterThan.php
@@ -16,8 +16,6 @@ class GreaterThan extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param mixed $greaterThan Greater than
 	 */
 	public function __construct(
 		protected mixed $greaterThan
@@ -26,10 +24,8 @@ class GreaterThan extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['greaterThan'];
+	protected array $i18nParameters = ['greaterThan'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/GreaterThanOrEqualTo.php
+++ b/src/mako/validator/rules/GreaterThanOrEqualTo.php
@@ -16,8 +16,6 @@ class GreaterThanOrEqualTo extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param mixed $greaterThanOrEqualTo Greater than or equal to
 	 */
 	public function __construct(
 		protected mixed $greaterThanOrEqualTo
@@ -26,10 +24,8 @@ class GreaterThanOrEqualTo extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['greaterThanOrEqualTo'];
+	protected array $i18nParameters = ['greaterThanOrEqualTo'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/I18nAwareInterface.php
+++ b/src/mako/validator/rules/I18nAwareInterface.php
@@ -16,19 +16,11 @@ interface I18nAwareInterface
 {
 	/**
 	 * Sets the I18n instance.
-	 *
-	 * @param  \mako\i18n\I18n                          $i18n I18n
-	 * @return \mako\validator\rules\I18nAwareInterface
 	 */
 	public function setI18n(I18n $i18n): I18nAwareInterface;
 
 	/**
 	 * Returns the translated error message.
-	 *
-	 * @param  string      $field   Field name
-	 * @param  string      $rule    Rule name
-	 * @param  string|null $package Package name
-	 * @return string
 	 */
 	public function getTranslatedErrorMessage(string $field, string $rule, ?string $package = null): string;
 }

--- a/src/mako/validator/rules/IP.php
+++ b/src/mako/validator/rules/IP.php
@@ -20,8 +20,6 @@ class IP extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param string|null $version IP version
 	 */
 	public function __construct(
 		protected ?string $version = null
@@ -30,15 +28,11 @@ class IP extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['version'];
+	protected array $i18nParameters = ['version'];
 
 	/**
 	 * Returns the filter flags.
-	 *
-	 * @return int
 	 */
 	protected function getFlags(): int
 	{
@@ -53,8 +47,6 @@ class IP extends Rule implements RuleInterface
 
 	/**
 	 * Returns the name of the IP version that we're validating.
-	 *
-	 * @return string
 	 */
 	protected function getVersion(): string
 	{

--- a/src/mako/validator/rules/In.php
+++ b/src/mako/validator/rules/In.php
@@ -17,8 +17,6 @@ class In extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param array $values Allowed values
 	 */
 	public function __construct(
 		protected array $values
@@ -27,10 +25,8 @@ class In extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['values'];
+	protected array $i18nParameters = ['values'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/LessThan.php
+++ b/src/mako/validator/rules/LessThan.php
@@ -16,8 +16,6 @@ class LessThan extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param mixed $lessThan Less than
 	 */
 	public function __construct(
 		protected mixed $lessThan
@@ -26,10 +24,8 @@ class LessThan extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['lessThan'];
+	protected array $i18nParameters = ['lessThan'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/LessThanOrEqualTo.php
+++ b/src/mako/validator/rules/LessThanOrEqualTo.php
@@ -16,8 +16,6 @@ class LessThanOrEqualTo extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param mixed $lessThanOrEqualTo Less than or equal to
 	 */
 	public function __construct(
 		protected mixed $lessThanOrEqualTo
@@ -26,10 +24,8 @@ class LessThanOrEqualTo extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['lessThanOrEqualTo'];
+	protected array $i18nParameters = ['lessThanOrEqualTo'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/MatchField.php
+++ b/src/mako/validator/rules/MatchField.php
@@ -18,8 +18,6 @@ class MatchField extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param string $field Field name
 	 */
 	public function __construct(
 		protected string $field
@@ -28,17 +26,13 @@ class MatchField extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['field'];
+	protected array $i18nParameters = ['field'];
 
 	/**
 	 * Parameters holding additional i18n field names.
-	 *
-	 * @var array
 	 */
-	protected $i18nFieldNameParameters = ['field'];
+	protected array $i18nFieldNameParameters = ['field'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/MaxLength.php
+++ b/src/mako/validator/rules/MaxLength.php
@@ -17,8 +17,6 @@ class MaxLength extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param int $maxLength Max length
 	 */
 	public function __construct(
 		protected int $maxLength
@@ -27,10 +25,8 @@ class MaxLength extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['maxLength'];
+	protected array $i18nParameters = ['maxLength'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/MinLength.php
+++ b/src/mako/validator/rules/MinLength.php
@@ -17,8 +17,6 @@ class MinLength extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param int $minLength Min length
 	 */
 	public function __construct(
 		protected int $minLength
@@ -27,10 +25,8 @@ class MinLength extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['minLength'];
+	protected array $i18nParameters = ['minLength'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/NotIn.php
+++ b/src/mako/validator/rules/NotIn.php
@@ -17,8 +17,6 @@ class NotIn extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param array $values Disallowed values
 	 */
 	public function __construct(
 		protected array $values
@@ -27,10 +25,8 @@ class NotIn extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['values'];
+	protected array $i18nParameters = ['values'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/Regex.php
+++ b/src/mako/validator/rules/Regex.php
@@ -17,8 +17,6 @@ class Regex extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param string $regex Regex
 	 */
 	public function __construct(
 		protected string $regex
@@ -27,10 +25,8 @@ class Regex extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['regex'];
+	protected array $i18nParameters = ['regex'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/RuleInterface.php
+++ b/src/mako/validator/rules/RuleInterface.php
@@ -14,26 +14,16 @@ interface RuleInterface
 {
 	/**
 	 * Returns TRUE if the rule should be executed when the input is empty and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function validateWhenEmpty(): bool;
 
 	/**
 	 * Returns TRUE if the rule succeeds and FALSE if not.
-	 *
-	 * @param  mixed  $value Value to validate
-	 * @param  string $field Input field
-	 * @param  array  $input Input
-	 * @return bool
 	 */
 	public function validate(mixed $value, string $field, array $input): bool;
 
 	/**
 	 * Returns an error message.
-	 *
-	 * @param  string $field Field name
-	 * @return string
 	 */
 	public function getErrorMessage(string $field): string;
 }

--- a/src/mako/validator/rules/TimeZone.php
+++ b/src/mako/validator/rules/TimeZone.php
@@ -19,9 +19,6 @@ class TimeZone extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param int         $group   Time zone group
-	 * @param string|null $country Country code
 	 */
 	public function __construct(
 		protected int $group = DateTimeZone::ALL,

--- a/src/mako/validator/rules/database/Exists.php
+++ b/src/mako/validator/rules/database/Exists.php
@@ -20,18 +20,11 @@ class Exists extends Rule implements RuleInterface
 {
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['table', 'column'];
+	protected array $i18nParameters = ['table', 'column'];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string                           $table      Table
-	 * @param string                           $column     Column
-	 * @param string|null                      $connection Connection
-	 * @param \mako\database\ConnectionManager $database   Connection manager
 	 */
 	public function __construct(
 		protected string $table,

--- a/src/mako/validator/rules/database/Unique.php
+++ b/src/mako/validator/rules/database/Unique.php
@@ -20,19 +20,11 @@ class Unique extends Rule implements RuleInterface
 {
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['table', 'column'];
+	protected array $i18nParameters = ['table', 'column'];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param string                           $table      Table
-	 * @param string                           $column     Column
-	 * @param mixed                            $allowed    Allowed value
-	 * @param string|null                      $connection Connection
-	 * @param \mako\database\ConnectionManager $database   Connection manager
 	 */
 	public function __construct(
 		protected string $table,

--- a/src/mako/validator/rules/file/Hash.php
+++ b/src/mako/validator/rules/file/Hash.php
@@ -19,9 +19,6 @@ class Hash extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param string $hash      Hash
-	 * @param string $algorithm Algorithm
 	 */
 	public function __construct(
 		protected string $hash,
@@ -31,10 +28,8 @@ class Hash extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['hash', 'algorithm'];
+	protected array $i18nParameters = ['hash', 'algorithm'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/file/Hmac.php
+++ b/src/mako/validator/rules/file/Hmac.php
@@ -19,10 +19,6 @@ class Hmac extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param string $hmac      Hmac
-	 * @param string $key       Key
-	 * @param string $algorithm Algorithm
 	 */
 	public function __construct(
 		protected string $hmac,
@@ -33,10 +29,8 @@ class Hmac extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['hmac', 'algorithm'];
+	protected array $i18nParameters = ['hmac', 'algorithm'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/file/MaxFileSize.php
+++ b/src/mako/validator/rules/file/MaxFileSize.php
@@ -24,8 +24,6 @@ class MaxFileSize extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param int|string $maxSize Max size
 	 */
 	public function __construct(
 		protected int|string $maxSize
@@ -34,16 +32,11 @@ class MaxFileSize extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['maxSize'];
+	protected array $i18nParameters = ['maxSize'];
 
 	/**
 	 * Convert human friendly size to bytes.
-	 *
-	 * @param  int|string $size Size
-	 * @return float|int
 	 */
 	protected function convertToBytes(int|string $size): float|int
 	{

--- a/src/mako/validator/rules/file/MaxFilenameLength.php
+++ b/src/mako/validator/rules/file/MaxFilenameLength.php
@@ -21,8 +21,6 @@ class MaxFilenameLength extends Rule implements RuleInterface
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param int $maxLength Max filename length
 	 */
 	public function __construct(
 		protected int $maxLength
@@ -31,10 +29,8 @@ class MaxFilenameLength extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['maxLength'];
+	protected array $i18nParameters = ['maxLength'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/file/MimeType.php
+++ b/src/mako/validator/rules/file/MimeType.php
@@ -21,15 +21,11 @@ class MimeType extends Rule implements RuleInterface
 {
 	/**
 	 * Mime types.
-	 *
-	 * @var array
 	 */
-	protected $mimeTypes;
+	protected array $mimeTypes;
 
 	/**
 	 * Constructor.
-	 *
-	 * @param array|string $mimeType Mime type or array of mime types
 	 */
 	public function __construct(array|string $mimeType)
 	{
@@ -38,10 +34,8 @@ class MimeType extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['mimeTypes'];
+	protected array $i18nParameters = ['mimeTypes'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/file/image/AspectRatio.php
+++ b/src/mako/validator/rules/file/image/AspectRatio.php
@@ -22,9 +22,6 @@ class AspectRatio extends Rule implements RuleInterface
 
 	/**
 	 * Constructor.
-	 *
-	 * @param int $width  Width
-	 * @param int $height Height
 	 */
 	public function __construct(
 		protected int $width,
@@ -34,10 +31,8 @@ class AspectRatio extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['width', 'height'];
+	protected array $i18nParameters = ['width', 'height'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/file/image/ExactDimensions.php
+++ b/src/mako/validator/rules/file/image/ExactDimensions.php
@@ -22,9 +22,6 @@ class ExactDimensions extends Rule implements RuleInterface
 
 	/**
 	 * Constructor.
-	 *
-	 * @param int $width  Width
-	 * @param int $height Height
 	 */
 	public function __construct(
 		protected int $width,
@@ -34,10 +31,8 @@ class ExactDimensions extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['width', 'height'];
+	protected array $i18nParameters = ['width', 'height'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/file/image/MaxDimensions.php
+++ b/src/mako/validator/rules/file/image/MaxDimensions.php
@@ -22,9 +22,6 @@ class MaxDimensions extends Rule implements RuleInterface
 
 	/**
 	 * Constructor.
-	 *
-	 * @param int $width  Width
-	 * @param int $height Height
 	 */
 	public function __construct(
 		protected int $width,
@@ -34,10 +31,8 @@ class MaxDimensions extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['width', 'height'];
+	protected array $i18nParameters = ['width', 'height'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/file/image/MinDimensions.php
+++ b/src/mako/validator/rules/file/image/MinDimensions.php
@@ -22,9 +22,6 @@ class MinDimensions extends Rule implements RuleInterface
 
 	/**
 	 * Constructor.
-	 *
-	 * @param int $width  Width
-	 * @param int $height Height
 	 */
 	public function __construct(
 		protected int $width,
@@ -34,10 +31,8 @@ class MinDimensions extends Rule implements RuleInterface
 
 	/**
 	 * I18n parameters.
-	 *
-	 * @var array
 	 */
-	protected $i18nParameters = ['width', 'height'];
+	protected array $i18nParameters = ['width', 'height'];
 
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/file/image/traits/GetImageSizeTrait.php
+++ b/src/mako/validator/rules/file/image/traits/GetImageSizeTrait.php
@@ -18,9 +18,6 @@ trait GetImageSizeTrait
 {
 	/**
 	 * Returns the image size.
-	 *
-	 * @param  \SplFileInfo $image Image file
-	 * @return array
 	 */
 	protected function getImageSize(SplFileInfo $image): array
 	{

--- a/src/mako/validator/rules/session/OneTimeToken.php
+++ b/src/mako/validator/rules/session/OneTimeToken.php
@@ -21,8 +21,6 @@ class OneTimeToken extends Rule implements RuleInterface
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\session\Session $session Session
 	 */
 	public function __construct(
 		protected Session $session

--- a/src/mako/validator/rules/session/Token.php
+++ b/src/mako/validator/rules/session/Token.php
@@ -21,8 +21,6 @@ class Token extends Rule implements RuleInterface
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\session\Session $session Session
 	 */
 	public function __construct(
 		protected Session $session

--- a/src/mako/validator/rules/traits/DoesntValidateWhenEmptyTrait.php
+++ b/src/mako/validator/rules/traits/DoesntValidateWhenEmptyTrait.php
@@ -14,8 +14,6 @@ trait DoesntValidateWhenEmptyTrait
 {
 	/**
 	 * Returns TRUE if the rule should be executed when the input is empty and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function validateWhenEmpty(): bool
 	{

--- a/src/mako/validator/rules/traits/I18nAwareTrait.php
+++ b/src/mako/validator/rules/traits/I18nAwareTrait.php
@@ -27,16 +27,11 @@ trait I18nAwareTrait
 {
 	/**
 	 * I18n.
-	 *
-	 * @var \mako\i18n\I18n
 	 */
-	protected $i18n;
+	protected I18n $i18n;
 
 	/**
 	 * Sets the I18n instance.
-	 *
-	 * @param  \mako\i18n\I18n                          $i18n I18n
-	 * @return \mako\validator\rules\I18nAwareInterface
 	 */
 	public function setI18n(I18n $i18n): I18nAwareInterface
 	{
@@ -47,10 +42,6 @@ trait I18nAwareTrait
 
 	/**
 	 * Returns a translated field name.
-	 *
-	 * @param  string $field   Field name
-	 * @param  string $package Package prefix
-	 * @return string
 	 */
 	protected function translateFieldName(string $field, string $package): string
 	{
@@ -68,10 +59,6 @@ trait I18nAwareTrait
 
 	/**
 	 * Gets the i18n parameters.
-	 *
-	 * @param  string $field   Field name
-	 * @param  string $package Package prefix
-	 * @return array
 	 */
 	protected function getI18nParameters(string $field, string $package): array
 	{
@@ -95,19 +82,11 @@ trait I18nAwareTrait
 
 	/**
 	 * Returns an error message.
-	 *
-	 * @param  string $field Field name
-	 * @return string
 	 */
 	abstract public function getErrorMessage(string $field): string;
 
 	/**
 	 * Returns the translated error message.
-	 *
-	 * @param  string      $field   Field name
-	 * @param  string      $rule    Rule name
-	 * @param  string|null $package Package name
-	 * @return string
 	 */
 	public function getTranslatedErrorMessage(string $field, string $rule, ?string $package = null): string
 	{

--- a/src/mako/validator/rules/traits/ValidatesWhenEmptyTrait.php
+++ b/src/mako/validator/rules/traits/ValidatesWhenEmptyTrait.php
@@ -14,8 +14,6 @@ trait ValidatesWhenEmptyTrait
 {
 	/**
 	 * Returns TRUE if the rule should be executed when the input is empty and FALSE if not.
-	 *
-	 * @return bool
 	 */
 	public function validateWhenEmpty(): bool
 	{

--- a/src/mako/view/View.php
+++ b/src/mako/view/View.php
@@ -17,10 +17,6 @@ class View implements Stringable
 {
 	/**
 	 * Constructor.
-	 *
-	 * @param string                                 $path      View path
-	 * @param array                                  $variables View variables
-	 * @param \mako\view\renderers\RendererInterface $renderer  Renderer instance
 	 */
 	public function __construct(
 		protected string $path,
@@ -31,8 +27,6 @@ class View implements Stringable
 
 	/**
 	 * Returns the assigned view variables.
-	 *
-	 * @return array
 	 */
 	public function getVariables(): array
 	{
@@ -41,8 +35,6 @@ class View implements Stringable
 
 	/**
 	 * Returns the renderer instance.
-	 *
-	 * @return \mako\view\renderers\RendererInterface
 	 */
 	public function getRenderer(): RendererInterface
 	{
@@ -51,10 +43,6 @@ class View implements Stringable
 
 	/**
 	 * Assign a local view variable.
-	 *
-	 * @param  string          $name  Variable name
-	 * @param  mixed           $value View variable
-	 * @return \mako\view\View
 	 */
 	public function assign(string $name, mixed $value): View
 	{
@@ -65,8 +53,6 @@ class View implements Stringable
 
 	/**
 	 * Returns the rendered view.
-	 *
-	 * @return string
 	 */
 	public function render(): string
 	{
@@ -75,8 +61,6 @@ class View implements Stringable
 
 	/**
 	 * Returns the rendered view.
-	 *
-	 * @return string
 	 */
 	public function __toString(): string
 	{

--- a/src/mako/view/ViewFactory.php
+++ b/src/mako/view/ViewFactory.php
@@ -26,53 +26,36 @@ class ViewFactory
 
 	/**
 	 * Charset.
-	 *
-	 * @var string
 	 */
-	protected $charset;
+	protected string $charset;
 
 	/**
 	 * View renderers.
-	 *
-	 * @var array
 	 */
-	protected $renderers = ['.php' => PHP::class];
+	protected array $renderers = ['.php' => PHP::class];
 
 	/**
 	 * Global view variables.
-	 *
-	 * @var array
 	 */
-	protected $globalVariables = [];
+	protected array $globalVariables = [];
 
 	/**
 	 * Variables that should be auto assigned to views.
-	 *
-	 * @var array
 	 */
-	protected $autoAssignVariables = [];
+	protected array $autoAssignVariables = [];
 
 	/**
 	 * View cache.
-	 *
-	 * @var array
 	 */
-	protected $viewCache = [];
+	protected array $viewCache = [];
 
 	/**
 	 * Renderer instances.
-	 *
-	 * @var array
 	 */
-	protected $rendererInstances;
+	protected array $rendererInstances = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\file\FileSystem   $fileSystem File system instance
-	 * @param string                  $path       Default path
-	 * @param string                  $charset    Charset
-	 * @param \mako\syringe\Container $container  Container
 	 */
 	public function __construct(
 		protected FileSystem $fileSystem,
@@ -90,8 +73,6 @@ class ViewFactory
 
 	/**
 	 * Returns the charset.
-	 *
-	 * @return string
 	 */
 	public function getCharset(): string
 	{
@@ -100,9 +81,6 @@ class ViewFactory
 
 	/**
 	 * Sets the charset.
-	 *
-	 * @param  string                 $charset Charset
-	 * @return \mako\view\ViewFactory
 	 */
 	public function setCharset(string $charset): ViewFactory
 	{
@@ -113,10 +91,6 @@ class ViewFactory
 
 	/**
 	 * Registers a custom view renderer.
-	 *
-	 * @param  string                 $extension Extension handled by the renderer
-	 * @param  \Closure|string        $renderer  Renderer class or closure that creates a renderer instance
-	 * @return \mako\view\ViewFactory
 	 */
 	public function extend(string $extension, Closure|string $renderer): ViewFactory
 	{
@@ -127,10 +101,6 @@ class ViewFactory
 
 	/**
 	 * Assign a global view variable that will be available in all views.
-	 *
-	 * @param  string                 $name  Variable name
-	 * @param  mixed                  $value View variable
-	 * @return \mako\view\ViewFactory
 	 */
 	public function assign(string $name, mixed $value): ViewFactory
 	{
@@ -141,10 +111,6 @@ class ViewFactory
 
 	/**
 	 * Assign variables that should be auto assigned to views upon creation.
-	 *
-	 * @param  string                 $view      View name or array of view names
-	 * @param  callable               $variables Callable that returns an array of variables
-	 * @return \mako\view\ViewFactory
 	 */
 	public function autoAssign($view, callable $variables): ViewFactory
 	{
@@ -158,8 +124,6 @@ class ViewFactory
 
 	/**
 	 * Clears the autoassign variables.
-	 *
-	 * @return \mako\view\ViewFactory
 	 */
 	public function clearAutoAssignVariables(): ViewFactory
 	{
@@ -170,10 +134,6 @@ class ViewFactory
 
 	/**
 	 * Returns an array containing the view path and the renderer we should use.
-	 *
-	 * @param  string      $view           View
-	 * @param  bool        $throwException Throw exception if view doesn't exist?
-	 * @return array|false
 	 */
 	protected function getViewPathAndExtension(string $view, bool $throwException = true)
 	{
@@ -209,9 +169,6 @@ class ViewFactory
 
 	/**
 	 * Creates a renderer instance.
-	 *
-	 * @param  \Closure|string                        $renderer Renderer class or closure
-	 * @return \mako\view\renderers\RendererInterface
 	 */
 	protected function rendererFactory(Closure|string $renderer): RendererInterface
 	{
@@ -220,9 +177,6 @@ class ViewFactory
 
 	/**
 	 * Returns a renderer instance.
-	 *
-	 * @param  string                                 $extension Extension associated with the renderer
-	 * @return \mako\view\renderers\RendererInterface
 	 */
 	protected function resolveRenderer(string $extension): RendererInterface
 	{
@@ -236,9 +190,6 @@ class ViewFactory
 
 	/**
 	 * Returns TRUE if the view exists and FALSE if not.
-	 *
-	 * @param  string $view View
-	 * @return bool
 	 */
 	public function exists(string $view): bool
 	{
@@ -247,9 +198,6 @@ class ViewFactory
 
 	/**
 	 * Returns view specific auto assign variables.
-	 *
-	 * @param  string $view View
-	 * @return array
 	 */
 	protected function getAutoAssignVariablesForView(string $view): array
 	{
@@ -263,9 +211,6 @@ class ViewFactory
 
 	/**
 	 * Returns auto assign variables for a view.
-	 *
-	 * @param  string $view View
-	 * @return array
 	 */
 	protected function getAutoAssignVariables(string $view): array
 	{
@@ -274,10 +219,6 @@ class ViewFactory
 
 	/**
 	 * Returns array where variables have been merged in order of importance.
-	 *
-	 * @param  string $view      View
-	 * @param  array  $variables View variables
-	 * @return array
 	 */
 	protected function mergeVariables(string $view, array $variables): array
 	{
@@ -286,10 +227,6 @@ class ViewFactory
 
 	/**
 	 * Creates and returns a view instance.
-	 *
-	 * @param  string          $view      View
-	 * @param  array           $variables View variables
-	 * @return \mako\view\View
 	 */
 	public function create(string $view, array $variables = []): View
 	{
@@ -300,10 +237,6 @@ class ViewFactory
 
 	/**
 	 * Creates and returns a rendered view.
-	 *
-	 * @param  string $view      View
-	 * @param  array  $variables View variables
-	 * @return string
 	 */
 	public function render(string $view, array $variables = []): string
 	{

--- a/src/mako/view/compilers/Template.php
+++ b/src/mako/view/compilers/Template.php
@@ -33,17 +33,13 @@ class Template
 
 	/**
 	 * Verbatims.
-	 *
-	 * @var array
 	 */
-	protected $verbatims = [];
+	protected array $verbatims = [];
 
 	/**
 	 * Compilation order.
-	 *
-	 * @var array
 	 */
-	protected $compileOrder =
+	protected array $compileOrder =
 	[
 		'collectVerbatims',
 		'comments',
@@ -59,10 +55,6 @@ class Template
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\file\FileSystem $fileSystem File system instance
-	 * @param string                $cachePath  Cache path
-	 * @param string                $template   Path to template
 	 */
 	public function __construct(
 		protected FileSystem $fileSystem,
@@ -73,9 +65,6 @@ class Template
 
 	/**
 	 * Collects verbatim blocks and replaces them with a palceholder.
-	 *
-	 * @param  string $template Template
-	 * @return string
 	 */
 	protected function collectVerbatims(string $template): string
 	{
@@ -89,9 +78,6 @@ class Template
 
 	/**
 	 * Replaces verbatim placeholders with their original values.
-	 *
-	 * @param  string $template Template
-	 * @return string
 	 */
 	public function insertVerbatims(string $template): string
 	{
@@ -105,9 +91,6 @@ class Template
 
 	/**
 	 * Compiles comments.
-	 *
-	 * @param  string $template Template
-	 * @return string
 	 */
 	protected function comments(string $template): string
 	{
@@ -118,9 +101,6 @@ class Template
 
 	/**
 	 * Compiles template extensions.
-	 *
-	 * @param  string $template Template
-	 * @return string
 	 */
 	protected function extensions(string $template): string
 	{
@@ -141,9 +121,6 @@ class Template
 
 	/**
 	 * Compiles nospace blocks.
-	 *
-	 * @param  string $template Template
-	 * @return string
 	 */
 	protected function nospaces(string $template): string
 	{
@@ -163,9 +140,6 @@ class Template
 
 	/**
 	 * Compiles view includes.
-	 *
-	 * @param  string $template Template
-	 * @return string
 	 */
 	protected function views(string $template): string
 	{
@@ -180,9 +154,6 @@ class Template
 
 	/**
 	 * Compiles capture blocks.
-	 *
-	 * @param  string $template Template
-	 * @return string
 	 */
 	protected function captures(string $template): string
 	{
@@ -194,9 +165,6 @@ class Template
 
 	/**
 	 * Compiles blocks.
-	 *
-	 * @param  string $template Template
-	 * @return string
 	 */
 	protected function blocks(string $template): string
 	{
@@ -211,9 +179,6 @@ class Template
 
 	/**
 	 * Compiles control structures.
-	 *
-	 * @param  string $template Template
-	 * @return string
 	 */
 	protected function controlStructures(string $template): string
 	{
@@ -228,9 +193,6 @@ class Template
 
 	/**
 	 * Compiles echos.
-	 *
-	 * @param  string $template Template
-	 * @return string
 	 */
 	protected function echos(string $template): string
 	{

--- a/src/mako/view/renderers/RendererInterface.php
+++ b/src/mako/view/renderers/RendererInterface.php
@@ -14,10 +14,6 @@ interface RendererInterface
 {
 	/**
 	 * Returns the rendered view.
-	 *
-	 * @param  string $__view__      View path
-	 * @param  array  $__variables__ View variables
-	 * @return string
 	 */
 	public function render(string $__view__, array $__variables__): string;
 }

--- a/src/mako/view/renderers/Template.php
+++ b/src/mako/view/renderers/Template.php
@@ -24,23 +24,16 @@ class Template extends PHP
 {
 	/**
 	 * Template blocks.
-	 *
-	 * @var array
 	 */
-	protected $blocks = [];
+	protected array $blocks = [];
 
 	/**
 	 * Open template blocks.
-	 *
-	 * @var array
 	 */
-	protected $openBlocks = [];
+	protected array $openBlocks = [];
 
 	/**
 	 * Constructor.
-	 *
-	 * @param \mako\file\FileSystem $fileSystem File system instance
-	 * @param string                $cachePath  Cache path
 	 */
 	public function __construct(
 		protected FileSystem $fileSystem,
@@ -50,8 +43,6 @@ class Template extends PHP
 
 	/**
 	 * Returns the path to the compiled template.
-	 *
-	 * @return string
 	 */
 	protected function getCompiledPath(string $view): string
 	{
@@ -60,10 +51,6 @@ class Template extends PHP
 
 	/**
 	 * Returns TRUE if the template needs to be compiled and FALSE if not.
-	 *
-	 * @param  string $view     View path
-	 * @param  string $compiled Compiled view path
-	 * @return bool
 	 */
 	protected function needToCompile(string $view, string $compiled): bool
 	{
@@ -72,8 +59,6 @@ class Template extends PHP
 
 	/**
 	 * Compiles view.
-	 *
-	 * @param string $view View path
 	 */
 	protected function compile(string $view): void
 	{
@@ -82,8 +67,6 @@ class Template extends PHP
 
 	/**
 	 * Opens a template block.
-	 *
-	 * @param string $name Block name
 	 */
 	public function open(string $name): void
 	{
@@ -92,8 +75,6 @@ class Template extends PHP
 
 	/**
 	 * Closes a template block.
-	 *
-	 * @return string
 	 */
 	public function close(): string
 	{
@@ -102,8 +83,6 @@ class Template extends PHP
 
 	/**
 	 * Output a template block.
-	 *
-	 * @param string $name Block name
 	 */
 	public function output(string $name): void
 	{

--- a/src/mako/view/renderers/traits/EscaperTrait.php
+++ b/src/mako/view/renderers/traits/EscaperTrait.php
@@ -28,10 +28,8 @@ trait EscaperTrait
 {
 	/**
 	 * HTML entity map.
-	 *
-	 * @var array
 	 */
-	protected $htmlNamedEntityMap =
+	protected array $htmlNamedEntityMap =
 	[
 		34 => 'quot',
 		38 => 'amp',
@@ -41,11 +39,6 @@ trait EscaperTrait
 
 	/**
 	 * Returns a string that has been escaped for a HTML body context.
-	 *
-	 * @param  string|null $string       String to escape
-	 * @param  string      $charset      Character set
-	 * @param  bool        $doubleEncode Should existing entities be encoded?
-	 * @return string
 	 */
 	public function escapeHTML(?string $string, string $charset, bool $doubleEncode = true): string
 	{
@@ -59,9 +52,6 @@ trait EscaperTrait
 
 	/**
 	 * Returns a string that has been escaped for a URI or parameter context.
-	 *
-	 * @param  string|null $string String to escape
-	 * @return string
 	 */
 	public function escapeURL(?string $string): string
 	{
@@ -77,9 +67,6 @@ trait EscaperTrait
 	 * Escapes characters for use in a HTML attribute context.
 	 *
 	 * (This method contains code from the SecurityMultiTool library).
-	 *
-	 * @param  array  $matches Regex matches
-	 * @return string
 	 */
 	protected function attributeEscaper(array $matches): string
 	{
@@ -125,10 +112,6 @@ trait EscaperTrait
 
 	/**
 	 * Returns a string that has been escaped for a HTML attribute context.
-	 *
-	 * @param  string|null $string  String to escape
-	 * @param  string      $charset Character set
-	 * @return string
 	 */
 	public function escapeAttribute(?string $string, string $charset): string
 	{
@@ -156,9 +139,6 @@ trait EscaperTrait
 	 * Escapes characters for use in a CSS context.
 	 *
 	 * (This method contains code from the SecurityMultiTool library).
-	 *
-	 * @param  array  $matches Regex matches
-	 * @return string
 	 */
 	protected function cssEscaper(array $matches): string
 	{
@@ -180,10 +160,6 @@ trait EscaperTrait
 
 	/**
 	 * Returns a string that has been escaped for a CSS context.
-	 *
-	 * @param  string|null $string  String to escape
-	 * @param  string      $charset Character set
-	 * @return string
 	 */
 	public function escapeCSS(?string $string, string $charset): string
 	{
@@ -216,9 +192,6 @@ trait EscaperTrait
 	 * Escapes characters for use in a Javascript context.
 	 *
 	 * (This method contains code from the SecurityMultiTool library).
-	 *
-	 * @param  array  $matches Regex matches
-	 * @return string
 	 */
 	protected function javascriptEscaper(array $matches): string
 	{
@@ -236,10 +209,6 @@ trait EscaperTrait
 
 	/**
 	 * Returns a string that has been escaped for a Javascript context.
-	 *
-	 * @param  string|null $string  String to escape
-	 * @param  string      $charset Character set
-	 * @return string
 	 */
 	public function escapeJavascript(?string $string, string $charset): string
 	{

--- a/tests/integration/BuilderTestCase.php
+++ b/tests/integration/BuilderTestCase.php
@@ -17,9 +17,9 @@ use PDO;
 abstract class BuilderTestCase extends TestCase
 {
 	/**
-	 * @var \mako\database\ConnectionManager
+	 *
 	 */
-	protected $connectionManager;
+	protected ConnectionManager $connectionManager;
 
 	/**
 	 * {@inheritDoc}

--- a/tests/integration/database/midgard/NullableTest.php
+++ b/tests/integration/database/midgard/NullableTest.php
@@ -24,9 +24,9 @@ class NullableTest extends ORMTestCase
 		{
 			use NullableTrait;
 
-			protected $tableName = 'nullables';
+			protected string $tableName = 'nullables';
 
-			protected $nullable = ['value1'];
+			protected array $nullable = ['value1'];
 		};
 	}
 

--- a/tests/integration/database/midgard/ORMTest.php
+++ b/tests/integration/database/midgard/ORMTest.php
@@ -23,7 +23,7 @@ use mako\utility\UUID;
 
 class TestUser extends TestORM
 {
-	protected $tableName = 'users';
+	protected string $tableName = 'users';
 
 	public function profile(): HasOne
 	{
@@ -33,7 +33,7 @@ class TestUser extends TestORM
 
 class Profile extends TestORM
 {
-	protected $tableName = 'profiles';
+	protected string $tableName = 'profiles';
 }
 
 class TestUserScoped extends TestUser
@@ -46,21 +46,21 @@ class TestUserScoped extends TestUser
 
 class TestUserDateTime extends TestUser
 {
-	protected $cast = ['created_at' => 'date'];
+	protected array $cast = ['created_at' => 'date'];
 }
 
 class UUIDKey extends TestORM
 {
-	protected $tableName = 'uuid_keys';
+	protected string $tableName = 'uuid_keys';
 
-	protected $primaryKeyType = TestORM::PRIMARY_KEY_TYPE_UUID;
+	protected int $primaryKeyType = TestORM::PRIMARY_KEY_TYPE_UUID;
 }
 
 class CustomKey extends TestORM
 {
-	protected $tableName = 'custom_keys';
+	protected string $tableName = 'custom_keys';
 
-	protected $primaryKeyType = TestORM::PRIMARY_KEY_TYPE_CUSTOM;
+	protected int $primaryKeyType = TestORM::PRIMARY_KEY_TYPE_CUSTOM;
 
 	protected function generatePrimaryKey(): mixed
 	{
@@ -70,14 +70,14 @@ class CustomKey extends TestORM
 
 class NoKey extends TestORM
 {
-	protected $tableName = 'no_keys';
+	protected string $tableName = 'no_keys';
 
-	protected $primaryKeyType = TestORM::PRIMARY_KEY_TYPE_NONE;
+	protected int $primaryKeyType = TestORM::PRIMARY_KEY_TYPE_NONE;
 }
 
 class Counter extends TestORM
 {
-	protected $tableName = 'counters';
+	protected string $tableName = 'counters';
 }
 
 enum FooEnum: int
@@ -88,7 +88,7 @@ enum FooEnum: int
 
 class Enum extends TestORM
 {
-	protected $cast = ['value' => ['enum' => FooEnum::class]];
+	protected array $cast = ['value' => ['enum' => FooEnum::class]];
 }
 
 // --------------------------------------------------------------------------

--- a/tests/integration/database/midgard/OptimisticLockingTest.php
+++ b/tests/integration/database/midgard/OptimisticLockingTest.php
@@ -20,7 +20,7 @@ class OptimisticLock extends TestORM
 {
 	use OptimisticLockingTrait;
 
-	protected $tableName = 'optimistic_locks';
+	protected string $tableName = 'optimistic_locks';
 }
 
 // --------------------------------------------------------------------------

--- a/tests/integration/database/midgard/TimestampedTest.php
+++ b/tests/integration/database/midgard/TimestampedTest.php
@@ -20,16 +20,16 @@ class TimestampedFoo extends TestORM
 {
 	use TimestampedTrait;
 
-	protected $tableName = 'timestamped_foos';
+	protected string $tableName = 'timestamped_foos';
 }
 
 class TimestampedBar extends TestORM
 {
 	use TimestampedTrait;
 
-	protected $tableName = 'timestamped_bars';
+	protected string $tableName = 'timestamped_bars';
 
-	protected $touch = ['foo'];
+	protected array $touch = ['foo'];
 
 	public function foo()
 	{

--- a/tests/integration/database/midgard/relations/AutoEagerLoadingTest.php
+++ b/tests/integration/database/midgard/relations/AutoEagerLoadingTest.php
@@ -17,9 +17,9 @@ use mako\tests\integration\TestORM;
 
 class AutoEagerLoadingUser extends TestORM
 {
-	protected $tableName = 'users';
+	protected string $tableName = 'users';
 
-	protected $including = ['articles'];
+	protected array $including = ['articles'];
 
 	public function articles()
 	{
@@ -29,7 +29,7 @@ class AutoEagerLoadingUser extends TestORM
 
 class AutoEagerLoadingArticle extends TestORM
 {
-	protected $tableName = 'articles';
+	protected string $tableName = 'articles';
 }
 
 // --------------------------------------------------------------------------

--- a/tests/integration/database/midgard/relations/BelongsToPolymorphicTest.php
+++ b/tests/integration/database/midgard/relations/BelongsToPolymorphicTest.php
@@ -16,12 +16,12 @@ use mako\tests\integration\TestORM;
 
 class BelongsToPolymorphicProfile extends TestORM
 {
-	protected $tableName = 'profiles';
+	protected string $tableName = 'profiles';
 }
 
 class BelongsToPolymorphicImage extends TestORM
 {
-	protected $tableName = 'images';
+	protected string $tableName = 'images';
 
 	public function profile()
 	{

--- a/tests/integration/database/midgard/relations/BelongsToTest.php
+++ b/tests/integration/database/midgard/relations/BelongsToTest.php
@@ -18,12 +18,12 @@ use mako\tests\integration\TestORM;
 
 class BelongsToUser extends TestORM
 {
-	protected $tableName = 'users';
+	protected string $tableName = 'users';
 }
 
 class BelongsToProfile extends TestORM
 {
-	protected $tableName = 'profiles';
+	protected string $tableName = 'profiles';
 
 	public function user()
 	{

--- a/tests/integration/database/midgard/relations/HasManyPolymorphicTest.php
+++ b/tests/integration/database/midgard/relations/HasManyPolymorphicTest.php
@@ -18,7 +18,7 @@ use mako\tests\integration\TestORM;
 
 class HasManyPolymorphicArticle extends TestORM
 {
-	protected $tableName = 'articles';
+	protected string $tableName = 'articles';
 
 	public function comments()
 	{
@@ -28,7 +28,7 @@ class HasManyPolymorphicArticle extends TestORM
 
 class HasManyPolymorphicComment extends TestORM
 {
-	protected $tableName = 'polymorphic_comments';
+	protected string $tableName = 'polymorphic_comments';
 }
 
 // --------------------------------------------------------------------------

--- a/tests/integration/database/midgard/relations/HasManyTest.php
+++ b/tests/integration/database/midgard/relations/HasManyTest.php
@@ -18,7 +18,7 @@ use mako\tests\integration\TestORM;
 
 class HasManyUser extends TestORM
 {
-	protected $tableName = 'users';
+	protected string $tableName = 'users';
 
 	public function articles()
 	{
@@ -28,7 +28,7 @@ class HasManyUser extends TestORM
 
 class HasManyArticle extends TestORM
 {
-	protected $tableName = 'articles';
+	protected string $tableName = 'articles';
 }
 
 // --------------------------------------------------------------------------

--- a/tests/integration/database/midgard/relations/HasOnePolymorphicTest.php
+++ b/tests/integration/database/midgard/relations/HasOnePolymorphicTest.php
@@ -17,7 +17,7 @@ use mako\tests\integration\TestORM;
 
 class HasOnePolymorphicProfile extends TestORM
 {
-	protected $tableName = 'profiles';
+	protected string $tableName = 'profiles';
 
 	public function image()
 	{
@@ -27,7 +27,7 @@ class HasOnePolymorphicProfile extends TestORM
 
 class HasOnePolymorphicImage extends TestORM
 {
-	protected $tableName = 'images';
+	protected string $tableName = 'images';
 }
 
 // --------------------------------------------------------------------------

--- a/tests/integration/database/midgard/relations/HasOneTest.php
+++ b/tests/integration/database/midgard/relations/HasOneTest.php
@@ -17,7 +17,7 @@ use mako\tests\integration\TestORM;
 
 class HasOneUser extends TestORM
 {
-	protected $tableName = 'users';
+	protected string $tableName = 'users';
 
 	public function profile()
 	{
@@ -27,7 +27,7 @@ class HasOneUser extends TestORM
 
 class HasOneProfile extends TestORM
 {
-	protected $tableName = 'profiles';
+	protected string $tableName = 'profiles';
 }
 
 // --------------------------------------------------------------------------

--- a/tests/integration/database/midgard/relations/LazyEagerLoadTest.php
+++ b/tests/integration/database/midgard/relations/LazyEagerLoadTest.php
@@ -16,7 +16,7 @@ use mako\tests\integration\TestORM;
 
 class LazyHasManyUser extends TestORM
 {
-	protected $tableName = 'users';
+	protected string $tableName = 'users';
 
 	public function articles()
 	{
@@ -26,7 +26,7 @@ class LazyHasManyUser extends TestORM
 
 class LazyHasManyArticle extends TestORM
 {
-	protected $tableName = 'articles';
+	protected string $tableName = 'articles';
 }
 
 // --------------------------------------------------------------------------

--- a/tests/integration/database/midgard/relations/ManyToManyTest.php
+++ b/tests/integration/database/midgard/relations/ManyToManyTest.php
@@ -18,7 +18,7 @@ use mako\tests\integration\TestORM;
 
 class ManyToManyUser extends TestORM
 {
-	protected $tableName = 'users';
+	protected string $tableName = 'users';
 
 	public function groups()
 	{
@@ -28,7 +28,7 @@ class ManyToManyUser extends TestORM
 
 class ManyToManyGroup extends TestORM
 {
-	protected $tableName = 'groups';
+	protected string $tableName = 'groups';
 
 	public function users()
 	{

--- a/tests/integration/database/midgard/relations/NestedEagerLoadingTest.php
+++ b/tests/integration/database/midgard/relations/NestedEagerLoadingTest.php
@@ -17,7 +17,7 @@ use mako\tests\integration\TestORM;
 
 class NestedEagerLoadingUser extends TestORM
 {
-	protected $tableName = 'users';
+	protected string $tableName = 'users';
 
 	public function articles()
 	{
@@ -27,7 +27,7 @@ class NestedEagerLoadingUser extends TestORM
 
 class NestedEagerLoadingArticle extends TestORM
 {
-	protected $tableName = 'articles';
+	protected string $tableName = 'articles';
 
 	public function comments()
 	{
@@ -37,7 +37,7 @@ class NestedEagerLoadingArticle extends TestORM
 
 class NestedEagerLoadingComment extends TestORM
 {
-	protected $tableName = 'article_comments';
+	protected string $tableName = 'article_comments';
 }
 
 // --------------------------------------------------------------------------

--- a/tests/integration/database/midgard/relations/NestedProtectTest.php
+++ b/tests/integration/database/midgard/relations/NestedProtectTest.php
@@ -16,7 +16,7 @@ use mako\tests\integration\TestORM;
 
 class NestedProtectUser extends TestORM
 {
-	protected $tableName = 'users';
+	protected string $tableName = 'users';
 
 	public function articles()
 	{
@@ -26,9 +26,9 @@ class NestedProtectUser extends TestORM
 
 class NestedPreProtectUser extends TestORM
 {
-	protected $tableName = 'users';
+	protected string $tableName = 'users';
 
-	protected $protected = ['id', 'articles.id', 'articles.comments.id'];
+	protected array $protected = ['id', 'articles.id', 'articles.comments.id'];
 
 	public function articles()
 	{
@@ -38,7 +38,7 @@ class NestedPreProtectUser extends TestORM
 
 class NestedProtectArticle extends TestORM
 {
-	protected $tableName = 'articles';
+	protected string $tableName = 'articles';
 
 	public function comments()
 	{
@@ -48,7 +48,7 @@ class NestedProtectArticle extends TestORM
 
 class NestedProtectComment extends TestORM
 {
-	protected $tableName = 'article_comments';
+	protected string $tableName = 'article_comments';
 }
 
 // --------------------------------------------------------------------------

--- a/tests/integration/database/midgard/relations/WithCountOfTest.php
+++ b/tests/integration/database/midgard/relations/WithCountOfTest.php
@@ -16,7 +16,7 @@ use mako\tests\integration\TestORM;
 
 class WithCountOfUser extends TestOrm
 {
-	protected $tableName = 'users';
+	protected string $tableName = 'users';
 
 	public function articles()
 	{
@@ -31,12 +31,12 @@ class WithCountOfUser extends TestOrm
 
 class WithCountOfArticle extends TestORM
 {
-	protected $tableName = 'articles';
+	protected string $tableName = 'articles';
 }
 
 class WithCountOfProfile extends TestORM
 {
-	protected $tableName = 'profiles';
+	protected string $tableName = 'profiles';
 }
 
 // --------------------------------------------------------------------------

--- a/tests/integration/redis/ConnectionTest.php
+++ b/tests/integration/redis/ConnectionTest.php
@@ -18,9 +18,9 @@ use mako\tests\TestCase;
 class ConnectionTest extends TestCase
 {
 	/**
-	 * @var \mako\redis\Connection
+	 *
 	 */
-	protected $connection;
+	protected Connection|null $connection = null;
 
 	/**
 	 *

--- a/tests/integration/redis/RedisTest.php
+++ b/tests/integration/redis/RedisTest.php
@@ -25,9 +25,9 @@ use mako\tests\TestCase;
 class RedisTest extends TestCase
 {
 	/**
-	 * @var \mako\redis\Redis
+	 *
 	 */
-	protected $redis;
+	protected Redis|null $redis = null;
 
 	/**
 	 *

--- a/tests/unit/database/midgard/CamelCasedORMTest.php
+++ b/tests/unit/database/midgard/CamelCasedORMTest.php
@@ -19,7 +19,7 @@ class CamelCasedORM extends ORM
 {
     use CamelCasedTrait;
 
-	protected $cast = ['is_something' => 'bool'];
+	protected array $cast = ['is_something' => 'bool'];
 
 	protected function jsonColumnMutator(array $value)
 	{

--- a/tests/unit/database/midgard/ORMTest.php
+++ b/tests/unit/database/midgard/ORMTest.php
@@ -28,11 +28,11 @@ class FakeRelation
 
 class TestUser1 extends ORM
 {
-	protected $including = ['profile'];
+	protected array $including = ['profile'];
 
-	protected $primaryKey = 'id';
+	protected string $primaryKey = 'id';
 
-	protected $tableName = 'users';
+	protected string $tableName = 'users';
 }
 
 class TestUser2 extends TestUser1
@@ -57,16 +57,16 @@ class TestUser2 extends TestUser1
 
 class TestUser3 extends TestUser1
 {
-	protected $foreignKeyName = 'testuser3';
+	protected string $foreignKeyName = 'testuser3';
 
-	protected $assignable = ['username', 'email'];
+	protected array $assignable = ['username', 'email'];
 }
 
 class TestUser4 extends TestUser1
 {
-	protected $protected = ['password'];
+	protected array $protected = ['password'];
 
-	protected $columns = ['username' => 'foo', 'password' => 'bar', 'array' => '[1,2,3]', 'optional' => null];
+	protected array $columns = ['username' => 'foo', 'password' => 'bar', 'array' => '[1,2,3]', 'optional' => null];
 
 	public function arrayAccessor($json)
 	{
@@ -78,7 +78,7 @@ class Testuser5 extends TestUser1
 {
 	protected static $dateFormat = 'Y-m-d H:i:s';
 
-	protected $cast = ['created_at' => 'date'];
+	protected array $cast = ['created_at' => 'date'];
 
 	protected function getDateFormat(): string
 	{
@@ -93,12 +93,12 @@ class ORMTestApple extends ORM
 
 class TestCastingScalars extends ORM
 {
-	protected $cast = ['boolean' => 'bool', 'integer' => 'int', 'float' => 'float'];
+	protected array $cast = ['boolean' => 'bool', 'integer' => 'int', 'float' => 'float'];
 }
 
 class TestCastingDate extends ORM
 {
-	protected $cast = ['date' => 'date'];
+	protected array $cast = ['date' => 'date'];
 }
 
 // --------------------------------------------------------------------------

--- a/tests/unit/database/midgard/QueryTest.php
+++ b/tests/unit/database/midgard/QueryTest.php
@@ -22,7 +22,7 @@ use Mockery;
 
 class ScopedModel extends ORM
 {
-	protected $tableName = 'foos';
+	protected string $tableName = 'foos';
 
 	public function popularScope($query): void
 	{
@@ -115,9 +115,9 @@ class QueryTest extends TestCase
 
 		$query->shouldReceive('where')->once()->with('id', '=', 1984)->andReturn($query);
 
-		$query->shouldReceive('first')->once()->andReturn(true);
+		$query->shouldReceive('first')->once()->andReturn(Mockery::mock(ORM::class));
 
-		$this->assertTrue($query->get(1984));
+		$this->assertInstanceOf(ORM::class, $query->get(1984));
 	}
 
 	/**
@@ -136,9 +136,9 @@ class QueryTest extends TestCase
 
 		$query->shouldReceive('where')->once()->with('id', '=', 1984)->andReturn($query);
 
-		$query->shouldReceive('first')->once()->andReturn(true);
+		$query->shouldReceive('first')->once()->andReturn(Mockery::mock(ORM::class));
 
-		$this->assertTrue($query->get(1984, ['foo', 'bar']));
+		$this->assertInstanceOf(ORM::class, $query->get(1984, ['foo', 'bar']));
 	}
 
 	/**

--- a/tests/unit/error/handlers/cli/DevelopmentHandlerTest.php
+++ b/tests/unit/error/handlers/cli/DevelopmentHandlerTest.php
@@ -22,12 +22,8 @@ class DevelopmentHandlerTest extends TestCase
 {
 	/**
 	 * Returns output string.
-	 *
-	 * @param string $type    Error type
-	 * @param string $message Error message
-	 * @param string $trace   Exception trace
 	 */
-	protected function getOutputString($type, $message, $trace)
+	protected function getOutputString(string $type, string $message, string $trace)
 	{
 		return '<bg_red><white>' . $type . ': ' . $message . PHP_EOL . PHP_EOL . $trace . PHP_EOL . '</white></bg_red>';
 	}

--- a/tests/unit/http/routing/middleware/AccessControlTest.php
+++ b/tests/unit/http/routing/middleware/AccessControlTest.php
@@ -27,7 +27,7 @@ class AccessControlTest extends TestCase
 	{
 		$middleware = new class extends AccessControl
 		{
-			protected $allowAllDomains = true;
+			protected bool $allowAllDomains = true;
 		};
 
 		/** @var \mako\http\request\Headers|\Mockery\MockInterface $requestHeaders */
@@ -63,7 +63,7 @@ class AccessControlTest extends TestCase
 	{
 		$middleware = new class extends AccessControl
 		{
-			protected $allowAllDomains = true;
+			protected bool $allowAllDomains = true;
 		};
 
 		/** @var \mako\http\request\Headers|\Mockery\MockInterface $requestHeaders */
@@ -99,9 +99,9 @@ class AccessControlTest extends TestCase
 	{
 		$middleware = new class extends AccessControl
 		{
-			protected $allowAllDomains = true;
+			protected bool $allowAllDomains = true;
 
-			protected $allowedDomains =
+			protected array $allowedDomains =
 			[
 				'https://example.org',
 			];
@@ -142,7 +142,7 @@ class AccessControlTest extends TestCase
 	{
 		$middleware = new class extends AccessControl
 		{
-			protected $allowedDomains =
+			protected array $allowedDomains =
 			[
 				'https://example.org',
 			];
@@ -183,7 +183,7 @@ class AccessControlTest extends TestCase
 	{
 		$middleware = new class extends AccessControl
 		{
-			protected $allowedDomains =
+			protected array $allowedDomains =
 			[
 				'https://example.org',
 			];
@@ -215,7 +215,7 @@ class AccessControlTest extends TestCase
 	{
 		$middleware = new class extends AccessControl
 		{
-			protected $allowedDomains =
+			protected array $allowedDomains =
 			[
 				'https://example.org',
 			];
@@ -247,8 +247,8 @@ class AccessControlTest extends TestCase
 	{
 		$middleware = new class extends AccessControl
 		{
-			protected $allowAllDomains = true;
-			protected $allowCredentials = true;
+			protected bool $allowAllDomains = true;
+			protected bool $allowCredentials = true;
 		};
 
 		/** @var \mako\http\request\Headers|\Mockery\MockInterface $requestHeaders */
@@ -286,8 +286,8 @@ class AccessControlTest extends TestCase
 	{
 		$middleware = new class extends AccessControl
 		{
-			protected $allowAllDomains = true;
-			protected $allowedHeaders = ['X-Custom-Header1', 'X-Custom-Header2'];
+			protected bool $allowAllDomains = true;
+			protected array $allowedHeaders = ['X-Custom-Header1', 'X-Custom-Header2'];
 		};
 
 		/** @var \mako\http\request\Headers|\Mockery\MockInterface $requestHeaders */
@@ -325,8 +325,8 @@ class AccessControlTest extends TestCase
 	{
 		$middleware = new class extends AccessControl
 		{
-			protected $allowAllDomains = true;
-			protected $allowedMethods = ['GET', 'POST'];
+			protected bool $allowAllDomains = true;
+			protected array $allowedMethods = ['GET', 'POST'];
 		};
 
 		/** @var \mako\http\request\Headers|\Mockery\MockInterface $requestHeaders */

--- a/tests/unit/http/routing/middleware/ContentSecurityPolicyTest.php
+++ b/tests/unit/http/routing/middleware/ContentSecurityPolicyTest.php
@@ -88,7 +88,7 @@ class ContentSecurityPolicyTest extends TestCase
 
 		$contentSecurityPolicy = new class ($container) extends ContentSecurityPolicy
 		{
-			protected $reportOnly = true;
+			protected bool $reportOnly = true;
 		};
 
 		$contentSecurityPolicy->execute($request, $response, $next);
@@ -126,7 +126,7 @@ class ContentSecurityPolicyTest extends TestCase
 
 		$contentSecurityPolicy = new class ($container) extends ContentSecurityPolicy
 		{
-			protected $directives =
+			protected array $directives =
 			[
 				'block-all-mixed-content' => true,
 				'default-src'             => ['self'],
@@ -178,7 +178,7 @@ class ContentSecurityPolicyTest extends TestCase
 
 		$contentSecurityPolicy = new class ($container) extends ContentSecurityPolicy
 		{
-			protected $directives =
+			protected array $directives =
 			[
 				'default-src' => ['nonce'],
 			];
@@ -233,9 +233,9 @@ class ContentSecurityPolicyTest extends TestCase
 
 		$contentSecurityPolicy = new class ($container) extends ContentSecurityPolicy
 		{
-			protected $nonceVariableName = 'cspNonce';
+			protected string $nonceVariableName = 'cspNonce';
 
-			protected $directives =
+			protected array $directives =
 			[
 				'default-src' => ['nonce'],
 			];
@@ -283,7 +283,7 @@ class ContentSecurityPolicyTest extends TestCase
 
 		$contentSecurityPolicy = new class ($container) extends ContentSecurityPolicy
 		{
-			protected $reportTo =
+			protected array|null $reportTo =
 			[
 				[
 					'group'     => 'csp-endpoint',
@@ -295,7 +295,7 @@ class ContentSecurityPolicyTest extends TestCase
 				],
 			];
 
-			protected $directives =
+			protected array $directives =
 			[
 
 				'report-to' => ['csp-endpoint'],

--- a/tests/unit/http/routing/middleware/ContentSecurityPolicyTest.php
+++ b/tests/unit/http/routing/middleware/ContentSecurityPolicyTest.php
@@ -283,7 +283,7 @@ class ContentSecurityPolicyTest extends TestCase
 
 		$contentSecurityPolicy = new class ($container) extends ContentSecurityPolicy
 		{
-			protected array|null $reportTo =
+			protected array $reportTo =
 			[
 				[
 					'group'     => 'csp-endpoint',

--- a/tests/unit/http/traits/ContentNegotiationTraitTest.php
+++ b/tests/unit/http/traits/ContentNegotiationTraitTest.php
@@ -20,9 +20,7 @@ use Mockery;
 class ContentNegotiationTraitTest extends TestCase
 {
 	/**
-	 * @param  \mako\http\Request  $request  Request
-	 * @param  \mako\http\Response $response Response
-	 * @return object
+	 *
 	 */
 	protected function getTestClass(Request $request, Response $response): object
 	{

--- a/tests/unit/reactor/CommandTest.php
+++ b/tests/unit/reactor/CommandTest.php
@@ -20,7 +20,7 @@ use Mockery;
 
 class Foo extends Command
 {
-	protected $description = 'Command description.';
+	protected string|null $description = 'Command description.';
 
 	public function getArguments(): array
 	{
@@ -74,7 +74,7 @@ class CommandTest extends TestCase
 
 		$command = new class ($input, $output) extends Command
 		{
-			protected $description = 'Command description.';
+			protected string|null $description = 'Command description.';
 		};
 
 		$this->assertEquals('Command description.', $command->getDescription());

--- a/tests/unit/reactor/CommandTest.php
+++ b/tests/unit/reactor/CommandTest.php
@@ -20,7 +20,7 @@ use Mockery;
 
 class Foo extends Command
 {
-	protected string|null $description = 'Command description.';
+	protected string $description = 'Command description.';
 
 	public function getArguments(): array
 	{
@@ -74,7 +74,7 @@ class CommandTest extends TestCase
 
 		$command = new class ($input, $output) extends Command
 		{
-			protected string|null $description = 'Command description.';
+			protected string $description = 'Command description.';
 		};
 
 		$this->assertEquals('Command description.', $command->getDescription());

--- a/tests/unit/validator/ValidatorFactoryTest.php
+++ b/tests/unit/validator/ValidatorFactoryTest.php
@@ -21,10 +21,6 @@ class ValidatorFactoryTest extends TestCase
 {
 	/**
 	 * Attribute spy.
-	 *
-	 * @param  \mako\validator\Validator $validator Validator factory
-	 * @param  string                    $attribute Attribute name
-	 * @return array
 	 */
 	protected function attributeSpy(Validator $validator, string $attribute): array
 	{

--- a/tests/unit/validator/ValidatorTest.php
+++ b/tests/unit/validator/ValidatorTest.php
@@ -39,10 +39,6 @@ class ValidatorTest extends TestCase
 {
 	/**
 	 * Attribute spy.
-	 *
-	 * @param  \mako\validator\Validator $validator Validator
-	 * @param  string                    $attribute Attribute name
-	 * @return array
 	 */
 	protected function attributeSpy(Validator $validator, string $attribute): array
 	{

--- a/tests/unit/validator/input/InputTest.php
+++ b/tests/unit/validator/input/InputTest.php
@@ -24,7 +24,7 @@ class InputTest extends TestCase
 	{
 		$input = new class extends Input
 		{
-			protected $rules = ['foo' => 'bar'];
+			protected array $rules = ['foo' => 'bar'];
 
 			public function getInput(): array { return []; }
 		};
@@ -39,7 +39,7 @@ class InputTest extends TestCase
 	{
 		$input = new class extends Input
 		{
-			protected $extensions = ['bar' => 'foo'];
+			protected array $extensions = ['bar' => 'foo'];
 
 			public function getInput(): array { return []; }
 		};
@@ -79,7 +79,7 @@ class InputTest extends TestCase
 
 		$input = new class extends Input
 		{
-			protected $errorMessage = 'Invalid input.';
+			protected string|null $errorMessage = 'Invalid input.';
 
 			public function getInput(): array { return []; }
 		};

--- a/tests/unit/validator/input/http/InputTest.php
+++ b/tests/unit/validator/input/http/InputTest.php
@@ -63,7 +63,7 @@ class InputTest extends TestCase
 
 		$input = new class ($request, $urlBuilder) extends Input
 		{
-			protected $shouldRedirect = false;
+			protected bool $shouldRedirect = false;
 		};
 
 		$this->assertFalse($input->shouldRedirect());
@@ -110,7 +110,7 @@ class InputTest extends TestCase
 
 		$input = new class ($request, $urlBuilder) extends Input
 		{
-			protected $shouldIncludeOldInput = false;
+			protected bool $shouldIncludeOldInput = false;
 		};
 
 		$this->assertFalse($input->shouldIncludeOldInput());

--- a/tests/unit/validator/input/http/routing/middleware/InputValidationTest.php
+++ b/tests/unit/validator/input/http/routing/middleware/InputValidationTest.php
@@ -360,7 +360,7 @@ class InputValidationTest extends TestCase
 
 		$middleware = new class ($urlBuilder) extends InputValidation
 		{
-			protected $dontInclude = ['username', 'password'];
+			protected array $dontInclude = ['username', 'password'];
 		};
 
 		$this->assertSame($expected2, (function () use ($input)
@@ -426,7 +426,7 @@ class InputValidationTest extends TestCase
 
 		$middleware = new class ($urlBuilder) extends InputValidation
 		{
-			protected $defaultErrorMessage = 'foobar';
+			protected string $defaultErrorMessage = 'foobar';
 		};
 
 		$this->assertSame('foobar', (function ()


### PR DESCRIPTION
<!--
Please use the provided template when creating pull requests 🙂
-->

### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      |  No     |
| New feature? | No      |
| Other?       |  Yes     |

### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | Yes      |
| Has unit and/or integration tests?  | Yes      |

###  Description
---

Add types to all class properties (where possible) and remove redundant docblock info. There are some minor breaking changes when extending classes and overriding properties since child classes will have to define the same class property types as the parent classes.
