### PR TITLE
Now possible to create image instances from a binary blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ The major version bump is due to upping the required PHP version from `8.5` to `
 * Added `PSR-20` (ClockInterface) implementation.
 * Added `SleeperInterface` and `Sleeper` implementation for time-based delays.
 * Added the following methods to the `ImageInterface` interface:
+	- `ImageInterface::fromPath()`
+	- `ImageInterface::fromBlob()`
 	- `ImageInterface::toBase64()`
 	- `ImageInterface::toDataUri()`
 	- `ImageInterface::getMimeType()`

--- a/src/mako/pixel/image/Gd.php
+++ b/src/mako/pixel/image/Gd.php
@@ -16,6 +16,7 @@ use function array_slice;
 use function arsort;
 use function explode;
 use function getimagesize;
+use function getimagesizefromstring;
 use function imagealphablending;
 use function imageavif;
 use function imagebmp;
@@ -25,6 +26,7 @@ use function imagecreatefromavif;
 use function imagecreatefromgif;
 use function imagecreatefromjpeg;
 use function imagecreatefrompng;
+use function imagecreatefromstring;
 use function imagecreatefromwebp;
 use function imagecreatetruecolor;
 use function imagegif;
@@ -57,7 +59,7 @@ class Gd extends Image
 	/**
 	 * Returns information about the image.
 	 */
-	protected function getImageInfo(string $imagePath): array
+	protected function getImageInfoFromPath(string $imagePath): array
 	{
 		$imageInfo = getimagesize($imagePath);
 
@@ -72,9 +74,11 @@ class Gd extends Image
 	 * {@inheritDoc}
 	 */
 	#[Override]
-	protected function createImageResource(string $imagePath): object
+	protected function createImageResourceFromPath(string $imagePath): object
 	{
-		$imageInfo = $this->getImageInfo($imagePath);
+		$this->imagePath = $imagePath;
+
+		$imageInfo = $this->getImageInfoFromPath($imagePath);
 
 		$this->mimeType = $this->normalizeMimeType($imageInfo['mime']);
 
@@ -86,6 +90,33 @@ class Gd extends Image
 			IMAGETYPE_AVIF => imagecreatefromavif($imagePath),
 			default        => throw new ImageException(sprintf('Unable to create image resource from [ %s ]. Unsupported image type [ %s ].', $imagePath, $this->mimeType)),
 		};
+    }
+
+	/**
+	 * Returns information about the image.
+	 */
+	protected function getImageInfoFromBlob(string $blob): array
+	{
+		$imageInfo = getimagesizefromstring($blob);
+
+		if ($imageInfo === false) {
+			throw new ImageException('Unable to process the image.');
+		}
+
+		return $imageInfo;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	#[Override]
+	protected function createImageResourceFromBlob(string $blob): object
+	{
+		$imageInfo = $this->getImageInfoFromBlob($blob);
+
+		$this->mimeType = $this->normalizeMimeType($imageInfo['mime']);
+
+		return imagecreatefromstring($blob);
     }
 
 	/**

--- a/src/mako/pixel/image/Gd.php
+++ b/src/mako/pixel/image/Gd.php
@@ -180,17 +180,6 @@ class Gd extends Image
 	 * {@inheritDoc}
 	 */
 	#[Override]
-	protected function getOuputMimeType(?string $type): string
-	{
-		return $type === null
-			? $this->mimeType
-			: $this->normalizeMimeType($type);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	#[Override]
 	protected function saveImageResource(string $imagePath, int $quality): void
 	{
 		$extension = pathinfo($imagePath, PATHINFO_EXTENSION);

--- a/src/mako/pixel/image/Image.php
+++ b/src/mako/pixel/image/Image.php
@@ -10,6 +10,7 @@ namespace mako\pixel\image;
 use mako\pixel\image\exceptions\ImageException;
 use mako\pixel\image\operations\OperationInterface;
 use Override;
+use ReflectionClass;
 
 use function base64_encode;
 use function file_exists;
@@ -33,6 +34,11 @@ abstract class Image implements ImageInterface
 	protected ?object $imageResource = null;
 
 	/**
+	 * Image path.
+	 */
+	protected ?string $imagePath = null;
+
+	/**
 	 * Mime type.
 	 */
 	protected string $mimeType;
@@ -45,8 +51,8 @@ abstract class Image implements ImageInterface
 	/**
 	 * Constructor.
 	 */
-	public function __construct(
-		protected string $imagePath
+	final public function __construct(
+		string $imagePath
 	) {
 		if (file_exists($imagePath) === false) {
 			throw new ImageException(sprintf('The image [ %s ] does not exist.', $imagePath));
@@ -56,15 +62,37 @@ abstract class Image implements ImageInterface
 			throw new ImageException(sprintf('The image [ %s ] is not readable.', $imagePath));
 		}
 
-		$this->imageResource = $this->createImageResource($imagePath);
+		$this->imageResource = $this->createImageResourceFromPath($imagePath);
 	}
 
 	/**
 	 * Destructor.
 	 */
-	public function __destruct()
+	final public function __destruct()
 	{
 		$this->destroyImageResource();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	#[Override]
+	final public static function fromPath(string $imagePath): static
+	{
+		return new static($imagePath);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	#[Override]
+	final public static function fromBlob(string $blob): static
+	{
+		$image = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
+
+		$image->createImageResourceFromBlob($blob);
+
+		return $image;
 	}
 
 	/**
@@ -83,9 +111,14 @@ abstract class Image implements ImageInterface
 	}
 
 	/**
-	 * Creates an image resource.
+	 * Creates an image resource from a file path.
 	 */
-	abstract protected function createImageResource(string $imagePath): object;
+	abstract protected function createImageResourceFromPath(string $imagePath): object;
+
+	/**
+	 * Creates an image resource from a binary blob.
+	 */
+	abstract protected function createImageResourceFromBlob(string $blob): object;
 
 	/**
 	 * Destroys an image resource.
@@ -186,7 +219,7 @@ abstract class Image implements ImageInterface
 	#[Override]
 	public function save(?string $imagePath = null, int $quality = 95): void
 	{
-		$imagePath ??= $this->imagePath;
+		$imagePath ??= $this->imagePath ?? throw new ImageException('An image path must be provided when saving images created from a blob.');
 
 		if (file_exists($imagePath)) {
 			if (!is_writable($imagePath)) {

--- a/src/mako/pixel/image/Image.php
+++ b/src/mako/pixel/image/Image.php
@@ -131,11 +131,6 @@ abstract class Image implements ImageInterface
 	abstract protected function getImageResourceAsBlob(?string $type, int $quality): string;
 
 	/**
-	 * Returns the mime type of the image resource.
-	 */
-	abstract protected function getOuputMimeType(?string $type): string;
-
-	/**
 	 * Save an image resource.
 	 */
 	abstract protected function saveImageResource(string $imagePath, int $quality): void;
@@ -202,6 +197,16 @@ abstract class Image implements ImageInterface
 	public function toBase64(?string $type = null, int $quality = 95): string
 	{
 		return base64_encode($this->toBlob($type, $quality));
+	}
+
+	/**
+	 * {Returns the output mime type of the image resource.
+	 */
+	protected function getOuputMimeType(?string $type): string
+	{
+		return $type === null
+			? $this->mimeType
+			: $this->normalizeMimeType($type);
 	}
 
 	/**

--- a/src/mako/pixel/image/ImageInterface.php
+++ b/src/mako/pixel/image/ImageInterface.php
@@ -15,6 +15,16 @@ use mako\pixel\image\operations\OperationInterface;
 interface ImageInterface
 {
 	/**
+	 * Creates an image instance from a file path.
+	 */
+	public static function fromPath(string $imagePath): static;
+
+	/**
+	 * Creates an image instance from a binary blob.
+	 */
+	public static function fromBlob(string $blob): static;
+
+	/**
 	 * Returns the underlying image resource object.
 	 */
 	public function getImageResource(): object;

--- a/src/mako/pixel/image/ImageMagick.php
+++ b/src/mako/pixel/image/ImageMagick.php
@@ -36,13 +36,10 @@ class ImageMagick extends Image
 	protected bool $isAnimatedGif = false;
 
 	/**
-	 * {@inheritDoc}
+	 * Stores the mime type and performs a gif check.
 	 */
-	#[Override]
-	protected function createImageResource(string $imagePath): object
+	protected function collectMimeTypeAndPerformGifCheck(Imagick $imageResource): Imagick
 	{
-		$imageResource = new Imagick($imagePath);
-
 		$this->mimeType = $this->normalizeMimeType($imageResource->getImageFormat());
 
 		if ($this->mimeType === 'image/gif' && $imageResource->getNumberImages() > 1) {
@@ -52,6 +49,32 @@ class ImageMagick extends Image
 		}
 
 		return $imageResource;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	#[Override]
+	protected function createImageResourceFromPath(string $imagePath): object
+	{
+		$this->imagePath = $imagePath;
+
+		$imageResource = new Imagick($imagePath);
+
+		return $this->collectMimeTypeAndPerformGifCheck($imageResource);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	#[Override]
+	protected function createImageResourceFromBlob(string $blob): object
+	{
+		$imageResource = new Imagick;
+
+		$imageResource->readImageBlob($blob);
+
+		return $this->collectMimeTypeAndPerformGifCheck($imageResource);
 	}
 
 	/**

--- a/src/mako/pixel/image/ImageMagick.php
+++ b/src/mako/pixel/image/ImageMagick.php
@@ -148,17 +148,6 @@ class ImageMagick extends Image
 	 * {@inheritDoc}
 	 */
 	#[Override]
-	protected function getOuputMimeType(?string $type): string
-	{
-		return $type === null
-			? $this->mimeType
-			: $this->normalizeMimeType($type);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	#[Override]
 	protected function saveImageResource(string $imagePath, int $quality): void
 	{
 		$type = strtolower(pathinfo($imagePath, PATHINFO_EXTENSION));

--- a/src/mako/pixel/image/ImageMagick.php
+++ b/src/mako/pixel/image/ImageMagick.php
@@ -83,10 +83,12 @@ class ImageMagick extends Image
 	#[Override]
 	protected function destroyImageResource(): void
 	{
-		$this->imageResource->clear();
-		$this->imageResource->destroy();
+		if ($this->imageResource !== null) {
+			$this->imageResource->clear();
+			$this->imageResource->destroy();
 
-		$this->imageResource = null;
+			$this->imageResource = null;
+		}
 
 		if ($this->snapshot !== null) {
 			$this->snapshot->clear();

--- a/tests/unit/pixel/image/GdTest.php
+++ b/tests/unit/pixel/image/GdTest.php
@@ -7,6 +7,7 @@
 
 namespace mako\tests\unit\pixel\image;
 
+use mako\pixel\image\exceptions\ImageException;
 use mako\pixel\image\Gd;
 use mako\pixel\image\operations\gd\Bitonal;
 use mako\pixel\image\operations\gd\Negate;
@@ -133,5 +134,38 @@ class GdTest extends TestCase
 		$image = new Gd(__DIR__ . '/fixtures/002.jpg');
 
 		$this->assertSame('image/jpeg', $image->getMimeType());
+	}
+
+	/**
+	 *
+	 */
+	public function testFromPath(): void
+	{
+		$image = Gd::fromPath(__DIR__ . '/fixtures/001.png');
+
+		$this->assertSame('image/png', $image->getMimeType());
+	}
+
+	/**
+	 *
+	 */
+	public function testFromBlob(): void
+	{
+		$image = Gd::fromBlob(file_get_contents(__DIR__ . '/fixtures/001.png'));
+
+		$this->assertSame('image/png', $image->getMimeType());
+	}
+
+	/**
+	 *
+	 */
+	public function testSaveFromBlobWithoutPath(): void
+	{
+		$this->expectException(ImageException::class);
+		$this->expectExceptionMessageIs('An image path must be provided when saving images created from a blob.');
+
+		$image = Gd::fromBlob(file_get_contents(__DIR__ . '/fixtures/001.png'));
+
+		$image->save();
 	}
 }

--- a/tests/unit/pixel/image/ImageMagickTest.php
+++ b/tests/unit/pixel/image/ImageMagickTest.php
@@ -7,6 +7,7 @@
 
 namespace mako\tests\unit\pixel\image;
 
+use mako\pixel\image\exceptions\ImageException;
 use mako\pixel\image\ImageMagick;
 use mako\pixel\image\operations\imagemagick\Bitonal;
 use mako\pixel\image\operations\imagemagick\Negate;
@@ -134,5 +135,38 @@ class ImageMagickTest extends TestCase
 		$image = new ImageMagick(__DIR__ . '/fixtures/002.jpg');
 
 		$this->assertSame('image/jpeg', $image->getMimeType());
+	}
+
+	/**
+	 *
+	 */
+	public function testFromPath(): void
+	{
+		$image = ImageMagick::fromPath(__DIR__ . '/fixtures/001.png');
+
+		$this->assertSame('image/png', $image->getMimeType());
+	}
+
+	/**
+	 *
+	 */
+	public function testFromBlob(): void
+	{
+		$image = ImageMagick::fromBlob(file_get_contents(__DIR__ . '/fixtures/001.png'));
+
+		$this->assertSame('image/png', $image->getMimeType());
+	}
+
+	/**
+	 *
+	 */
+	public function testSaveFromBlobWithoutPath(): void
+	{
+		$this->expectException(ImageException::class);
+		$this->expectExceptionMessageIs('An image path must be provided when saving images created from a blob.');
+
+		$image = ImageMagick::fromBlob(file_get_contents(__DIR__ . '/fixtures/001.png'));
+
+		$image->save();
 	}
 }


### PR DESCRIPTION
<!--
Please use the provided template when creating pull requests 🙂
-->

### Type
---

|              | Yes/No |
|--------------|--------|
| Bugfix?      | -      |
| New feature? | Yes      |
| Other?       | -      |

### Additional information

|                                     | Yes/No |
|-------------------------------------|--------|
| Has backwards compatibility breaks? | No      |
| Has unit and/or integration tests?  | Yes      |

###  Description
---

It is now possible to create image instances from a binary blob.

```php
$image = Gd::fromBlob('binary data');
$image = ImageMagick::fromBlob('binary data');
```
