### PR TITLE
Improved middleware and constraint registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The major version bump is due to dropped support for PHP `8.0` and a several bre
 	- `JSON::setStatus()`
 	- `Redirect::setStatus()`
 * Added `HttpStatusException::getStatus()` method.
+* Improved middleware and constraint registration.
+* Global middleware and constraints can now be registered with parameters.
 
 #### Changes
 

--- a/src/mako/http/routing/Route.php
+++ b/src/mako/http/routing/Route.php
@@ -111,7 +111,7 @@ class Route
 		/** @var \ReflectionAttribute $attribute */
 		foreach($attributes as $attribute)
 		{
-			$attributeValues = [...$attributeValues, ...$attribute->newInstance()->$method()];
+			$attributeValues = [...$attributeValues, ...[$attribute->newInstance()->$method()]];
 		}
 
 		return $attributeValues;
@@ -131,8 +131,8 @@ class Route
 
 		return [
 			...$this->middleware,
-			...$this->getAttributeValues((new ReflectionClass($class))->getAttributes(Middleware::class), 'getMiddleware'),
-			...$this->getAttributeValues((new ReflectionMethod($class, $method))->getAttributes(Middleware::class), 'getMiddleware'),
+			...$this->getAttributeValues((new ReflectionClass($class))->getAttributes(Middleware::class), 'getMiddlewareAndParameters'),
+			...$this->getAttributeValues((new ReflectionMethod($class, $method))->getAttributes(Middleware::class), 'getMiddlewareAndParameters'),
 		];
 	}
 
@@ -150,8 +150,8 @@ class Route
 
 		return [
 			...$this->constraints,
-			...$this->getAttributeValues((new ReflectionClass($class))->getAttributes(Constraint::class), 'getConstraints'),
-			...$this->getAttributeValues((new ReflectionMethod($class, $method))->getAttributes(Constraint::class), 'getConstraints'),
+			...$this->getAttributeValues((new ReflectionClass($class))->getAttributes(Constraint::class), 'getConstraintAndParameters'),
+			...$this->getAttributeValues((new ReflectionMethod($class, $method))->getAttributes(Constraint::class), 'getConstraintAndParameters'),
 		];
 	}
 
@@ -203,21 +203,21 @@ class Route
 	}
 
 	/**
-	 * Adds a set of middleware.
+	 * Adds a middleware.
 	 */
-	public function middleware(array|string $middleware): Route
+	public function middleware(string $middleware, mixed ...$parameters): Route
 	{
-		$this->middleware = [...$this->middleware, ...(array) $middleware];
+		$this->middleware = [...$this->middleware, ...[['middleware' => $middleware, 'parameters' => $parameters]]];
 
 		return $this;
 	}
 
 	/**
-	 * Adds a set of constraints.
+	 * Adds a constraint.
 	 */
-	public function constraint(array|string $constraint): Route
+	public function constraint(string $constraint, mixed ...$parameters): Route
 	{
-		$this->constraints = [...$this->constraints, ...(array) $constraint];
+		$this->constraints = [...$this->constraints, ...[['constraint' => $constraint, 'parameters' => $parameters]]];
 
 		return $this;
 	}

--- a/src/mako/http/routing/Routes.php
+++ b/src/mako/http/routing/Routes.php
@@ -12,6 +12,7 @@ use mako\common\traits\ExtendableTrait;
 use mako\http\routing\exceptions\RoutingException;
 
 use function array_pop;
+use function is_string;
 use function vsprintf;
 
 /**
@@ -91,6 +92,31 @@ class Routes
 	}
 
 	/**
+	 * Registers a group option.
+	 */
+	protected function registerGroupOption(Route $route, string $option, mixed $value): void
+	{
+		if($option === 'middleware' || $option === 'constraint')
+		{
+			foreach((array) $value as $parameters)
+			{
+				if(is_string($parameters))
+				{
+					$route->$option($parameters);
+				}
+				else
+				{
+					$route->$option($parameters[0], ...$parameters[1]);
+				}
+			}
+
+			return;
+		}
+
+		$route->$option($value);
+	}
+
+	/**
 	 * Registers a route.
 	 */
 	protected function registerRoute(array $methods, string $route, array|Closure|string $action, ?string $name = null): Route
@@ -115,7 +141,7 @@ class Routes
 			{
 				foreach($group as $option => $value)
 				{
-					$route->$option($value);
+					$this->registerGroupOption($route, $option, $value);
 				}
 			}
 		}

