### PR TITLE
Fix stty check

### DIFF
--- a/src/mako/cli/input/helpers/Secret.php
+++ b/src/mako/cli/input/helpers/Secret.php
@@ -22,7 +22,7 @@ class Secret extends Question
 	/**
 	 * Do we have stty support?
 	 */
-	protected static bool $hasStty;
+	protected static null|bool $hasStty = null;
 
 	/**
 	 * Do we have stty support?


### PR DESCRIPTION
### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      | Y      |
| New feature? | N      |
| Other?       | N      |

### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | N      |
| Has unit and/or integration tests?  | N      |

###  Description
---
I'm running PHP 8.3.10. `mako\cli\input\helpers\Secret::$hasStty` has no starting value, and so when `mako\cli\input\helpers\Secret::hasStty()` tries to check it, we get an error:
```
Error: Typed static property mako\cli\input\helpers\Secret::$hasStty must not be accessed before initialization

Error location: .../vendor/mako/framework/src/mako/cli/input/helpers/Secret.php on line 32

#0 .../vendor/mako/framework/src/mako/cli/input/helpers/Secret.php(46): mako\cli\input\helpers\Secret->hasStty()
#1 .../vendor/mako/framework/src/mako/reactor/traits/CommandHelperTrait.php(164): mako\cli\input\helpers\Secret->ask()
#2 .../app/console/commands/CreateUser.php(48): mako\reactor\Command->secret()
#3 .../vendor/mako/framework/src/mako/syringe/Container.php(476): app\console\commands\CreateUser->execute()
#4 .../vendor/mako/framework/src/mako/reactor/Dispatcher.php(49): mako\syringe\Container->call()
#5 .../vendor/mako/framework/src/mako/reactor/Dispatcher.php(57): mako\reactor\Dispatcher->execute()
#6 .../vendor/mako/framework/src/mako/reactor/Reactor.php(294): mako\reactor\Dispatcher->dispatch()
#7 .../vendor/mako/framework/src/mako/reactor/Reactor.php(321): mako\reactor\Reactor->registerCommandArgumentsAndDispatch()
#8 .../vendor/mako/framework/src/mako/application/cli/Application.php(256): mako\reactor\Reactor->run()
#9 .../app/reactor(14): mako\application\cli\Application->run()
#10 {main}
```

I imagine this is just a leftover bug from an update to support a newer PHP version.