### PR TITLE
Add validation rule combinators (OneOf, AnyOf and AllOf)

### DIFF
--- a/src/mako/http/exceptions/UnprocessableEntityException.php
+++ b/src/mako/http/exceptions/UnprocessableEntityException.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\http\exceptions;
+
+use mako\http\response\Status;
+use Override;
+use Throwable;
+
+/**
+ * Unprocessable entity exception.
+ */
+class UnprocessableEntityException extends HttpStatusException
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	#[Override]
+	protected string $defaultMessage = 'The server was unable to process the request.';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct(string $message = '', ?Throwable $previous = null)
+	{
+		parent::__construct(Status::UnprocessableEntity, $message, $previous);
+	}
+}

--- a/src/mako/validator/Validator.php
+++ b/src/mako/validator/Validator.php
@@ -27,6 +27,7 @@ use mako\validator\rules\Between;
 use mako\validator\rules\Boolean;
 use mako\validator\rules\BooleanFalse;
 use mako\validator\rules\BooleanTrue;
+use mako\validator\rules\combinators\RuleCombinatorInterface;
 use mako\validator\rules\database\Exists;
 use mako\validator\rules\database\Unique;
 use mako\validator\rules\Date;
@@ -87,7 +88,6 @@ use mako\validator\rules\UUID;
 use function array_fill_keys;
 use function array_keys;
 use function array_merge_recursive;
-use function array_unique;
 use function class_exists;
 use function compact;
 use function in_array;
@@ -353,7 +353,7 @@ class Validator
 	/**
 	 * Returns the error message.
 	 */
