### PR TITLE
Added "update and return" to the query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 	- `Statistics::populationVariance()`
 	- `Statistics::sampleStandardDeviation()`
 	- `Statistics::populationStandardDeviation()`
+* Added "update and return" functionality to the query builder. The feature is currently supported by the `Firebird`, `PostgreSQL`, `SQLite` and `SQL Server` compilers.
 
 #### Changes
 

--- a/src/mako/database/query/Query.php
+++ b/src/mako/database/query/Query.php
@@ -1216,7 +1216,7 @@ class Query
 	}
 
 	/**
-	 * Executes a SELECT query and returns an array containing all of the result set rows.
+	 * Executes a SELECT query and returns an array or result set containing all of the result set rows.
 	 */
 	protected function fetchAll(bool $returnResultSet, mixed ...$fetchMode): array|ResultSet
 	{
@@ -1228,7 +1228,7 @@ class Query
 	}
 
 	/**
-	 * Executes a SELECT query and returns an array containing all of the result set rows.
+	 * Executes a SELECT query and returns a result set containing all of the result set rows.
 	 *
 	 * @return ResultSet<int, Result>
 	 */
@@ -1488,6 +1488,28 @@ class Query
 		$query = $this->compiler->update($values);
 
 		return $this->connection->queryAndCount($query['sql'], $query['params']);
+	}
+
+	/**
+	 * Updates data from the chosen table and returns an array or result set.
+	 */
+	protected function updateAndReturnAll(array $values, array $return, bool $returnResultSet, mixed ...$fetchMode): array|ResultSet
+	{
+		$query = $this->compiler->updateAndReturn($values, $return);
+
+		$results = $this->connection->all($query['sql'], $query['params'], ...$fetchMode);
+
+		return $returnResultSet ? $this->createResultSet($results) : $results;
+	}
+
+	/**
+	 * Updates data from the chosen table and returns a result set.
+	 *
+	 * @return ResultSet<int, Result>
+	 */
+	public function updateAndReturn(array $values, array $return = ['*']): ResultSet
+	{
+		return $this->updateAndReturnAll($values, $return, true, PDO::FETCH_CLASS, Result::class);
 	}
 
 	/**

--- a/src/mako/database/query/Query.php
+++ b/src/mako/database/query/Query.php
@@ -1216,7 +1216,7 @@ class Query
 	}
 
 	/**
-	 * Executes a SELECT query and returns an array or result set containing all of the result set rows.
+	 * Executes a SELECT query and returns an array or result set containing all of the matching rows.
 	 */
 	protected function fetchAll(bool $returnResultSet, mixed ...$fetchMode): array|ResultSet
 	{
@@ -1228,7 +1228,7 @@ class Query
 	}
 
 	/**
-	 * Executes a SELECT query and returns a result set containing all of the result set rows.
+	 * Executes a SELECT query and returns a result set containing all of the matching rows.
 	 *
 	 * @return ResultSet<int, Result>
 	 */

