### PR TITLE
Use empty string instead of null

### DIFF
--- a/src/mako/http/Response.php
+++ b/src/mako/http/Response.php
@@ -387,7 +387,7 @@ class Response
 
 			$this->headers->add('ETag', $hash);
 
-			if (str_replace('-gzip', '', $this->request->headers->get('If-None-Match')) === $hash) {
+			if (str_replace('-gzip', '', $this->request->headers->get('If-None-Match', '')) === $hash) {
 				$this->setStatus(Status::NOT_MODIFIED);
 
 				$sendBody = false;


### PR DESCRIPTION
### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      | Y      |
| New feature? | N      |
| Other?       | N      |

### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | N      |
| Has unit and/or integration tests?  | N      |

###  Description
---
```
str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated
```