### PR TITLE
fix: correct 'occured' to 'occurred' typo in CLI error handler

### DIFF
--- a/src/mako/error/handlers/cli/DevelopmentHandler.php
+++ b/src/mako/error/handlers/cli/DevelopmentHandler.php
@@ -85,7 +85,7 @@ class DevelopmentHandler implements HandlerInterface
 		if (!empty($exception->getFile())) {
 			$info .= PHP_EOL
 			. PHP_EOL
-			. " The error occured in <bold>{$this->escape(str_replace($cwd, '.', $exception->getFile()))}</bold>"
+			. " The error occurred in <bold>{$this->escape(str_replace($cwd, '.', $exception->getFile()))}</bold>"
 			. " on line <bold>{$exception->getLine()}</bold>"
 			. PHP_EOL;
 		}


### PR DESCRIPTION
## Summary
Correct a typo in the CLI error handler: `occured` → `occurred`.

## Changes
- `src/mako/error/handlers/cli/DevelopmentHandler.php` line 88: User-facing error message now correctly shows 'The error **occurred** in...' instead of 'The error **occured** in...'

## Testing
- Documentation-only change, PHP syntax validated

---
Git author: Jah-yee <jydu_seven@outlook.com>