--- a/src/mako/database/query/compilers/Compiler.php
+++ b/src/mako/database/query/compilers/Compiler.php
@@ -829,6 +829,16 @@ class Compiler
 	}
 
 	/**
+	 * Compiles an UPDATE query with a RETURNING clause.
+	 *
+	 * @return array{sql: string, params: array}
+	 */
+	public function updateAndReturn(array $values, array $return): array
+	{
+		throw new DatabaseException(sprintf('The [ %s ] query compiler does not support update and return queries.', static::class));
+	}
+
+	/**
 	 * Compiles a DELETE query.
 	 *
 	 * @return array{sql: string, params: array}

--- a/src/mako/database/query/compilers/Firebird.php
+++ b/src/mako/database/query/compilers/Firebird.php
@@ -75,4 +75,16 @@ class Firebird extends Compiler
 
 		return $lock === true ? ' FOR UPDATE WITH LOCK' : ($lock === false ? ' WITH LOCK' : " {$lock}");
 	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function updateAndReturn(array $values, array $return): array
+	{
+		$query = $this->update($values);
+
+		$query['sql'] .= ' RETURNING ' . $this->columns($return);
+
+		return $query;
+	}
 }

--- a/src/mako/database/query/compilers/Firebird.php
+++ b/src/mako/database/query/compilers/Firebird.php
@@ -83,7 +83,7 @@ class Firebird extends Compiler
 	{
 		$query = $this->update($values);
 
-		$query['sql'] .= ' RETURNING ' . $this->columns($return);
+		$query['sql'] .= ' RETURNING ' . $this->columnNames($return);
 
 		return $query;
 	}

--- a/src/mako/database/query/compilers/Postgres.php
+++ b/src/mako/database/query/compilers/Postgres.php
@@ -121,4 +121,16 @@ class Postgres extends Compiler
 
 		return ['sql' => $sql, 'params' => $this->params];
 	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function updateAndReturn(array $values, array $return): array
+	{
+		$query = $this->update($values);
+
+		$query['sql'] .= ' RETURNING ' . $this->columns($return);
+
+		return $query;
+	}
 }

--- a/src/mako/database/query/compilers/Postgres.php
+++ b/src/mako/database/query/compilers/Postgres.php
@@ -129,7 +129,7 @@ class Postgres extends Compiler
 	{
 		$query = $this->update($values);
 
-		$query['sql'] .= ' RETURNING ' . $this->columns($return);
+		$query['sql'] .= ' RETURNING ' . $this->columnNames($return);
 
 		return $query;
 	}

--- a/src/mako/database/query/compilers/SQLServer.php
+++ b/src/mako/database/query/compilers/SQLServer.php
@@ -11,8 +11,6 @@ use mako\database\query\compilers\traits\JsonPathBuilderTrait;
 use mako\database\query\Raw;
 use mako\database\query\Subquery;
 
-use function array_map;
-use function explode;
 use function implode;
 use function str_replace;
 
@@ -123,12 +121,16 @@ class SQLServer extends Compiler
 	 */
 	public function updateAndReturn(array $values, array $return): array
 	{
+		foreach ($return as $key => $column) {
+			$return[$key] = "inserted.{$this->columnName($column)}";
+		}
+
 		$sql = $this->query->getPrefix()
 		. 'UPDATE '
 		. $this->escapeTableName($this->query->getTable())
 		. ' SET '
 		. $this->updateColumns($values)
-		. ' OUTPUT ' . implode(', ', array_map(fn ($column) => "inserted.{$column}", explode(', ', $this->columns($return))))
+		. ' OUTPUT ' . implode(', ', $return)
 		. $this->wheres($this->query->getWheres());
 
 		return ['sql' => $sql, 'params' => $this->params];

--- a/src/mako/database/query/compilers/SQLServer.php
+++ b/src/mako/database/query/compilers/SQLServer.php
@@ -11,6 +11,9 @@ use mako\database\query\compilers\traits\JsonPathBuilderTrait;
 use mako\database\query\Raw;
 use mako\database\query\Subquery;
 
+use function array_map;
+use function explode;
+use function implode;
 use function str_replace;
 
 /**
@@ -113,5 +116,21 @@ class SQLServer extends Compiler
 		}
 
 		return '';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function updateAndReturn(array $values, array $return): array
+	{
+		$sql = $this->query->getPrefix()
+		. 'UPDATE '
+		. $this->escapeTableName($this->query->getTable())
+		. ' SET '
+		. $this->updateColumns($values)
+		. ' OUTPUT ' . implode(', ', array_map(fn ($column) => "inserted.{$column}", explode(', ', $this->columns($return))))
+		. $this->wheres($this->query->getWheres());
+
+		return ['sql' => $sql, 'params' => $this->params];
 	}
 }

--- a/src/mako/database/query/compilers/SQLite.php
+++ b/src/mako/database/query/compilers/SQLite.php
@@ -108,4 +108,16 @@ class SQLite extends Compiler
 
 		return ['sql' => $sql, 'params' => $this->params];
 	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function updateAndReturn(array $values, array $return): array
+	{
+		$query = $this->update($values);
+
+		$query['sql'] .= ' RETURNING ' . $this->columns($return);
+
+		return $query;
+	}
 }

--- a/src/mako/database/query/compilers/SQLite.php
+++ b/src/mako/database/query/compilers/SQLite.php
@@ -116,7 +116,7 @@ class SQLite extends Compiler
 	{
 		$query = $this->update($values);
 
-		$query['sql'] .= ' RETURNING ' . $this->columns($return);
+		$query['sql'] .= ' RETURNING ' . $this->columnNames($return);
 
 		return $query;
 	}

--- a/tests/integration/database/midgard/ORMTest.php
+++ b/tests/integration/database/midgard/ORMTest.php
@@ -676,4 +676,19 @@ class ORMTest extends ORMTestCase
 
 		$this->assertSame(3, count($counters));
 	}
+
+	/**
+	 *
+	 */
+	public function testUpdateAndReturn(): void
+	{
+		$updated = (new TestUser)->where('id', '=', 1)->updateAndReturn(['username' => 'bax'], ['username']);
+
+		$this->assertInstanceOf(ResultSet::class, $updated);
+		$this->assertInstanceOf(TestUser::class, $updated[0]);
+
+		$this->assertEquals(1, $updated[0]->id);
+		$this->assertEquals('bax', $updated[0]->username);
+		$this->assertSame(['id' => 1, 'username' => 'bax'], $updated[0]->toArray());
+	}
 }