-	protected function getErrorMessage(RuleInterface $rule, string $field, object $parsedRule): string
+	protected function getErrorMessage(RuleCombinatorInterface|RuleInterface $rule, string $field, object $parsedRule): string
 	{
 		$field = $this->getOriginalFieldName($field);
 
@@ -367,7 +367,7 @@ class Validator
 	/**
 	 * Validates the field using the specified rule.
 	 */
-	protected function validateField(string $field, RuleInterface|string $rule): bool
+	protected function validateField(string $field, RuleInterface|string $rule): array
 	{
 		if ($rule instanceof RuleInterface === false) {
 			$parsedRule = $this->parseRule($rule);
@@ -381,22 +381,56 @@ class Validator
 
 		if (($this->validateEmptyFields === false && $this->isInputFieldEmpty($inputValue) && $rule->validateWhenEmpty() === false)
 			|| ($this->validateEmptyFields && Arr::has($this->input, $field) === false)) {
-			return true;
+			return [true, null];
 		}
 
 		// Validate input
 
 		if ($rule->validate($inputValue, $field, $this->input) === false) {
-			$this->errors[$field] = $this->getErrorMessage(
+			$errorMessage = $this->getErrorMessage(
 				$rule,
 				$field,
 				$parsedRule ?? (object) ['name' => $rule::class, 'package' => null]
 			);
 
-			return $this->isValid = false;
+			return [false, $errorMessage];
 		}
 
-		return true;
+		return [true, null];
+	}
+
+	/**
+	 * Process rule combinator.
+	 */
+	protected function processRuleCombinator(string $field, RuleCombinatorInterface $ruleCombinator): array
+	{
+		$successes = 0;
+		$errorMessages = [];
+
+		foreach ($ruleCombinator->getRules() as $rule) {
+			[$success, $errorMessage] = $this->validateField($field, $rule);
+
+			if ($success) {
+				$successes++;
+			}
+			else {
+				$errorMessages[] = $errorMessage;
+			}
+		}
+
+		if ($ruleCombinator->getMatchCondition()($successes)) {
+			return [true, null];
+		}
+
+		return [
+			false,
+			$errorMessages[0] ?? $this->getErrorMessage(
+				$ruleCombinator,
+				$field,
+				(object) ['name', $ruleCombinator::class, null]
+			),
+		];
+
 	}
 
 	/**
@@ -406,14 +440,21 @@ class Validator
 	protected function process(): array
 	{
 		foreach ($this->ruleSets as $field => $ruleSet) {
-			// Ensure that we don't have any duplicated rules for a field
-
-			$ruleSet = array_unique($ruleSet);
-
-			// Validate field and stop as soon as one of the rules fail
+			// Validate field
 
 			foreach ($ruleSet as $rule) {
-				if ($this->validateField($field, $rule) === false) {
+				if ($rule instanceof RuleCombinatorInterface) {
+					[$success, $errorMessage] = $this->processRuleCombinator($field, $rule);
+				}
+				else {
+					[$success, $errorMessage] = $this->validateField($field, $rule);
+				}
+
+				// Stop as soon as one of the rules fail
+
+				if (!$success) {
+					$this->isValid = false;
+					$this->errors[$field] = $errorMessage;
 					break;
 				}
 			}

--- a/src/mako/validator/Validator.php
+++ b/src/mako/validator/Validator.php
@@ -27,7 +27,6 @@ use mako\validator\rules\Between;
 use mako\validator\rules\Boolean;
 use mako\validator\rules\BooleanFalse;
 use mako\validator\rules\BooleanTrue;
-use mako\validator\rules\combinators\OneOf;
 use mako\validator\rules\combinators\RuleCombinatorInterface;
 use mako\validator\rules\database\Exists;
 use mako\validator\rules\database\Unique;
@@ -432,18 +431,15 @@ class Validator
 			}
 		}
 
-		if ($ruleCombinator->getSuccessCondition()($successes)) {
+		if ($ruleCombinator->isSuccessful($successes)) {
 			return [true, null];
 		}
 
-		$errorMessage = (
-			empty($errorMessages)
-			|| ($ruleCombinator instanceof OneOf && $successes > 1)
-		) ? null : implode(' ', $errorMessages);
-
 		return [
 			false,
-			$errorMessage ?? $this->getErrorMessage(
+			$ruleCombinator->shouldAggregateChildErrors($successes, $errorMessages)
+			? implode(' ', $errorMessages)
+			: $this->getErrorMessage(
 				$ruleCombinator,
 				$field,
 				(object) ['name' => $ruleCombinator::class, 'package' => null]

--- a/src/mako/validator/Validator.php
+++ b/src/mako/validator/Validator.php
@@ -27,6 +27,7 @@ use mako\validator\rules\Between;
 use mako\validator\rules\Boolean;
 use mako\validator\rules\BooleanFalse;
 use mako\validator\rules\BooleanTrue;
+use mako\validator\rules\combinators\OneOf;
 use mako\validator\rules\combinators\RuleCombinatorInterface;
 use mako\validator\rules\database\Exists;
 use mako\validator\rules\database\Unique;
@@ -423,7 +424,10 @@ class Validator
 			return [true, null];
 		}
 
-		$errorMessage = empty($errorMessages) ? null : implode(' ', $errorMessages);
+		$errorMessage = (
+			empty($errorMessages)
+			|| ($ruleCombinator instanceof OneOf && $successes > 1)
+		) ? null : implode(' ', $errorMessages);
 
 		return [
 			false,

--- a/src/mako/validator/Validator.php
+++ b/src/mako/validator/Validator.php
@@ -402,15 +402,27 @@ class Validator
 	}
 
 	/**
-	 * Process rule combinator.
+	 * Validates a single rule or rule combinator.
 	 */
-	protected function processRuleCombinator(string $field, RuleCombinatorInterface $ruleCombinator): array
+	protected function validateRule(string $field, RuleCombinatorInterface|RuleInterface|string $rule): array
 	{
+		if ($rule instanceof RuleCombinatorInterface) {
+			return $this->processRuleCombinator($field, $rule);
+		}
+
+		return $this->validateField($field, $rule);
+	}
+
+	 /**
+	  * Process rule combinator.
+	  */
+	 protected function processRuleCombinator(string $field, RuleCombinatorInterface $ruleCombinator): array
+	 {
 		$successes = 0;
 		$errorMessages = [];
 
 		foreach ($ruleCombinator->getRules() as $rule) {
-			[$success, $errorMessage] = $this->validateField($field, $rule);
+			[$success, $errorMessage] = $this->validateRule($field, $rule);
 
 			if ($success) {
 				$successes++;
@@ -437,7 +449,6 @@ class Validator
 				(object) ['name' => $ruleCombinator::class, 'package' => null]
 			),
 		];
-
 	}
 
 	/**
@@ -446,18 +457,12 @@ class Validator
 	 */
 	protected function process(): array
 	{
+		$this->isValid = true;
+		$this->errors = [];
+
 		foreach ($this->ruleSets as $field => $ruleSet) {
-			// Validate field
-
 			foreach ($ruleSet as $rule) {
-				if ($rule instanceof RuleCombinatorInterface) {
-					[$success, $errorMessage] = $this->processRuleCombinator($field, $rule);
-				}
-				else {
-					[$success, $errorMessage] = $this->validateField($field, $rule);
-				}
-
-				// Stop as soon as one of the rules fail
+				[$success, $errorMessage] = $this->validateRule($field, $rule);
 
 				if (!$success) {
 					$this->isValid = false;
@@ -466,7 +471,6 @@ class Validator
 				}
 			}
 		}
-
 		return [$this->isValid, $this->errors];
 	}
 
@@ -481,7 +485,7 @@ class Validator
 	}
 
 	/**
-	 * Returns false if all rules passed and true if validation failed.
+	 * Returns FALSE if all rules passed and true if validation failed.
 	 */
 	public function isInvalid(?array &$errors = null): bool
 	{

--- a/src/mako/validator/Validator.php
+++ b/src/mako/validator/Validator.php
@@ -420,7 +420,7 @@ class Validator
 			}
 		}
 
-		if ($ruleCombinator->getMatchCondition()($successes)) {
+		if ($ruleCombinator->getSuccessCondition()($successes)) {
 			return [true, null];
 		}
 

--- a/src/mako/validator/Validator.php
+++ b/src/mako/validator/Validator.php
@@ -422,9 +422,11 @@ class Validator
 			return [true, null];
 		}
 
+		$errorMessage = empty($errorMessages) ? null : implode(' ', $errorMessages);
+
 		return [
 			false,
-			$errorMessages[0] ?? $this->getErrorMessage(
+			$errorMessage ?? $this->getErrorMessage(
 				$ruleCombinator,
 				$field,
 				(object) ['name', $ruleCombinator::class, null]

--- a/src/mako/validator/Validator.php
+++ b/src/mako/validator/Validator.php
@@ -90,6 +90,7 @@ use function array_keys;
 use function array_merge_recursive;
 use function class_exists;
 use function compact;
+use function implode;
 use function in_array;
 use function preg_match;
 use function sprintf;

--- a/src/mako/validator/Validator.php
+++ b/src/mako/validator/Validator.php
@@ -430,7 +430,7 @@ class Validator
 			$errorMessage ?? $this->getErrorMessage(
 				$ruleCombinator,
 				$field,
-				(object) ['name', $ruleCombinator::class, null]
+				(object) ['name' => $ruleCombinator::class, 'package' => null]
 			),
 		];
 

--- a/src/mako/validator/input/http/routing/middleware/InputValidation.php
+++ b/src/mako/validator/input/http/routing/middleware/InputValidation.php
@@ -13,6 +13,7 @@ use mako\http\Request;
 use mako\http\Response;
 use mako\http\response\builders\JSON;
 use mako\http\response\senders\Redirect;
+use mako\http\response\Status;
 use mako\http\routing\middleware\MiddlewareInterface;
 use mako\http\routing\URLBuilder;
 use mako\http\traits\ContentNegotiationTrait;
@@ -36,9 +37,9 @@ class InputValidation implements MiddlewareInterface
 	use ContentNegotiationTrait;
 
 	/**
-	 * Default HTTP status code for invalid requests.
+	 * Default HTTP status for invalid requests.
 	 */
-	protected int $httpStatusCode = 400;
+	protected Status $httpStatus = Status::BadRequest;
 
 	/**
 	 * Headers and cookies to keep.
@@ -210,7 +211,7 @@ class InputValidation implements MiddlewareInterface
 	 */
 	protected function handleOutput(ValidationException $exception): Response
 	{
-		$this->response->setStatus($this->httpStatusCode);
+		$this->response->setStatus($this->httpStatus);
 
 		if ($this->respondWithJson()) {
 			$this->response->setBody(new JSON([

--- a/src/mako/validator/rules/After.php
+++ b/src/mako/validator/rules/After.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * After rule.
  */
-class After extends Rule implements RuleInterface
+class After extends Rule
 {
 	/**
 	 * I18n parameters.

--- a/src/mako/validator/rules/Alpha.php
+++ b/src/mako/validator/rules/Alpha.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Alpha rule.
  */
-class Alpha extends Rule implements RuleInterface
+class Alpha extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/AlphaUnicode.php
+++ b/src/mako/validator/rules/AlphaUnicode.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Alpha unicode rule.
  */
-class AlphaUnicode extends Rule implements RuleInterface
+class AlphaUnicode extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/Alphanumeric.php
+++ b/src/mako/validator/rules/Alphanumeric.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Alphanumeric rule.
  */
-class Alphanumeric extends Rule implements RuleInterface
+class Alphanumeric extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/AlphanumericDash.php
+++ b/src/mako/validator/rules/AlphanumericDash.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Alphanumeric dash rule.
  */
-class AlphanumericDash extends Rule implements RuleInterface
+class AlphanumericDash extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/AlphanumericDashUnicode.php
+++ b/src/mako/validator/rules/AlphanumericDashUnicode.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Alphanumeric dash unicode rule.
  */
-class AlphanumericDashUnicode extends Rule implements RuleInterface
+class AlphanumericDashUnicode extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/AlphanumericUnicode.php
+++ b/src/mako/validator/rules/AlphanumericUnicode.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Alphanumeric unicode rule.
  */
-class AlphanumericUnicode extends Rule implements RuleInterface
+class AlphanumericUnicode extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/Arr.php
+++ b/src/mako/validator/rules/Arr.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Arr rule.
  */
-class Arr extends Rule implements RuleInterface
+class Arr extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/Before.php
+++ b/src/mako/validator/rules/Before.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Before rule.
  */
-class Before extends Rule implements RuleInterface
+class Before extends Rule
 {
 	/**
 	 * I18n parameters.

--- a/src/mako/validator/rules/Between.php
+++ b/src/mako/validator/rules/Between.php
@@ -14,7 +14,7 @@ use function sprintf;
 /**
  * Between rule.
  */
-class Between extends Rule implements RuleInterface
+class Between extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/Boolean.php
+++ b/src/mako/validator/rules/Boolean.php
@@ -14,7 +14,7 @@ use function sprintf;
 /**
  * Boolean rule.
  */
-class Boolean extends Rule implements RuleInterface
+class Boolean extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/BooleanFalse.php
+++ b/src/mako/validator/rules/BooleanFalse.php
@@ -14,7 +14,7 @@ use function sprintf;
 /**
  * Boolean false rule.
  */
-class BooleanFalse extends Rule implements RuleInterface
+class BooleanFalse extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/BooleanTrue.php
+++ b/src/mako/validator/rules/BooleanTrue.php
@@ -14,7 +14,7 @@ use function sprintf;
 /**
  * Boolean true rule.
  */
-class BooleanTrue extends Rule implements RuleInterface
+class BooleanTrue extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/Date.php
+++ b/src/mako/validator/rules/Date.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Date rule.
  */
-class Date extends Rule implements RuleInterface
+class Date extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/Different.php
+++ b/src/mako/validator/rules/Different.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Different rule.
  */
-class Different extends Rule implements RuleInterface
+class Different extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/Email.php
+++ b/src/mako/validator/rules/Email.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Email rule.
  */
-class Email extends Rule implements RuleInterface
+class Email extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/EmailDomain.php
+++ b/src/mako/validator/rules/EmailDomain.php
@@ -17,7 +17,7 @@ use function str_contains;
 /**
  * Email domain rule.
  */
-class EmailDomain extends Rule implements RuleInterface
+class EmailDomain extends Rule
 {
 	/**
 	 * Returns TRUE if the domain has a MX record and FALSE if not.

--- a/src/mako/validator/rules/Enum.php
+++ b/src/mako/validator/rules/Enum.php
@@ -17,7 +17,7 @@ use function sprintf;
 /**
  * Enum rule.
  */
-class Enum extends Rule implements RuleInterface
+class Enum extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/ExactCount.php
+++ b/src/mako/validator/rules/ExactCount.php
@@ -16,7 +16,7 @@ use function sprintf;
 /**
  * Exact count rule.
  */
-class ExactCount extends Rule implements RuleInterface
+class ExactCount extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/ExactLength.php
+++ b/src/mako/validator/rules/ExactLength.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Exact length rule.
  */
-class ExactLength extends Rule implements RuleInterface
+class ExactLength extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/GreaterThan.php
+++ b/src/mako/validator/rules/GreaterThan.php
@@ -14,7 +14,7 @@ use function sprintf;
 /**
  * Greater than rule.
  */
-class GreaterThan extends Rule implements RuleInterface
+class GreaterThan extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/GreaterThanOrEqualTo.php
+++ b/src/mako/validator/rules/GreaterThanOrEqualTo.php
@@ -14,7 +14,7 @@ use function sprintf;
 /**
  * Greater than or equal to rule.
  */
-class GreaterThanOrEqualTo extends Rule implements RuleInterface
+class GreaterThanOrEqualTo extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/Hex.php
+++ b/src/mako/validator/rules/Hex.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Hex rule.
  */
-class Hex extends Rule implements RuleInterface
+class Hex extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/IP.php
+++ b/src/mako/validator/rules/IP.php
@@ -16,7 +16,7 @@ use function sprintf;
 /**
  * IP rule.
  */
-class IP extends Rule implements RuleInterface
+class IP extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/In.php
+++ b/src/mako/validator/rules/In.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * In rule.
  */
-class In extends Rule implements RuleInterface
+class In extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/JSON.php
+++ b/src/mako/validator/rules/JSON.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * JSON rule.
  */
-class JSON extends Rule implements RuleInterface
+class JSON extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/LessThan.php
+++ b/src/mako/validator/rules/LessThan.php
@@ -14,7 +14,7 @@ use function sprintf;
 /**
  * Less than rule.
  */
-class LessThan extends Rule implements RuleInterface
+class LessThan extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/LessThanOrEqualTo.php
+++ b/src/mako/validator/rules/LessThanOrEqualTo.php
@@ -14,7 +14,7 @@ use function sprintf;
 /**
  * Less than or equal to rule.
  */
-class LessThanOrEqualTo extends Rule implements RuleInterface
+class LessThanOrEqualTo extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/MatchField.php
+++ b/src/mako/validator/rules/MatchField.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Match field rule.
  */
-class MatchField extends Rule implements RuleInterface
+class MatchField extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/MaxCount.php
+++ b/src/mako/validator/rules/MaxCount.php
@@ -16,7 +16,7 @@ use function sprintf;
 /**
  * Max count rule.
  */
-class MaxCount extends Rule implements RuleInterface
+class MaxCount extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/MaxLength.php
+++ b/src/mako/validator/rules/MaxLength.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Max length rule.
  */
-class MaxLength extends Rule implements RuleInterface
+class MaxLength extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/MinCount.php
+++ b/src/mako/validator/rules/MinCount.php
@@ -16,7 +16,7 @@ use function sprintf;
 /**
  * Min count rule.
  */
-class MinCount extends Rule implements RuleInterface
+class MinCount extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/MinLength.php
+++ b/src/mako/validator/rules/MinLength.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Min length rule.
  */
-class MinLength extends Rule implements RuleInterface
+class MinLength extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/NotEmpty.php
+++ b/src/mako/validator/rules/NotEmpty.php
@@ -17,7 +17,7 @@ use function sprintf;
 /**
  * Required rule.
  */
-class NotEmpty extends Rule implements RuleInterface
+class NotEmpty extends Rule
 {
 	use ValidatesWhenEmptyTrait;
 

--- a/src/mako/validator/rules/NotIn.php
+++ b/src/mako/validator/rules/NotIn.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Not in rule.
  */
-class NotIn extends Rule implements RuleInterface
+class NotIn extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/Number.php
+++ b/src/mako/validator/rules/Number.php
@@ -16,7 +16,7 @@ use function sprintf;
 /**
  * Number rule.
  */
-class Number extends Rule implements RuleInterface
+class Number extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/NumberFloat.php
+++ b/src/mako/validator/rules/NumberFloat.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Number float rule.
  */
-class NumberFloat extends Rule implements RuleInterface
+class NumberFloat extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/NumberInt.php
+++ b/src/mako/validator/rules/NumberInt.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Number integer rule.
  */
-class NumberInt extends Rule implements RuleInterface
+class NumberInt extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/NumberNatural.php
+++ b/src/mako/validator/rules/NumberNatural.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Number natural rule.
  */
-class NumberNatural extends Rule implements RuleInterface
+class NumberNatural extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/NumberNaturalNonZero.php
+++ b/src/mako/validator/rules/NumberNaturalNonZero.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Number natural non-zero rule.
  */
-class NumberNaturalNonZero extends Rule implements RuleInterface
+class NumberNaturalNonZero extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/Numeric.php
+++ b/src/mako/validator/rules/Numeric.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Numeric rule.
  */
-class Numeric extends Rule implements RuleInterface
+class Numeric extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/NumericFloat.php
+++ b/src/mako/validator/rules/NumericFloat.php
@@ -16,7 +16,7 @@ use function sprintf;
 /**
  * Numberic float rule.
  */
-class NumericFloat extends Rule implements RuleInterface
+class NumericFloat extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/NumericInt.php
+++ b/src/mako/validator/rules/NumericInt.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Numeric integer rule.
  */
-class NumericInt extends Rule implements RuleInterface
+class NumericInt extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/NumericNatural.php
+++ b/src/mako/validator/rules/NumericNatural.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Numeric natural rule.
  */
-class NumericNatural extends Rule implements RuleInterface
+class NumericNatural extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/NumericNaturalNonZero.php
+++ b/src/mako/validator/rules/NumericNaturalNonZero.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Numeric natural non-zero rule.
  */
-class NumericNaturalNonZero extends Rule implements RuleInterface
+class NumericNaturalNonZero extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/Optional.php
+++ b/src/mako/validator/rules/Optional.php
@@ -12,7 +12,7 @@ use Override;
 /**
  * Optional rule.
  */
-class Optional extends Rule implements RuleInterface
+class Optional extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/Regex.php
+++ b/src/mako/validator/rules/Regex.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Regex rule.
  */
-class Regex extends Rule implements RuleInterface
+class Regex extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/Required.php
+++ b/src/mako/validator/rules/Required.php
@@ -16,7 +16,7 @@ use function sprintf;
 /**
  * Required rule.
  */
-class Required extends Rule implements RuleInterface
+class Required extends Rule
 {
 	use ValidatesWhenEmptyTrait;
 

--- a/src/mako/validator/rules/Rule.php
+++ b/src/mako/validator/rules/Rule.php
@@ -13,7 +13,7 @@ use mako\validator\rules\traits\I18nAwareTrait;
 /**
  * Base rule.
  */
-abstract class Rule implements I18nAwareInterface
+abstract class Rule implements I18nAwareInterface, RuleInterface
 {
 	use DoesntValidateWhenEmptyTrait;
 	use I18nAwareTrait;

--- a/src/mako/validator/rules/Str.php
+++ b/src/mako/validator/rules/Str.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * Str rule.
  */
-class Str extends Rule implements RuleInterface
+class Str extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/TimeZone.php
+++ b/src/mako/validator/rules/TimeZone.php
@@ -16,7 +16,7 @@ use function sprintf;
 /**
  * Time zone rule.
  */
-class TimeZone extends Rule implements RuleInterface
+class TimeZone extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/URL.php
+++ b/src/mako/validator/rules/URL.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * URL rule.
  */
-class URL extends Rule implements RuleInterface
+class URL extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/UUID.php
+++ b/src/mako/validator/rules/UUID.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * UUID rule.
  */
-class UUID extends Rule implements RuleInterface
+class UUID extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/UniqueValues.php
+++ b/src/mako/validator/rules/UniqueValues.php
@@ -16,7 +16,7 @@ use function sprintf;
 /**
  * Unique values rule.
  */
-class UniqueValues extends Rule implements RuleInterface
+class UniqueValues extends Rule
 {
 	/**
 	 * I18n parameters.

--- a/src/mako/validator/rules/combinators/AllOf.php
+++ b/src/mako/validator/rules/combinators/AllOf.php
@@ -21,9 +21,18 @@ class AllOf extends RuleCombinator
 	 * {@inheritDoc}
 	 */
 	#[Override]
-	public function getSuccessCondition(): callable
+	public function isSuccessful(int $successes): bool
 	{
-		return fn (int $matches): bool => count($this->rules) === $matches;
+		return count($this->rules) === $successes;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	#[Override]
+	public function shouldAggregateChildErrors(int $successes, array $errorMessages): bool
+	{
+		return !empty($errorMessages);
 	}
 
 	/**

--- a/src/mako/validator/rules/combinators/AllOf.php
+++ b/src/mako/validator/rules/combinators/AllOf.php
@@ -21,7 +21,7 @@ class AllOf extends RuleCombinator
 	 * {@inheritDoc}
 	 */
 	#[Override]
-	public function getMatchCondition(): callable
+	public function getSuccessCondition(): callable
 	{
 		return fn (int $matches): bool => count($this->rules) === $matches;
 	}

--- a/src/mako/validator/rules/combinators/AllOf.php
+++ b/src/mako/validator/rules/combinators/AllOf.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\validator\rules\combinators;
+
+use Override;
+
+use function count;
+
+/**
+ * All of rule combinator.
+ */
+class AllOf extends RuleCombinator
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	#[Override]
+	public function getMatchCondition(): callable
+	{
+		return fn (int $matches): bool => count($this->rules) === $matches;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	#[Override]
+	public function getErrorMessage(string $field): string
+	{
+		return sprintf('The %1$s field must satisfy all of its validation rules.', $field);
+	}
+}

--- a/src/mako/validator/rules/combinators/AllOf.php
+++ b/src/mako/validator/rules/combinators/AllOf.php
@@ -10,6 +10,7 @@ namespace mako\validator\rules\combinators;
 use Override;
 
 use function count;
+use function sprintf;
 
 /**
  * All of rule combinator.

--- a/src/mako/validator/rules/combinators/AnyOf.php
+++ b/src/mako/validator/rules/combinators/AnyOf.php
@@ -20,9 +20,18 @@ class AnyOf extends RuleCombinator
 	 * {@inheritDoc}
 	 */
 	#[Override]
-	public function getSuccessCondition(): callable
+	public function isSuccessful(int $successes): bool
 	{
-		return fn (int $matches): bool => $matches >= 1;
+		return $successes >= 1;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	#[Override]
+	public function shouldAggregateChildErrors(int $successes, array $errorMessages): bool
+	{
+		return !empty($errorMessages);
 	}
 
 	/**

--- a/src/mako/validator/rules/combinators/AnyOf.php
+++ b/src/mako/validator/rules/combinators/AnyOf.php
@@ -9,6 +9,8 @@ namespace mako\validator\rules\combinators;
 
 use Override;
 
+use function sprintf;
+
 /**
  * Any of rule combinator.
  */

--- a/src/mako/validator/rules/combinators/AnyOf.php
+++ b/src/mako/validator/rules/combinators/AnyOf.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\validator\rules\combinators;
+
+use Override;
+
+/**
+ * Any of rule combinator.
+ */
+class AnyOf extends RuleCombinator
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	#[Override]
+	public function getMatchCondition(): callable
+	{
+		return fn (int $matches): bool => $matches >= 1;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	#[Override]
+	public function getErrorMessage(string $field): string
+	{
+		return sprintf('The %1$s field must satisfy at least one of its validation rules.', $field);
+	}
+}

--- a/src/mako/validator/rules/combinators/AnyOf.php
+++ b/src/mako/validator/rules/combinators/AnyOf.php
@@ -20,7 +20,7 @@ class AnyOf extends RuleCombinator
 	 * {@inheritDoc}
 	 */
 	#[Override]
-	public function getMatchCondition(): callable
+	public function getSuccessCondition(): callable
 	{
 		return fn (int $matches): bool => $matches >= 1;
 	}

--- a/src/mako/validator/rules/combinators/OneOf.php
+++ b/src/mako/validator/rules/combinators/OneOf.php
@@ -20,9 +20,18 @@ class OneOf extends RuleCombinator
 	 * {@inheritDoc}
 	 */
 	#[Override]
-	public function getSuccessCondition(): callable
+	public function isSuccessful(int $successes): bool
 	{
-		return fn (int $matches): bool => $matches === 1;
+		return $successes === 1;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	#[Override]
+	public function shouldAggregateChildErrors(int $successes, array $errorMessages): bool
+	{
+		return !empty($errorMessages) && $successes === 0;
 	}
 
 	/**

--- a/src/mako/validator/rules/combinators/OneOf.php
+++ b/src/mako/validator/rules/combinators/OneOf.php
@@ -9,6 +9,8 @@ namespace mako\validator\rules\combinators;
 
 use Override;
 
+use function sprintf;
+
 /**
  * One of rule combinator.
  */

--- a/src/mako/validator/rules/combinators/OneOf.php
+++ b/src/mako/validator/rules/combinators/OneOf.php
@@ -20,7 +20,7 @@ class OneOf extends RuleCombinator
 	 * {@inheritDoc}
 	 */
 	#[Override]
-	public function getMatchCondition(): callable
+	public function getSuccessCondition(): callable
 	{
 		return fn (int $matches): bool => $matches === 1;
 	}

--- a/src/mako/validator/rules/combinators/OneOf.php
+++ b/src/mako/validator/rules/combinators/OneOf.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\validator\rules\combinators;
+
+use Override;
+
+/**
+ * One of rule combinator.
+ */
+class OneOf extends RuleCombinator
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	#[Override]
+	public function getMatchCondition(): callable
+	{
+		return fn (int $matches): bool => $matches === 1;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	#[Override]
+	public function getErrorMessage(string $field): string
+	{
+		return sprintf('The %1$s field must satisfy exactly one of its validation rules.', $field);
+	}
+}

--- a/src/mako/validator/rules/combinators/RuleCombinator.php
+++ b/src/mako/validator/rules/combinators/RuleCombinator.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\validator\rules\combinators;
+
+use mako\validator\rules\I18nAwareInterface;
+use mako\validator\rules\RuleInterface;
+use mako\validator\rules\traits\I18nAwareTrait;
+use Override;
+
+/**
+ * Base rule combinator.
+ */
+abstract class RuleCombinator implements I18nAwareInterface, RuleCombinatorInterface
+{
+	use I18nAwareTrait;
+
+	/**
+	 * @var (RuleInterface|string)[]
+	 */
+	final protected array $rules;
+
+	/**
+	 * Constructor.
+	 */
+	final public function __construct(RuleInterface|string ...$rule)
+	{
+		$this->rules = $rule;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	#[Override]
+	final public function getRules(): array
+	{
+		return $this->rules;
+	}
+}

--- a/src/mako/validator/rules/combinators/RuleCombinatorInterface.php
+++ b/src/mako/validator/rules/combinators/RuleCombinatorInterface.php
@@ -22,11 +22,11 @@ interface RuleCombinatorInterface
 	public function getRules(): array;
 
 	/**
-	 * Returns a callable that can be used to check if the match condition is met.
+	 * Returns a callable that can be used to check if the success condition is met.
 	 *
 	 * @return callable(int): bool
 	 */
-	public function getMatchCondition(): callable;
+	public function getSuccessCondition(): callable;
 
 	/**
 	 * Returns an error message.

--- a/src/mako/validator/rules/combinators/RuleCombinatorInterface.php
+++ b/src/mako/validator/rules/combinators/RuleCombinatorInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Frederic G. Østby
+ * @license   http://www.makoframework.com/license
+ */
+
+namespace mako\validator\rules\combinators;
+
+use mako\validator\rules\RuleInterface;
+
+/**
+ * Rule combinator interface.
+ */
+interface RuleCombinatorInterface
+{
+	/**
+	 * Get the rules.
+	 *
+	 * @return (RuleInterface|string)[]
+	 */
+	public function getRules(): array;
+
+	/**
+	 * Returns a callable that can be used to check if the match condition is met.
+	 *
+	 * @return callable(int): bool
+	 */
+	public function getMatchCondition(): callable;
+
+	/**
+	 * Returns an error message.
+	 */
+	public function getErrorMessage(string $field): string;
+}

--- a/src/mako/validator/rules/combinators/RuleCombinatorInterface.php
+++ b/src/mako/validator/rules/combinators/RuleCombinatorInterface.php
@@ -22,11 +22,14 @@ interface RuleCombinatorInterface
 	public function getRules(): array;
 
 	/**
-	 * Returns a callable that can be used to check if the success condition is met.
-	 *
-	 * @return callable(int): bool
+	 * Returns TRUE if the combinator is considered successful and FALSE if not.
 	 */
-	public function getSuccessCondition(): callable;
+	public function isSuccessful(int $successes): bool;
+
+    /**
+     * Returns TRUE if child rule error messages should be aggregated for this failure and FALSE if not.
+     */
+    public function shouldAggregateChildErrors(int $successes, array $errorMessages): bool;
 
 	/**
 	 * Returns an error message.

--- a/src/mako/validator/rules/database/Exists.php
+++ b/src/mako/validator/rules/database/Exists.php
@@ -9,7 +9,6 @@ namespace mako\validator\rules\database;
 
 use mako\database\ConnectionManager;
 use mako\validator\rules\Rule;
-use mako\validator\rules\RuleInterface;
 use Override;
 
 use function sprintf;
@@ -17,7 +16,7 @@ use function sprintf;
 /**
  * Exists rule.
  */
-class Exists extends Rule implements RuleInterface
+class Exists extends Rule
 {
 	/**
 	 * I18n parameters.

--- a/src/mako/validator/rules/database/Unique.php
+++ b/src/mako/validator/rules/database/Unique.php
@@ -9,7 +9,6 @@ namespace mako\validator\rules\database;
 
 use mako\database\ConnectionManager;
 use mako\validator\rules\Rule;
-use mako\validator\rules\RuleInterface;
 use Override;
 
 use function sprintf;
@@ -17,7 +16,7 @@ use function sprintf;
 /**
  * Unique rule.
  */
-class Unique extends Rule implements RuleInterface
+class Unique extends Rule
 {
 	/**
 	 * I18n parameters.

--- a/src/mako/validator/rules/file/Hash.php
+++ b/src/mako/validator/rules/file/Hash.php
@@ -8,7 +8,6 @@
 namespace mako\validator\rules\file;
 
 use mako\validator\rules\Rule;
-use mako\validator\rules\RuleInterface;
 use Override;
 
 use function sprintf;
@@ -16,7 +15,7 @@ use function sprintf;
 /**
  * Hash rule.
  */
-class Hash extends Rule implements RuleInterface
+class Hash extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/file/Hmac.php
+++ b/src/mako/validator/rules/file/Hmac.php
@@ -8,7 +8,6 @@
 namespace mako\validator\rules\file;
 
 use mako\validator\rules\Rule;
-use mako\validator\rules\RuleInterface;
 use Override;
 use SensitiveParameter;
 
@@ -17,7 +16,7 @@ use function sprintf;
 /**
  * Hmac rule.
  */
-class Hmac extends Rule implements RuleInterface
+class Hmac extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/file/IsUploaded.php
+++ b/src/mako/validator/rules/file/IsUploaded.php
@@ -9,7 +9,6 @@ namespace mako\validator\rules\file;
 
 use mako\http\request\UploadedFile;
 use mako\validator\rules\Rule;
-use mako\validator\rules\RuleInterface;
 use Override;
 
 use function sprintf;
@@ -17,7 +16,7 @@ use function sprintf;
 /**
  * Is uploaded rule.
  */
-class IsUploaded extends Rule implements RuleInterface
+class IsUploaded extends Rule
 {
 	/**
 	 * {@inheritDoc}

--- a/src/mako/validator/rules/file/MaxFileSize.php
+++ b/src/mako/validator/rules/file/MaxFileSize.php
@@ -9,7 +9,6 @@ namespace mako\validator\rules\file;
 
 use mako\validator\exceptions\ValidatorException;
 use mako\validator\rules\Rule;
-use mako\validator\rules\RuleInterface;
 use Override;
 
 use function is_numeric;
@@ -20,7 +19,7 @@ use function substr;
 /**
  * Max file size rule.
  */
-class MaxFileSize extends Rule implements RuleInterface
+class MaxFileSize extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/file/MaxFilenameLength.php
+++ b/src/mako/validator/rules/file/MaxFilenameLength.php
@@ -9,7 +9,6 @@ namespace mako\validator\rules\file;
 
 use mako\http\request\UploadedFile;
 use mako\validator\rules\Rule;
-use mako\validator\rules\RuleInterface;
 use Override;
 
 use function mb_strlen;
@@ -18,7 +17,7 @@ use function sprintf;
 /**
  * Max filename length rule.
  */
-class MaxFilenameLength extends Rule implements RuleInterface
+class MaxFilenameLength extends Rule
 {
 	/**
 	 * Constructor.

--- a/src/mako/validator/rules/file/MimeType.php
+++ b/src/mako/validator/rules/file/MimeType.php
@@ -8,7 +8,6 @@
 namespace mako\validator\rules\file;
 
 use mako\validator\rules\Rule;
-use mako\validator\rules\RuleInterface;
 use Override;
 
 use function implode;
@@ -18,7 +17,7 @@ use function sprintf;
 /**
  * Mime type rule.
  */
-class MimeType extends Rule implements RuleInterface
+class MimeType extends Rule
 {
 	/**
 	 * Mime types.

--- a/src/mako/validator/rules/file/image/AspectRatio.php
+++ b/src/mako/validator/rules/file/image/AspectRatio.php
@@ -9,7 +9,6 @@ namespace mako\validator\rules\file\image;
 
 use mako\validator\rules\file\image\traits\GetImageSizeTrait;
 use mako\validator\rules\Rule;
-use mako\validator\rules\RuleInterface;
 use Override;
 
 use function sprintf;
@@ -17,7 +16,7 @@ use function sprintf;
 /**
  * Aspect ratio rule.
  */
-class AspectRatio extends Rule implements RuleInterface
+class AspectRatio extends Rule
 {
 	use GetImageSizeTrait;
 

--- a/src/mako/validator/rules/file/image/ExactDimensions.php
+++ b/src/mako/validator/rules/file/image/ExactDimensions.php
@@ -9,7 +9,6 @@ namespace mako\validator\rules\file\image;
 
 use mako\validator\rules\file\image\traits\GetImageSizeTrait;
 use mako\validator\rules\Rule;
-use mako\validator\rules\RuleInterface;
 use Override;
 
 use function sprintf;
@@ -17,7 +16,7 @@ use function sprintf;
 /**
  * Exact dimensions rule.
  */
-class ExactDimensions extends Rule implements RuleInterface
+class ExactDimensions extends Rule
 {
 	use GetImageSizeTrait;
 

--- a/src/mako/validator/rules/file/image/MaxDimensions.php
+++ b/src/mako/validator/rules/file/image/MaxDimensions.php
@@ -9,7 +9,6 @@ namespace mako\validator\rules\file\image;
 
 use mako\validator\rules\file\image\traits\GetImageSizeTrait;
 use mako\validator\rules\Rule;
-use mako\validator\rules\RuleInterface;
 use Override;
 
 use function sprintf;
@@ -17,7 +16,7 @@ use function sprintf;
 /**
  * Max dimensions rule.
  */
-class MaxDimensions extends Rule implements RuleInterface
+class MaxDimensions extends Rule
 {
 	use GetImageSizeTrait;
 

--- a/src/mako/validator/rules/file/image/MinDimensions.php
+++ b/src/mako/validator/rules/file/image/MinDimensions.php
@@ -9,7 +9,6 @@ namespace mako\validator\rules\file\image;
 
 use mako\validator\rules\file\image\traits\GetImageSizeTrait;
 use mako\validator\rules\Rule;
-use mako\validator\rules\RuleInterface;
 use Override;
 
 use function sprintf;
@@ -17,7 +16,7 @@ use function sprintf;
 /**
  * Min dimensions rule.
  */
-class MinDimensions extends Rule implements RuleInterface
+class MinDimensions extends Rule
 {
 	use GetImageSizeTrait;
 

--- a/src/mako/validator/rules/session/OneTimeToken.php
+++ b/src/mako/validator/rules/session/OneTimeToken.php
@@ -9,7 +9,6 @@ namespace mako\validator\rules\session;
 
 use mako\session\Session;
 use mako\validator\rules\Rule;
-use mako\validator\rules\RuleInterface;
 use mako\validator\rules\traits\ValidatesWhenEmptyTrait;
 use Override;
 use SensitiveParameter;
@@ -17,7 +16,7 @@ use SensitiveParameter;
 /**
  * One-time token rule.
  */
-class OneTimeToken extends Rule implements RuleInterface
+class OneTimeToken extends Rule
 {
 	use ValidatesWhenEmptyTrait;
 

--- a/src/mako/validator/rules/session/Token.php
+++ b/src/mako/validator/rules/session/Token.php
@@ -9,7 +9,6 @@ namespace mako\validator\rules\session;
 
 use mako\session\Session;
 use mako\validator\rules\Rule;
-use mako\validator\rules\RuleInterface;
 use mako\validator\rules\traits\ValidatesWhenEmptyTrait;
 use Override;
 use SensitiveParameter;
@@ -17,7 +16,7 @@ use SensitiveParameter;
 /**
  * Token rule.
  */
-class Token extends Rule implements RuleInterface
+class Token extends Rule
 {
 	use ValidatesWhenEmptyTrait;
 

--- a/tests/unit/validator/ValidatorTest.php
+++ b/tests/unit/validator/ValidatorTest.php
@@ -548,9 +548,9 @@ class ValidatorTest extends TestCase
 	 */
 	public function testValidateWithValidAnyOfRuleCombinator(): void
 	{
-		$input = ['foo' => [1, 2, 3]];
+		$input = ['foo' => 9];
 
-		$rules = ['foo' => [new AnyOf('string', 'array')]];
+		$rules = ['foo' => [new AnyOf('less_than(10)', 'greater_than(20)')]];
 
 		$validator = new Validator($input, $rules);
 
@@ -562,14 +562,14 @@ class ValidatorTest extends TestCase
 	 */
 	public function testValidateWithInvalidAnyOfRuleCombinator(): void
 	{
-		$input = ['foo' => [1, 2, 3]];
+		$input = ['foo' => 15];
 
-		$rules = ['foo' => [new AnyOf('string', 'boolean')]];
+		$rules = ['foo' => [new AnyOf('less_than(10)', 'greater_than(20)')]];
 
 		$validator = new Validator($input, $rules);
 
 		$this->assertFalse($validator->isValid());
-		$this->assertSame(['foo' => 'The foo field must contain a string.'], $validator->getErrors());
+		$this->assertSame(['foo' => 'The value of the foo field must be less than 10.'], $validator->getErrors());
 	}
 
 	/**

--- a/tests/unit/validator/ValidatorTest.php
+++ b/tests/unit/validator/ValidatorTest.php
@@ -569,7 +569,7 @@ class ValidatorTest extends TestCase
 		$validator = new Validator($input, $rules);
 
 		$this->assertFalse($validator->isValid());
-		$this->assertSame(['foo' => 'The value of the foo field must be less than 10.'], $validator->getErrors());
+		$this->assertSame(['foo' => 'The value of the foo field must be less than 10. The value of the foo field must be greater than 20.'], $validator->getErrors());
 	}
 
 	/**

--- a/tests/unit/validator/ValidatorTest.php
+++ b/tests/unit/validator/ValidatorTest.php
@@ -10,6 +10,9 @@ namespace mako\tests\unit\validator;
 use mako\i18n\I18n;
 use mako\tests\TestCase;
 use mako\validator\exceptions\ValidationException;
+use mako\validator\rules\combinators\AllOf;
+use mako\validator\rules\combinators\AnyOf;
+use mako\validator\rules\combinators\OneOf;
 use mako\validator\rules\I18nAwareInterface;
 use mako\validator\rules\Rule;
 use mako\validator\rules\RuleInterface;
@@ -20,7 +23,7 @@ use Throwable;
 
 use function mako\f;
 
-class MyRule extends Rule implements RuleInterface
+class MyRule extends Rule
 {
 	public function validate(mixed $value, string $field, array $input): bool
 	{
@@ -495,6 +498,107 @@ class ValidatorTest extends TestCase
 		$validator = new Validator($input, $rules);
 
 		$this->assertSame($input, $validator->getValidatedInput());
+	}
+
+	/**
+	 *
+	 */
+	public function testValidateWithMixOfStringAndInstanceRules(): void
+	{
+		$input = ['username' => 'foo'];
+
+		$rules = ['username' => [MyRule::class, new MyRule]];
+
+		$validator = new Validator($input, $rules);
+
+		$this->assertSame($input, $validator->getValidatedInput());
+	}
+
+	/**
+	 *
+	 */
+	public function testValidateWithValidOneOfRuleCombinator(): void
+	{
+		$input = ['foo' => [1, 2, 3]];
+
+		$rules = ['foo' => [new OneOf('array', 'string')]];
+
+		$validator = new Validator($input, $rules);
+
+		$this->assertTrue($validator->isValid());
+	}
+
+	/**
+	 *
+	 */
+	public function testValidateWithInvalidOneOfRuleCombinator(): void
+	{
+		$input = ['foo' => [1, 2, 3]];
+
+		$rules = ['foo' => [new OneOf('array', 'array')]];
+
+		$validator = new Validator($input, $rules);
+
+		$this->assertFalse($validator->isValid());
+		$this->assertSame(['foo' => 'The foo field must satisfy exactly one of its validation rules.'], $validator->getErrors());
+	}
+
+	/**
+	 *
+	 */
+	public function testValidateWithValidAnyOfRuleCombinator(): void
+	{
+		$input = ['foo' => [1, 2, 3]];
+
+		$rules = ['foo' => [new AnyOf('string', 'array')]];
+
+		$validator = new Validator($input, $rules);
+
+		$this->assertTrue($validator->isValid());
+	}
+
+	/**
+	 *
+	 */
+	public function testValidateWithInvalidAnyOfRuleCombinator(): void
+	{
+		$input = ['foo' => [1, 2, 3]];
+
+		$rules = ['foo' => [new AnyOf('string', 'boolean')]];
+
+		$validator = new Validator($input, $rules);
+
+		$this->assertFalse($validator->isValid());
+		$this->assertSame(['foo' => 'The foo field must contain a string.'], $validator->getErrors());
+	}
+
+	/**
+	 *
+	 */
+	public function testValidateWithValidAllOfRuleCombinator(): void
+	{
+		$input = ['foo' => [1, 2, 3]];
+
+		$rules = ['foo' => [new AllOf('array', 'exact_count(3)')]];
+
+		$validator = new Validator($input, $rules);
+
+		$this->assertTrue($validator->isValid());
+	}
+
+	/**
+	 *
+	 */
+	public function testValidateWithInvalidAllOfRuleCombinator(): void
+	{
+		$input = ['foo' => [1, 2, 3]];
+
+		$rules = ['foo' => [new AllOf('array', 'string')]];
+
+		$validator = new Validator($input, $rules);
+
+		$this->assertFalse($validator->isValid());
+		$this->assertSame(['foo' => 'The foo field must contain a string.'], $validator->getErrors());
 	}
 
 	/**

--- a/tests/unit/validator/ValidatorTest.php
+++ b/tests/unit/validator/ValidatorTest.php
@@ -535,12 +535,23 @@ class ValidatorTest extends TestCase
 	{
 		$input = ['foo' => [1, 2, 3]];
 
-		$rules = ['foo' => [new OneOf('array', 'array')]];
+		$rules = ['foo' => [new OneOf('array', 'array', 'string')]];
 
 		$validator = new Validator($input, $rules);
 
 		$this->assertFalse($validator->isValid());
 		$this->assertSame(['foo' => 'The foo field must satisfy exactly one of its validation rules.'], $validator->getErrors());
+
+		//
+
+		$input = ['foo' => [1, 2, 3]];
+
+		$rules = ['foo' => [new OneOf('string', 'boolean')]];
+
+		$validator = new Validator($input, $rules);
+
+		$this->assertFalse($validator->isValid());
+		$this->assertSame(['foo' => 'The foo field must contain a string. The foo field must contain a boolean.'], $validator->getErrors());
 	}
 
 	/**

--- a/tests/unit/validator/input/http/routing/middleware/InputValidationTest.php
+++ b/tests/unit/validator/input/http/routing/middleware/InputValidationTest.php
@@ -13,6 +13,7 @@ use mako\http\request\Parameters;
 use mako\http\Response;
 use mako\http\response\builders\JSON;
 use mako\http\response\senders\Redirect;
+use mako\http\response\Status;
 use mako\http\routing\URLBuilder;
 use mako\session\Session;
 use mako\tests\TestCase;
@@ -554,7 +555,7 @@ class InputValidationTest extends TestCase
 
 		$response = Mockery::mock(Response::class);
 
-		$response->shouldReceive('setStatus')->once()->with(400);
+		$response->shouldReceive('setStatus')->once()->with(Status::BadRequest);
 
 		$response->makePartial();
 
@@ -607,7 +608,7 @@ class InputValidationTest extends TestCase
 
 		$response = Mockery::mock(Response::class);
 
-		$response->shouldReceive('setStatus')->once()->with(400);
+		$response->shouldReceive('setStatus')->once()->with(Status::BadRequest);
 
 		$response->shouldReceive('setType')->once()->with('application/xml');
 
@@ -648,7 +649,7 @@ class InputValidationTest extends TestCase
 
 		$response = Mockery::mock(Response::class);
 
-		$response->shouldReceive('setStatus')->once()->with(400);
+		$response->shouldReceive('setStatus')->once()->with(Status::BadRequest);
 
 		//
 
@@ -706,7 +707,7 @@ class InputValidationTest extends TestCase
 
 		$response->shouldReceive('clearExcept')->once()->with(['headers' => ['Access-Control-.*']]);
 
-		$response->shouldReceive('setStatus')->once()->with(400);
+		$response->shouldReceive('setStatus')->once()->with(Status::BadRequest);
 
 		//-------------
 


### PR DESCRIPTION
<!--
Please use the provided template when creating pull requests 🙂
-->

### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      | -      |
| New feature? | Yes      |
| Other?       | -      |

### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | -      |
| Has unit and/or integration tests?  | Yes      |

###  Description
---

Added support for validation rule combinators (`OneOf`, `AnyOf`, `AllOf`).

```php
$rules = [
    'foo' => new AnyOf('less_than(10)', 'greater_than(20)')]
];
```