--- a/src/mako/http/routing/attributes/Constraint.php
+++ b/src/mako/http/routing/attributes/Constraint.php
@@ -15,19 +15,43 @@ use Attribute;
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
 class Constraint
 {
+	/**
+	 * Parameters.
+	 */
+	protected array $parameters;
+
     /**
      * Constructor.
      */
     public function __construct(
-        protected array|string $constraint
+        protected string $constraint,
+		mixed ...$parameters
     )
-    {}
+    {
+		$this->parameters = $parameters;
+	}
 
     /**
-     * Returns an array of constraints.
+     * Returns the constraint.
      */
-    public function getConstraints(): array
+    public function getConstraint(): string
     {
-        return (array) $this->constraint;
+        return $this->constraint;
     }
+
+	/**
+	 * Returns the constraint parameters.
+	 */
+	public function getParameters(): array
+	{
+		return $this->parameters;
+	}
+
+	/**
+	 * Returns the constraint and parameters.
+	 */
+	public function getConstraintAndParameters(): array
+	{
+		return ['constraint' => $this->constraint, 'parameters' => $this->parameters];
+	}
 }

--- a/src/mako/http/routing/attributes/Middleware.php
+++ b/src/mako/http/routing/attributes/Middleware.php
@@ -15,19 +15,43 @@ use Attribute;
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
 class Middleware
 {
+	/**
+	 * Parameters.
+	 */
+	protected array $parameters;
+
     /**
      * Constructor.
      */
     public function __construct(
-        protected array|string $middleware
+        protected string $middleware,
+		mixed ...$parameters
     )
-    {}
+    {
+		$this->parameters = $parameters;
+	}
 
     /**
-     * Returns an array of middleware.
+     * Returns the middleware.
      */
-    public function getMiddleware(): array
+    public function getMiddleware(): string
     {
-        return (array) $this->middleware;
+        return $this->middleware;
     }
+
+	/**
+	 * Returns the middleware parameters.
+	 */
+	public function getParameters(): array
+	{
+		return $this->parameters;
+	}
+
+	/**
+	 * Returns the middleware and parameters.
+	 */
+	public function getMiddlewareAndParameters(): array
+	{
+		return ['middleware' => $this->middleware, 'parameters' => $this->parameters];
+	}
 }

--- a/tests/unit/FunctionsTest.php
+++ b/tests/unit/FunctionsTest.php
@@ -8,7 +8,6 @@
 namespace mako\tests\unit;
 
 use mako\tests\TestCase;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 use function mako\env;
 use function mako\f;
@@ -39,7 +38,6 @@ class FunctionsTest extends TestCase
 	/**
 	 *
 	 */