--- a/tests/integration/database/query/compilers/BaseCompilerTest.php
+++ b/tests/integration/database/query/compilers/BaseCompilerTest.php
@@ -10,6 +10,8 @@ namespace mako\tests\integration\database\query\compilers;
 use LogicException;
 use mako\database\exceptions\NotFoundException;
 use mako\database\query\Query;
+use mako\database\query\Result;
+use mako\database\query\ResultSet;
 use mako\database\query\Subquery;
 use mako\pagination\PaginationFactoryInterface;
 use mako\pagination\PaginationInterface;
@@ -454,5 +456,23 @@ class BaseCompilerTest extends InMemoryDbTestCase
 		$user = $query->table('users')->where('username', '=', UsernameEnum::foo)->first();
 
 		$this->assertSame(UsernameEnum::foo->name, $user->username);
+	}
+
+	/**
+	 *
+	 */
+	public function testUpdateAndReturn(): void
+	{
+		$query = new Query($this->connectionManager->getConnection());
+
+		$updated = $query->table('users')->where('id', '=', 1)->updateAndReturn(['username' => 'bax'], ['id', 'username']);
+
+		$this->assertInstanceOf(ResultSet::class, $updated);
+		$this->assertInstanceOf(Result::class, $updated[0]);
+
+		$this->assertSame(1, $updated[0]->id);
+		$this->assertSame('bax', $updated[0]->username);
+
+		$this->assertEquals('UPDATE "users" SET "username" = \'bax\' WHERE "id" = 1 RETURNING "id", "username"', $this->connectionManager->getConnection()->getLog()[0]['query']);
 	}
 }

--- a/tests/unit/database/query/compilers/FirebirdCompilerTest.php
+++ b/tests/unit/database/query/compilers/FirebirdCompilerTest.php
@@ -315,4 +315,19 @@ class FirebirdCompilerTest extends TestCase
 		$this->assertEquals('SELECT * FROM "foobar" WHERE "foo" = ? OR CAST("date" AS DATE) = ?', $query['sql']);
 		$this->assertEquals(['bar', '2019-07-05'], $query['params']);
 	}
+
+	/**
+	 *
+	 */
+	public function testUpdateAndReturn(): void
+	{
+		$query = $this->getBuilder();
+
+		$query->where('id', '=', 1);
+
+		$query = $query->getCompiler()->updateAndReturn(['foo' => 'bar'], ['id', 'foo']);
+
+		$this->assertEquals('UPDATE "foobar" SET "foo" = ? WHERE "id" = ? RETURNING "id", "foo"', $query['sql']);
+		$this->assertEquals(['bar', 1], $query['params']);
+	}
 }

--- a/tests/unit/database/query/compilers/PostgresCompilerTest.php
+++ b/tests/unit/database/query/compilers/PostgresCompilerTest.php
@@ -400,4 +400,19 @@ class PostgresCompilerTest extends TestCase
 		$this->assertEquals('INSERT INTO "foobar" ("foo") VALUES (?) ON CONFLICT ("foo", "bar") DO UPDATE SET "foo" = ?', $query['sql']);
 		$this->assertEquals(['bar', 'dupe'], $query['params']);
 	}
+
+	/**
+	 *
+	 */
+	public function testUpdateAndReturn(): void
+	{
+		$query = $this->getBuilder();
+
+		$query->where('id', '=', 1);
+
+		$query = $query->getCompiler()->updateAndReturn(['foo' => 'bar'], ['id', 'foo']);
+
+		$this->assertEquals('UPDATE "foobar" SET "foo" = ? WHERE "id" = ? RETURNING "id", "foo"', $query['sql']);
+		$this->assertEquals(['bar', 1], $query['params']);
+	}
 }

--- a/tests/unit/database/query/compilers/SQLServerCompilerTest.php
+++ b/tests/unit/database/query/compilers/SQLServerCompilerTest.php
@@ -454,4 +454,19 @@ class SQLServerCompilerTest extends TestCase
 		$this->assertEquals('SELECT * FROM [foobar] WHERE [foo] = ? OR CAST([date] AS DATE) = ?', $query['sql']);
 		$this->assertEquals(['bar', '2019-07-05'], $query['params']);
 	}
+
+	/**
+	 *
+	 */
+	public function testUpdateAndReturn(): void
+	{
+		$query = $this->getBuilder();
+
+		$query->where('id', '=', 1);
+
+		$query = $query->getCompiler()->updateAndReturn(['foo' => 'bar'], ['id', 'foo']);
+
+		$this->assertEquals('UPDATE [foobar] SET [foo] = ? OUTPUT inserted.[id], inserted.[foo] WHERE [id] = ?', $query['sql']);
+		$this->assertEquals(['bar', 1], $query['params']);
+	}
 }

--- a/tests/unit/database/query/compilers/SQLiteCompilerTest.php
+++ b/tests/unit/database/query/compilers/SQLiteCompilerTest.php
@@ -329,4 +329,19 @@ class SQLiteCompilerTest extends TestCase
 		$this->assertEquals('INSERT INTO "foobar" ("foo") VALUES (?) ON CONFLICT ("foo", "bar") DO UPDATE SET "foo" = ?', $query['sql']);
 		$this->assertEquals(['bar', 'dupe'], $query['params']);
 	}
+
+	/**
+	 *
+	 */
+	public function testUpdateAndReturn(): void
+	{
+		$query = $this->getBuilder();
+
+		$query->where('id', '=', 1);
+
+		$query = $query->getCompiler()->updateAndReturn(['foo' => 'bar'], ['id', 'foo']);
+
+		$this->assertEquals('UPDATE "foobar" SET "foo" = ? WHERE "id" = ? RETURNING "id", "foo"', $query['sql']);
+		$this->assertEquals(['bar', 1], $query['params']);
+	}
 }


### PR DESCRIPTION
<!--
Please use the provided template when creating pull requests 🙂
-->

### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      | No      |
| New feature? | Yes      |
| Other?       | No      |

### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | No     |
| Has unit and/or integration tests?  | Yes      |

###  Description
---

You can now update columns and return the updated values in an atomic operation:

```php
$updated = $query->where('id', '=', 1)
->updateAndReturn(
    values: ['jobs_done' => new Raw('jobs_done + 1')],
    return: ['jobs_done']
);

var_dump($updated->first()->jobs_done);
```