-	#[RunInSeparateProcess]
 	public function testEnvWithMissingVariable(): void
 	{
 		$this->assertNull(env('MAKO_MISSING'));
@@ -50,29 +48,26 @@ class FunctionsTest extends TestCase
 	/**
 	 *
 	 */
-	#[RunInSeparateProcess]
 	public function testEnvWithVariableFromEnvSuperglobal(): void
 	{
-		$_ENV['MAKO_FOOBAR'] = 'hello';
+		$_ENV['MAKO_FOOBAR1'] = 'hello';
 
-		$this->assertSame('hello', env('MAKO_FOOBAR'));
+		$this->assertSame('hello', env('MAKO_FOOBAR1'));
 	}
 
 	/**
 	 *
 	 */
-	#[RunInSeparateProcess]
 	public function testEnvWithVariableFromGetenv(): void
 	{
-		putenv('MAKO_FOOBAR=hello');
+		putenv('MAKO_FOOBAR2=hello');
 
-		$this->assertSame('hello', env('MAKO_FOOBAR'));
+		$this->assertSame('hello', env('MAKO_FOOBAR2'));
 	}
 
 	/**
 	 *
 	 */
-	#[RunInSeparateProcess]
 	public function testEnvWithBooleanValues(): void
 	{
 		$_ENV['MAKO_TRUE'] = 'true';

--- a/tests/unit/http/routing/RouteTest.php
+++ b/tests/unit/http/routing/RouteTest.php
@@ -343,19 +343,19 @@ class RouteTest extends TestCase
 	{
 		$route = (new Route(['GET'], '/', fn () => 'Hello, world!'))->middleware('foo');
 
-		$this->assertSame(['foo'], $route->getMiddleware());
-
-		//
-
-		$route = (new Route(['GET'], '/', fn () => 'Hello, world!'))->middleware(['foo', 'bar']);
-
-		$this->assertSame(['foo', 'bar'], $route->getMiddleware());
+		$this->assertSame([['middleware' => 'foo', 'parameters' => []]], $route->getMiddleware());
 
 		//
 
 		$route = (new Route(['GET'], '/', fn () => 'Hello, world!'))->middleware('foo')->middleware('bar');
 
-		$this->assertSame(['foo', 'bar'], $route->getMiddleware());
+		$this->assertSame([['middleware' => 'foo', 'parameters' => []], ['middleware' => 'bar', 'parameters' => []]], $route->getMiddleware());
+
+		//
+
+		$route = (new Route(['GET'], '/', fn () => 'Hello, world!'))->middleware('foo', foo: 'bar')->middleware('bar', foo: 'bar');
+
+		$this->assertSame([['middleware' => 'foo', 'parameters' => ['foo' => 'bar']], ['middleware' => 'bar', 'parameters' => ['foo' => 'bar']]], $route->getMiddleware());
 	}
 
 	/**
@@ -385,11 +385,21 @@ class RouteTest extends TestCase
 	 */
 	public function testAttributeMiddleware(): void
 	{
+		$expected = [
+			['middleware' => 'foo0', 'parameters' => []],
+			['middleware' => 'foo1', 'parameters' => []],
+			['middleware' => 'foo2', 'parameters' => []],
+			['middleware' => 'foo3', 'parameters' => []],
+			['middleware' => 'foo4', 'parameters' => []],
+		];
+
+		//
+
 		$route = new Route(['GET'], '/', [AttributeController::class, 'method']);
 
 		$route->middleware('foo0');
 
-		$this->assertSame(['foo0', 'foo1', 'foo2', 'foo3', 'foo4'], $route->getMiddleware());
+		$this->assertSame($expected, $route->getMiddleware());
 
 		//
 
@@ -397,7 +407,7 @@ class RouteTest extends TestCase
 
 		$route->middleware('foo0');
 
-		$this->assertSame(['foo0', 'foo1', 'foo2', 'foo3', 'foo4'], $route->getMiddleware());
+		$this->assertSame($expected, $route->getMiddleware());
 	}
 
 	/**
@@ -405,11 +415,21 @@ class RouteTest extends TestCase
 	 */
 	public function testAttributeConstraints(): void
 	{
+		$expected = [
+			['constraint' => 'bar0', 'parameters' => []],
+			['constraint' => 'bar1', 'parameters' => []],
+			['constraint' => 'bar2', 'parameters' => []],
+			['constraint' => 'bar3', 'parameters' => []],
+			['constraint' => 'bar4', 'parameters' => []],
+		];
+
+		//
+
 		$route = new Route(['GET'], '/', [AttributeController::class, 'method']);
 
 		$route->constraint('bar0');
 
-		$this->assertSame(['bar0', 'bar1', 'bar2', 'bar3', 'bar4'], $route->getConstraints());
+		$this->assertSame($expected, $route->getConstraints());
 
 		//
 
@@ -417,6 +437,6 @@ class RouteTest extends TestCase
 
 		$route->constraint('bar0');
 
-		$this->assertSame(['bar0', 'bar1', 'bar2', 'bar3', 'bar4'], $route->getConstraints());
+		$this->assertSame($expected, $route->getConstraints());
 	}
 }

--- a/tests/unit/http/routing/RouterTest.php
+++ b/tests/unit/http/routing/RouterTest.php
@@ -401,7 +401,7 @@ class RouterTest extends TestCase
 	{
 		$routes = new Routes;
 
-		$routes->get('/foo', fn () => 'Hello, world!', 'get.foo')->constraint('bar');
+		$routes->get('/foo', fn () => 'Hello, world!', 'get.foo')->constraint(BarConstraint::class);
 
 		/** @var \mako\syringe\Container|\Mockery\MockInterface $container */
 		$container = Mockery::mock(Container::class);
@@ -410,7 +410,7 @@ class RouterTest extends TestCase
 
 		$router = new Router($routes, $container);
 
-		$router->registerConstraint('bar', BarConstraint::class);
+		$router->registerConstraint(BarConstraint::class);
 
 		$request = $this->getRequest();
 
@@ -465,7 +465,7 @@ class RouterTest extends TestCase
 
 		$routes = new Routes;
 
-		$routes->get('/foo', fn () => 'Hello, world!', 'get.foo')->constraint('foo');
+		$routes->get('/foo', fn () => 'Hello, world!', 'get.foo')->constraint(FooConstraint::class);
 
 		/** @var \mako\syringe\Container|\Mockery\MockInterface $container */
 		$container = Mockery::mock(Container::class);
@@ -474,7 +474,7 @@ class RouterTest extends TestCase
 
 		$router = new Router($routes, $container);
 
-		$router->registerConstraint('foo', FooConstraint::class);
+		$router->registerConstraint(FooConstraint::class);
 
 		$request = $this->getRequest();
 
@@ -503,9 +503,9 @@ class RouterTest extends TestCase
 
 		$router = new Router($routes, $container);
 
-		$router->registerConstraint('foo', FooConstraint::class);
+		$router->registerConstraint(FooConstraint::class);
 
-		$router->setConstraintAsGlobal(['foo']);
+		$router->setConstraintAsGlobal([FooConstraint::class]);
 
 		$request = $this->getRequest();
 
@@ -523,11 +523,11 @@ class RouterTest extends TestCase
 	{
 		$this->expectException(RoutingException::class);
 
-		$this->expectExceptionMessage('No constraint named [ foo ] has been registered.');
+		$this->expectExceptionMessage('The [ mako\tests\unit\http\routing\FooConstraint ] constraint hasn\'t been registered.');
 
 		$routes = new Routes;
 
-		$routes->get('/foo', fn () => 'Hello, world!', 'get.foo')->constraint('foo');
+		$routes->get('/foo', fn () => 'Hello, world!', 'get.foo')->constraint(FooConstraint::class);
 
 		$router = new Router($routes);
 

--- a/tests/unit/http/routing/attributes/ConstraintTest.php
+++ b/tests/unit/http/routing/attributes/ConstraintTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.makoframework.com/license
  */
 
-namespace mako\tests\unit\http\routing\middleware;
+namespace mako\tests\unit\http\routing\attributes;
 
 use mako\http\routing\attributes\Constraint;
 use mako\tests\TestCase;
@@ -18,20 +18,30 @@ class ConstraintTest extends TestCase
 	/**
 	 *
 	 */
-	public function testWithArray(): void
+	public function testGetConstraint(): void
 	{
-		$constraint = new Constraint(['foobar', 'barfoo']);
+		$constraint = new Constraint(FooBar::class);
 
-		$this->assertSame(['foobar', 'barfoo'], $constraint->getConstraints());
+		$this->assertSame(FooBar::class, $constraint->getConstraint());
 	}
 
 	/**
 	 *
 	 */
-	public function testWithString(): void
+	public function testGetParameters(): void
 	{
-		$constraint = new Constraint('foobar');
+		$constraint = new Constraint(FooBar::class, foo: 'bar');
 
-		$this->assertSame(['foobar'], $constraint->getConstraints());
+		$this->assertSame(['foo' => 'bar'], $constraint->getParameters());
+	}
+
+	/**
+	 *
+	 */
+	public function testGetConstraintAndParameters(): void
+	{
+		$constraint = new Constraint(FooBar::class, foo: 'bar');
+
+		$this->assertSame(['constraint' => FooBar::class, 'parameters' => ['foo' => 'bar']], $constraint->getConstraintAndParameters());
 	}
 }

--- a/tests/unit/http/routing/attributes/MiddlewareTest.php
+++ b/tests/unit/http/routing/attributes/MiddlewareTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.makoframework.com/license
  */
 
-namespace mako\tests\unit\http\routing\middleware;
+namespace mako\tests\unit\http\routing\attributes;
 
 use mako\http\routing\attributes\Middleware;
 use mako\tests\TestCase;
@@ -18,20 +18,30 @@ class MiddlewareTest extends TestCase
 	/**
 	 *
 	 */
-	public function testWithArray(): void
+	public function testGetMiddleware(): void
 	{
-		$middleware = new Middleware(['foobar', 'barfoo']);
+		$middleware = new Middleware(FooBar::class);
 
-		$this->assertSame(['foobar', 'barfoo'], $middleware->getMiddleware());
+		$this->assertSame(FooBar::class, $middleware->getMiddleware());
 	}
 
 	/**
 	 *
 	 */
-	public function testWithString(): void
+	public function testGetParameters(): void
 	{
-		$middleware = new Middleware('foobar');
+		$middleware = new Middleware(FooBar::class, foo: 'bar');
 
-		$this->assertSame(['foobar'], $middleware->getMiddleware());
+		$this->assertSame(['foo' => 'bar'], $middleware->getParameters());
+	}
+
+	/**
+	 *
+	 */
+	public function testGetMiddlewareAndParameters(): void
+	{
+		$middleware = new Middleware(FooBar::class, foo: 'bar');
+
+		$this->assertSame(['middleware' => FooBar::class, 'parameters' => ['foo' => 'bar']], $middleware->getMiddlewareAndParameters());
 	}
 }


### PR DESCRIPTION
<!--
Please use the provided template when creating pull requests 🙂
-->

### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      |  No      |
| New feature? |  Yes      |
| Other?       |  Yes      |

### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? |  Yes      |
| Has unit and/or integration tests?  | Yes      |

###  Description
---

Improved registration of middleware and constraints. Middleware and constraints are only registered using the class name and parameters are registered using named parameters or associative arrays.

```php
$routes->get('/articles/{id}', [Articles::class, 'view'])
->patterns(['id' => '[0-9]+'])
->middleware(Cache::class, minutes: 60);

//

#[Middleware(Cache::class, minutes: 60)]
#[Middleware(InputValidation::class)]
class Search
{
    public function __invoke()
    {
        
    }
}

//

$middleware = [[Cache::class, ['minutes' => 60]]];

$routes->group(['middleware' => $middleware], function ($routes) {

});
```
